### PR TITLE
Add branch protection and staging workflow rules

### DIFF
--- a/.github/workflows/baremetal-staging-deploy.yml
+++ b/.github/workflows/baremetal-staging-deploy.yml
@@ -2,7 +2,7 @@ name: Baremetal Staging Deploy
 
 on:
   push:
-    branches: [main]
+    branches: [main, staging]
     paths:
       - "agent/**"
       - "control-plane/**"

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -2,7 +2,7 @@ name: Staging Deploy
 
 on:
   push:
-    branches: [main]
+    branches: [main, staging]
     paths:
       - "agent/**"
       - "control-plane/**"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,6 +149,34 @@ Landing page for devopsdefender.com, deployed via GitHub Pages.
 - `style.css` — design system (indigo/teal theme, responsive, dark mode support)
 - `CNAME` — GitHub Pages custom domain config
 
+## Development Workflow & Branch Rules
+
+### Branch Protection (Enforced)
+
+- **`main` is protected.** All changes to `main` require a pull request with at least one approving review from a board member / repository owner. Direct pushes to `main` are blocked.
+- **Stale reviews are dismissed** — if you push new commits to a PR, previous approvals are invalidated and re-approval is required.
+
+### Working on Changes
+
+1. **Always work on a feature branch.** Create a branch from `main` (e.g., `feat/my-change`, `fix/bug-description`).
+2. **Push your feature branch** and open a PR targeting `main`.
+3. **Wait for board approval** before merging. Never merge your own PR without an approving review.
+
+### Testing in Staging
+
+- The **`staging` branch** auto-deploys to the staging environment (`app-staging.devopsdefender.com`).
+- You can freely push to `staging` to test changes without approval.
+- To test: merge or push your feature branch into `staging`. This triggers the staging deploy pipeline.
+- The `staging` branch can be force-pushed or reset as needed — it is not protected.
+
+### Summary
+
+| Branch    | Protection | Deploys to  | Approval Required |
+|-----------|-----------|-------------|-------------------|
+| `main`    | Yes       | Production-ready | Yes — board review required |
+| `staging` | No        | Staging     | No — free to test |
+| Feature   | No        | —           | No — work freely  |
+
 ## Build & Development
 
 ### Rust Projects (agent/, control-plane/)


### PR DESCRIPTION
## Summary

- Enabled GitHub branch protection on `main`: requires 1 approving review, stale reviews dismissed
- Created `staging` branch for free-form testing (deploys to staging environment)
- Updated staging deploy workflows (GCP + baremetal) to trigger from both `main` and `staging` branches
- Added development workflow documentation to CLAUDE.md with clear branch rules

## What this enforces

| Branch | Protected | Deploys to | Approval |
|--------|-----------|-----------|----------|
| `main` | Yes | Production-ready | Board review required |
| `staging` | No | Staging | None — free to test |
| Feature | No | — | None — work freely |

## Test plan

- [x] Branch protection set via GitHub API
- [x] `staging` branch created and pushed
- [ ] Verify direct push to `main` is blocked
- [ ] Verify PR to `main` requires review
- [ ] Verify push to `staging` triggers staging deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)