### PR TITLE
fix(agent): fix registration bugs + libvirt VM scripts

### DIFF
--- a/agent/src/bin/dd-agent/main.rs
+++ b/agent/src/bin/dd-agent/main.rs
@@ -37,7 +37,6 @@ async fn run_agent_mode(cfg: AgentRuntimeConfig) {
         }
     };
 
-    // 1. Build an HTTP client.
     let http = match reqwest::Client::builder()
         .danger_accept_invalid_certs(false)
         .build()
@@ -49,65 +48,73 @@ async fn run_agent_mode(cfg: AgentRuntimeConfig) {
         }
     };
 
-    // 2. Obtain a challenge nonce from the control plane.
-    let challenge = match fetch_challenge(&http, &cp_url).await {
-        Ok(c) => c,
+    let registration = match register_with_retry(&http, &cp_url, &cfg).await {
+        Ok(r) => r,
         Err(e) => {
-            eprintln!("dd-agent: challenge failed: {e}");
+            eprintln!("dd-agent: registration failed: {e}");
             std::process::exit(1);
         }
     };
-
-    eprintln!(
-        "dd-agent: received nonce (expires in {}s)",
-        challenge.expires_in_seconds
-    );
-
-    // 3. Generate a TDX quote embedding the nonce as report data.
-    let quote_b64 = match dd_agent::attestation::tsm::generate_tdx_quote_base64() {
-        Ok(q) => q,
-        Err(e) => {
-            eprintln!("dd-agent: TDX quote generation failed: {e}");
-            std::process::exit(1);
-        }
-    };
-
-    // 4. Register with the control plane.
-    let registration =
-        match register_agent(&http, &cp_url, &challenge.nonce, &quote_b64, &cfg).await {
-            Ok(r) => r,
-            Err(e) => {
-                eprintln!("dd-agent: registration failed: {e}");
-                std::process::exit(1);
-            }
-        };
 
     eprintln!(
         "dd-agent: registered as {} at {}",
         registration.agent_id, registration.hostname
     );
 
-    // 5. Start cloudflared tunnel.
     if let Err(e) = start_cloudflared(&registration.tunnel_token).await {
         eprintln!("dd-agent: cloudflared start failed: {e}");
-        // Non-fatal: continue to workload.
     }
 
-    // 6. Run workload containers.
     if let Err(e) = run_workloads(&cfg).await {
         eprintln!("dd-agent: workload launch failed: {e}");
     }
 
-    // 7. Heartbeat / reconciliation loop.
     let agent_id = registration.agent_id.clone();
     heartbeat_loop(&http, &cp_url, &agent_id).await;
+}
+
+async fn register_with_retry(
+    http: &reqwest::Client,
+    cp_url: &str,
+    cfg: &AgentRuntimeConfig,
+) -> Result<AgentRegisterResponse, String> {
+    let max_retries = 30u32;
+
+    for attempt in 1..=max_retries {
+        let challenge = match fetch_challenge(http, cp_url).await {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("dd-agent: challenge failed (attempt {attempt}/{max_retries}): {e}");
+                backoff_sleep(attempt).await;
+                continue;
+            }
+        };
+
+        let quote_b64 = match dd_agent::attestation::tsm::generate_tdx_quote_base64() {
+            Ok(q) => q,
+            Err(e) => {
+                eprintln!("dd-agent: TDX quote generation failed, using fallback: {e}");
+                "no-tdx-available".to_string()
+            }
+        };
+
+        match register_agent(http, cp_url, &challenge.nonce, &quote_b64, cfg).await {
+            Ok(r) => return Ok(r),
+            Err(e) => {
+                eprintln!("dd-agent: registration failed (attempt {attempt}/{max_retries}): {e}");
+                backoff_sleep(attempt).await;
+            }
+        }
+    }
+
+    Err(format!("failed after {max_retries} attempts"))
 }
 
 async fn fetch_challenge(
     http: &reqwest::Client,
     cp_url: &str,
 ) -> Result<AgentChallengeResponse, String> {
-    let url = format!("{cp_url}/api/agents/challenge");
+    let url = format!("{cp_url}/api/v1/agents/challenge");
     let resp = http
         .get(&url)
         .send()
@@ -130,11 +137,11 @@ async fn register_agent(
     quote_b64: &str,
     cfg: &AgentRuntimeConfig,
 ) -> Result<AgentRegisterResponse, String> {
-    let url = format!("{cp_url}/api/agents/register");
+    let url = format!("{cp_url}/api/v1/agents/register");
 
     let body = serde_json::json!({
         "nonce": nonce,
-        "quote": quote_b64,
+        "intel_ta_token": quote_b64,
         "vm_name": hostname(),
         "node_size": cfg.node_size,
         "datacenter": cfg.datacenter,
@@ -223,7 +230,7 @@ async fn run_workloads(cfg: &AgentRuntimeConfig) -> Result<(), String> {
 }
 
 async fn heartbeat_loop(http: &reqwest::Client, cp_url: &str, agent_id: &str) {
-    let url = format!("{cp_url}/api/agents/{agent_id}/heartbeat");
+    let url = format!("{cp_url}/api/v1/agents/{agent_id}/heartbeat");
     let mut interval = tokio::time::interval(std::time::Duration::from_secs(30));
 
     loop {
@@ -309,4 +316,9 @@ fn hostname() -> String {
         .unwrap_or_else(|_| "unknown".into())
         .trim()
         .to_string()
+}
+
+async fn backoff_sleep(attempt: u32) {
+    let secs = std::cmp::min(5 * 2u64.saturating_pow(attempt.saturating_sub(1)), 60);
+    tokio::time::sleep(std::time::Duration::from_secs(secs)).await;
 }

--- a/infra/scripts/vm-launch.sh
+++ b/infra/scripts/vm-launch.sh
@@ -1,10 +1,5 @@
 #!/usr/bin/env bash
-# Launch a QEMU/KVM VM from a baked qcow2 image.
-#
-# Usage:
-#   ./vm-launch.sh --image /path/to/base.qcow2 --name dd-cp-staging \
-#     --config /path/to/config.json --memory 8G --cpus 4 \
-#     --port-forward 8080:8080
+# Launch a libvirt-managed VM from a baked qcow2 image.
 set -euo pipefail
 
 IMAGE=""
@@ -14,8 +9,10 @@ MEMORY="4G"
 CPUS="2"
 PORT_FORWARDS=()
 VFIO_DEVICE=""
+TDX="false"
 VM_DIR="/var/lib/devopsdefender/vms"
-CONFIG_MODE="agent"  # agent or control-plane
+CONFIG_MODE="agent"
+LIBVIRT_NETWORK="${LIBVIRT_NETWORK:-default}"
 
 usage() {
   cat <<EOF
@@ -26,10 +23,87 @@ Usage: $0 [options]
   --config-mode MODE    Config target: agent (default) or control-plane
   --memory SIZE         VM memory (default: 4G)
   --cpus N              VM CPUs (default: 2)
-  --port-forward H:G    Forward host port H to guest port G (repeatable)
+  --port-forward H:G    Recorded for metadata only in libvirt mode
   --vfio-device ADDR    PCI device to pass through via VFIO (e.g. 0d:00.0)
+  --tdx                 Request Intel TDX launch settings
 EOF
   exit 1
+}
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "Error: required command not found: $1" >&2
+    exit 1
+  }
+}
+
+detect_libvirt_qemu_owner() {
+  if [ -n "${LIBVIRT_QEMU_USER:-}" ]; then
+    LIBVIRT_QEMU_GROUP="${LIBVIRT_QEMU_GROUP:-$(id -gn "$LIBVIRT_QEMU_USER" 2>/dev/null || true)}"
+    return 0
+  fi
+
+  for candidate in libvirt-qemu qemu; do
+    if id -u "$candidate" >/dev/null 2>&1; then
+      LIBVIRT_QEMU_USER="$candidate"
+      LIBVIRT_QEMU_GROUP="$(id -gn "$candidate")"
+      return 0
+    fi
+  done
+
+  LIBVIRT_QEMU_USER=""
+  LIBVIRT_QEMU_GROUP=""
+}
+
+prepare_runtime_permissions() {
+  if [ "$(id -u)" -ne 0 ]; then
+    return 0
+  fi
+
+  detect_libvirt_qemu_owner
+  if [ -z "$LIBVIRT_QEMU_USER" ] || [ -z "$LIBVIRT_QEMU_GROUP" ]; then
+    return 0
+  fi
+
+  chown "$LIBVIRT_QEMU_USER:$LIBVIRT_QEMU_GROUP" "$VM_WORK_DIR"
+  chmod 0770 "$VM_WORK_DIR"
+
+  chown "$LIBVIRT_QEMU_USER:$LIBVIRT_QEMU_GROUP" "$OVERLAY" "$CIDATA_ISO"
+  chmod 0660 "$OVERLAY" "$CIDATA_ISO"
+
+  touch "$SERIAL_LOG"
+  chown "$LIBVIRT_QEMU_USER:$LIBVIRT_QEMU_GROUP" "$SERIAL_LOG"
+  chmod 0660 "$SERIAL_LOG"
+}
+
+to_mib() {
+  local value number unit
+  value="${1^^}"
+  if [[ "$value" =~ ^([0-9]+)([GM])I?B?$ ]]; then
+    number="${BASH_REMATCH[1]}"
+    unit="${BASH_REMATCH[2]}"
+  elif [[ "$value" =~ ^([0-9]+)$ ]]; then
+    echo "$value"
+    return 0
+  else
+    echo "Error: unsupported memory value '$1' (use 4096, 4G, 8192M)" >&2
+    exit 1
+  fi
+
+  if [ "$unit" = "G" ]; then
+    echo $((number * 1024))
+  else
+    echo "$number"
+  fi
+}
+
+escape_xml() {
+  sed \
+    -e 's/&/\&amp;/g' \
+    -e 's/</\&lt;/g' \
+    -e 's/>/\&gt;/g' \
+    -e "s/'/\&apos;/g" \
+    -e 's/"/\&quot;/g'
 }
 
 while [[ $# -gt 0 ]]; do
@@ -42,6 +116,7 @@ while [[ $# -gt 0 ]]; do
     --cpus) CPUS="$2"; shift 2 ;;
     --port-forward) PORT_FORWARDS+=("$2"); shift 2 ;;
     --vfio-device) VFIO_DEVICE="$2"; shift 2 ;;
+    --tdx) TDX="true"; shift ;;
     --help|-h) usage ;;
     *) echo "Unknown option: $1" >&2; usage ;;
   esac
@@ -52,17 +127,12 @@ if [ -z "$IMAGE" ] || [ -z "$VM_NAME" ] || [ -z "$CONFIG_FILE" ]; then
   usage
 fi
 
-if [ ! -f "$IMAGE" ]; then
-  echo "Error: base image not found: $IMAGE" >&2
-  exit 1
-fi
+require_cmd virsh
+require_cmd qemu-img
 
-if [ ! -f "$CONFIG_FILE" ]; then
-  echo "Error: config file not found: $CONFIG_FILE" >&2
-  exit 1
-fi
+[ -f "$IMAGE" ] || { echo "Error: base image not found: $IMAGE" >&2; exit 1; }
+[ -f "$CONFIG_FILE" ] || { echo "Error: config file not found: $CONFIG_FILE" >&2; exit 1; }
 
-# Create VM working directory.
 VM_WORK_DIR="${VM_DIR}/${VM_NAME}"
 mkdir -p "$VM_WORK_DIR"
 
@@ -87,8 +157,6 @@ fi
 # Generate cloud-init ISO for config injection.
 CIDATA_DIR="${VM_WORK_DIR}/cidata"
 mkdir -p "$CIDATA_DIR"
-
-# Escape JSON for embedding in cloud-init write_files.
 CONFIG_CONTENT="$(cat "$CONFIG_FILE")"
 
 cat > "${CIDATA_DIR}/user-data" <<USERDATA
@@ -111,9 +179,9 @@ local-hostname: ${VM_NAME}
 METADATA
 
 CIDATA_ISO="${VM_WORK_DIR}/cidata.iso"
-if command -v cloud-localds &>/dev/null; then
+if command -v cloud-localds >/dev/null 2>&1; then
   cloud-localds "$CIDATA_ISO" "${CIDATA_DIR}/user-data" "${CIDATA_DIR}/meta-data"
-elif command -v genisoimage &>/dev/null; then
+elif command -v genisoimage >/dev/null 2>&1; then
   genisoimage -output "$CIDATA_ISO" -volid cidata -joliet -rock \
     "${CIDATA_DIR}/user-data" "${CIDATA_DIR}/meta-data"
 else
@@ -121,77 +189,139 @@ else
   exit 1
 fi
 
-# Build QEMU command.
-QEMU_ARGS=(
-  qemu-system-x86_64
-  -enable-kvm
-  -machine q35
-  -cpu host
-  -m "$MEMORY"
-  -smp "$CPUS"
-  -drive "file=${OVERLAY},format=qcow2,if=virtio"
-  -drive "file=${CIDATA_ISO},format=raw,if=virtio,readonly=on"
-  -display none
-  -serial file:${VM_WORK_DIR}/${VM_NAME}.log
-  -daemonize
-  -pidfile "${VM_WORK_DIR}/${VM_NAME}.pid"
-)
+# Build libvirt domain XML.
+MEMORY_MIB="$(to_mib "$MEMORY")"
+DOMAIN_XML="${VM_WORK_DIR}/${VM_NAME}.xml"
+SERIAL_LOG="${VM_WORK_DIR}/${VM_NAME}.log"
 
-# Pass through VFIO device (GPU) if requested.
-if [ -n "$VFIO_DEVICE" ]; then
-  QEMU_ARGS+=(-device "vfio-pci,host=${VFIO_DEVICE}")
+prepare_runtime_permissions
+
+LAUNCH_SECURITY=""
+FEATURES_EXTRA=""
+CLOCK_XML="  <clock offset='utc'/>\n"
+PM_XML=""
+MEMORY_BACKING_XML=""
+OS_OPEN_TAG="  <os firmware='efi'>"
+LOADER_XML=""
+if [ "$TDX" = "true" ]; then
+  MEMORY_BACKING_XML+="  <memoryBacking>\n"
+  MEMORY_BACKING_XML+="    <source type='anonymous'/>\n"
+  MEMORY_BACKING_XML+="    <access mode='private'/>\n"
+  MEMORY_BACKING_XML+="  </memoryBacking>\n"
+  OS_OPEN_TAG="  <os>"
+  LOADER_XML+="    <loader type='rom' readonly='yes'>/usr/share/qemu/OVMF.fd</loader>\n"
+  LAUNCH_SECURITY+="  <launchSecurity type='tdx'>\n"
+  LAUNCH_SECURITY+="    <policy>0x10000000</policy>\n"
+  LAUNCH_SECURITY+="    <quoteGenerationService>\n"
+  LAUNCH_SECURITY+="      <SocketAddress type='vsock' cid='2' port='4050'/>\n"
+  LAUNCH_SECURITY+="    </quoteGenerationService>\n"
+  LAUNCH_SECURITY+="  </launchSecurity>\n"
+  FEATURES_EXTRA+="    <ioapic driver='qemu'/>\n"
+  CLOCK_XML="  <clock offset='utc'>\n"
+  CLOCK_XML+="    <timer name='hpet' present='no'/>\n"
+  CLOCK_XML+="  </clock>\n"
+  PM_XML+="  <pm>\n"
+  PM_XML+="    <suspend-to-mem enabled='no'/>\n"
+  PM_XML+="    <suspend-to-disk enabled='no'/>\n"
+  PM_XML+="  </pm>\n"
 fi
 
-# Build port forwarding netdev.
-HOSTFWD_ARGS=""
-for pf in "${PORT_FORWARDS[@]+"${PORT_FORWARDS[@]}"}"; do
-  host_port="${pf%%:*}"
-  guest_port="${pf##*:}"
-  HOSTFWD_ARGS="${HOSTFWD_ARGS},hostfwd=tcp::${host_port}-:${guest_port}"
-done
+HOSTDEV_XML=""
+if [ -n "$VFIO_DEVICE" ]; then
+  domain_hex="${VFIO_DEVICE%%:*}"
+  remainder="${VFIO_DEVICE#*:}"
+  bus_hex="${remainder%%.*}"
+  function_hex="${remainder##*.}"
+  HOSTDEV_XML+="    <hostdev mode='subsystem' type='pci' managed='yes'>\n"
+  HOSTDEV_XML+="      <source>\n"
+  HOSTDEV_XML+="        <address domain='0x0000' bus='0x${domain_hex}' slot='0x${bus_hex}' function='0x${function_hex}'/>\n"
+  HOSTDEV_XML+="      </source>\n"
+  HOSTDEV_XML+="    </hostdev>\n"
+fi
 
-# Always forward SSH on a high port for debugging.
-SSH_PORT=$((10000 + RANDOM % 50000))
-HOSTFWD_ARGS="${HOSTFWD_ARGS},hostfwd=tcp::${SSH_PORT}-:22"
+cat > "$DOMAIN_XML" <<EOF
+<domain type='kvm'>
+  <name>${VM_NAME}</name>
+  <memory unit='MiB'>${MEMORY_MIB}</memory>
+  <currentMemory unit='MiB'>${MEMORY_MIB}</currentMemory>
+$(printf "%b" "$MEMORY_BACKING_XML")  <vcpu placement='static'>${CPUS}</vcpu>
+$(printf "%b" "$OS_OPEN_TAG")
+    <type arch='x86_64' machine='q35'>hvm</type>
+$(printf "%b" "$LOADER_XML")    <boot dev='hd'/>
+  </os>
+$(printf "%b" "$LAUNCH_SECURITY")  <features>
+    <acpi/>
+    <apic/>
+$(printf "%b" "$FEATURES_EXTRA")  </features>
+  <cpu mode='host-passthrough' check='none'/>
+$(printf "%b" "$CLOCK_XML")  <on_poweroff>destroy</on_poweroff>
+  <on_reboot>restart</on_reboot>
+  <on_crash>destroy</on_crash>
+$(printf "%b" "$PM_XML")  <devices>
+    <emulator>/usr/bin/qemu-system-x86_64</emulator>
+    <disk type='file' device='disk'>
+      <driver name='qemu' type='qcow2' cache='none'/>
+      <source file='$(printf "%s" "$OVERLAY" | escape_xml)'/>
+      <target dev='vda' bus='virtio'/>
+    </disk>
+    <disk type='file' device='cdrom'>
+      <driver name='qemu' type='raw'/>
+      <source file='$(printf "%s" "$CIDATA_ISO" | escape_xml)'/>
+      <target dev='sda' bus='sata'/>
+      <readonly/>
+    </disk>
+    <interface type='network'>
+      <source network='${LIBVIRT_NETWORK}'/>
+      <model type='virtio'/>
+    </interface>
+    <serial type='file'>
+      <source path='$(printf "%s" "$SERIAL_LOG" | escape_xml)'/>
+      <target type='isa-serial' port='0'/>
+    </serial>
+    <console type='pty'>
+      <target type='serial' port='0'/>
+    </console>
+    <rng model='virtio'>
+      <backend model='random'>/dev/urandom</backend>
+    </rng>
+$(printf "%b" "$HOSTDEV_XML")  </devices>
+</domain>
+EOF
 
-QEMU_ARGS+=(-netdev "user,id=net0${HOSTFWD_ARGS}" -device "virtio-net-pci,netdev=net0")
+if virsh dominfo "$VM_NAME" >/dev/null 2>&1; then
+  echo "Error: domain '$VM_NAME' already exists; stop it first" >&2
+  exit 1
+fi
 
-echo "==> Launching VM: ${VM_NAME}"
+echo "==> Defining libvirt domain: ${VM_NAME}"
 echo "    Memory: ${MEMORY}, CPUs: ${CPUS}"
 echo "    Overlay: ${OVERLAY}"
 echo "    Config mode: ${CONFIG_MODE}"
-echo "    SSH port: ${SSH_PORT}"
+echo "    Libvirt network: ${LIBVIRT_NETWORK}"
+echo "    TDX: ${TDX}"
 if [ -n "$VFIO_DEVICE" ]; then
   echo "    VFIO device: ${VFIO_DEVICE}"
 fi
-for pf in "${PORT_FORWARDS[@]+"${PORT_FORWARDS[@]}"}"; do
-  echo "    Port forward: ${pf}"
-done
 
-"${QEMU_ARGS[@]}" </dev/null
+virsh define "$DOMAIN_XML" >/dev/null
+virsh start "$VM_NAME" >/dev/null
 
-PID_FILE="${VM_WORK_DIR}/${VM_NAME}.pid"
-if [ -f "$PID_FILE" ]; then
-  PID="$(cat "$PID_FILE")"
-  echo "==> VM started with PID ${PID}"
-  echo "    PID file: ${PID_FILE}"
-  echo "    SSH: ssh -p ${SSH_PORT} ubuntu@localhost"
-else
-  echo "Warning: PID file not created, VM may not have started" >&2
-fi
+STATE="$(virsh domstate "$VM_NAME" | tr -d '\r' | xargs)"
+echo "==> VM started with libvirt state: ${STATE}"
+echo "    Inspect with: virsh list --all"
 
-# Write metadata for vm-status.sh / vm-stop.sh.
 cat > "${VM_WORK_DIR}/vm-info.json" <<INFO
 {
   "name": "${VM_NAME}",
-  "pid_file": "${PID_FILE}",
   "overlay": "${OVERLAY}",
   "config_mode": "${CONFIG_MODE}",
   "memory": "${MEMORY}",
   "cpus": "${CPUS}",
-  "ssh_port": ${SSH_PORT},
+  "libvirt_network": "${LIBVIRT_NETWORK}",
   "port_forwards": "$(IFS=,; echo "${PORT_FORWARDS[*]+"${PORT_FORWARDS[*]}"}")",
   "vfio_device": "${VFIO_DEVICE}",
+  "tdx": ${TDX},
+  "xml_path": "${DOMAIN_XML}",
   "started_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 }
 INFO

--- a/infra/scripts/vm-status.sh
+++ b/infra/scripts/vm-status.sh
@@ -1,18 +1,22 @@
 #!/usr/bin/env bash
-# List running DevOps Defender VMs.
-# Usage: ./vm-status.sh
+# List DevOps Defender VMs managed through libvirt.
 set -euo pipefail
 
 VM_DIR="/var/lib/devopsdefender/vms"
+
+command -v virsh >/dev/null 2>&1 || {
+  echo "Error: virsh is required" >&2
+  exit 1
+}
 
 if [ ! -d "$VM_DIR" ]; then
   echo "No VMs found (${VM_DIR} does not exist)"
   exit 0
 fi
 
-printf "%-25s %-8s %-15s %-6s %-6s %-8s %s\n" \
-  "NAME" "PID" "STATUS" "MEM" "CPUS" "SSH" "STARTED"
-printf "%s\n" "$(printf '%.0s-' {1..100})"
+printf "%-25s %-12s %-6s %-6s %-12s %s\n" \
+  "NAME" "STATE" "MEM" "CPUS" "NETWORK" "STARTED"
+printf "%s\n" "$(printf '%.0s-' {1..90})"
 
 found=0
 for vm_dir in "${VM_DIR}"/*/; do
@@ -23,27 +27,25 @@ for vm_dir in "${VM_DIR}"/*/; do
 
   found=1
   name="$(jq -r '.name // "unknown"' "$info_file")"
-  pid_file="$(jq -r '.pid_file // ""' "$info_file")"
   memory="$(jq -r '.memory // "?"' "$info_file")"
   cpus="$(jq -r '.cpus // "?"' "$info_file")"
-  ssh_port="$(jq -r '.ssh_port // "?"' "$info_file")"
+  network="$(jq -r '.libvirt_network // "?"' "$info_file")"
   started="$(jq -r '.started_at // "?"' "$info_file")"
 
-  status="stopped"
-  pid="-"
-  if [ -n "$pid_file" ] && [ -f "$pid_file" ]; then
-    pid="$(cat "$pid_file")"
-    if kill -0 "$pid" 2>/dev/null; then
-      status="running"
-    else
-      status="dead"
-    fi
+  state="undefined"
+  if virsh dominfo "$name" >/dev/null 2>&1; then
+    state="$(virsh domstate "$name" | tr -d '\r' | xargs)"
   fi
 
-  printf "%-25s %-8s %-15s %-6s %-6s %-8s %s\n" \
-    "$name" "$pid" "$status" "$memory" "$cpus" "$ssh_port" "$started"
+  printf "%-25s %-12s %-6s %-6s %-12s %s\n" \
+    "$name" "$state" "$memory" "$cpus" "$network" "$started"
 done
 
 if [ "$found" -eq 0 ]; then
   echo "No VMs found"
+  exit 0
 fi
+
+echo
+echo "virsh list --all"
+virsh list --all

--- a/infra/scripts/vm-stop.sh
+++ b/infra/scripts/vm-stop.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Stop a VM by name.
+# Stop a libvirt-managed VM by name.
 # Usage: ./vm-stop.sh <vm-name> [--clean]
 set -euo pipefail
 
@@ -22,39 +22,39 @@ if [ -z "$VM_NAME" ]; then
 fi
 
 VM_WORK_DIR="${VM_DIR}/${VM_NAME}"
-PID_FILE="${VM_WORK_DIR}/${VM_NAME}.pid"
 
-if [ ! -f "$PID_FILE" ]; then
-  echo "No PID file found for VM '${VM_NAME}' at ${PID_FILE}" >&2
+command -v virsh >/dev/null 2>&1 || {
+  echo "Error: virsh is required" >&2
+  exit 1
+}
+
+if ! virsh dominfo "$VM_NAME" >/dev/null 2>&1; then
+  echo "No libvirt domain found for VM '${VM_NAME}'" >&2
   exit 1
 fi
 
-PID="$(cat "$PID_FILE")"
+STATE="$(virsh domstate "$VM_NAME" | tr -d '\r' | xargs)"
+echo "==> Stopping VM '${VM_NAME}' (state: ${STATE})"
 
-if kill -0 "$PID" 2>/dev/null; then
-  echo "==> Stopping VM '${VM_NAME}' (PID ${PID})"
-  kill "$PID"
-
-  # Wait for process to exit (up to 30s).
+if [ "$STATE" = "running" ] || [ "$STATE" = "paused" ] || [ "$STATE" = "in shutdown" ]; then
+  virsh shutdown "$VM_NAME" >/dev/null || true
   for _ in $(seq 1 30); do
-    if ! kill -0 "$PID" 2>/dev/null; then
+    STATE="$(virsh domstate "$VM_NAME" | tr -d '\r' | xargs)"
+    if [ "$STATE" = "shut off" ]; then
       break
     fi
     sleep 1
   done
-
-  # Force kill if still running.
-  if kill -0 "$PID" 2>/dev/null; then
-    echo "    Force killing PID ${PID}"
-    kill -9 "$PID" 2>/dev/null || true
-  fi
-
-  echo "==> VM '${VM_NAME}' stopped"
-else
-  echo "VM '${VM_NAME}' is not running (PID ${PID})"
 fi
 
-rm -f "$PID_FILE"
+STATE="$(virsh domstate "$VM_NAME" | tr -d '\r' | xargs)"
+if [ "$STATE" != "shut off" ]; then
+  echo "    Force destroying domain ${VM_NAME}"
+  virsh destroy "$VM_NAME" >/dev/null || true
+fi
+
+virsh undefine "$VM_NAME" --nvram >/dev/null 2>&1 || virsh undefine "$VM_NAME" >/dev/null
+echo "==> VM '${VM_NAME}' undefined"
 
 if [ "$CLEAN" = true ]; then
   echo "==> Cleaning up VM directory: ${VM_WORK_DIR}"


### PR DESCRIPTION
## Summary
- Fix agent registration bugs that prevented agent-CP communication:
  - API paths: `/api/agents/` → `/api/v1/agents/` (mismatched CP routes)
  - Request body: `"quote"` → `"intel_ta_token"` (mismatched CP struct)
  - Add retry-based registration with exponential backoff (30 attempts)
  - Add TDX fallback: use dummy token on non-TDX hardware (CP accepts any token when no ITA verifier configured)
- Rewrite VM scripts from raw QEMU to libvirt (virsh define/start/shutdown/undefine)

## Test plan
- [ ] `cargo test --workspace` passes
- [ ] `cargo clippy --workspace --all-targets` clean
- [ ] Merge and tag release so dd-agent binary is available for private-llm deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)