### PR TITLE
Add GitHub Actions workflow for website PR previews

### DIFF
--- a/.github/workflows/website-pr-preview.yml
+++ b/.github/workflows/website-pr-preview.yml
@@ -1,0 +1,22 @@
+name: Website PR Preview
+
+on:
+  pull_request:
+    paths: ["website/**"]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: pr-preview-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: website


### PR DESCRIPTION
## Summary
This PR adds a GitHub Actions workflow that automatically generates preview deployments for pull requests that modify files in the `website/` directory.

## Key Changes
- Added `.github/workflows/website-pr-preview.yml` workflow file that:
  - Triggers on pull requests with changes to the `website/` directory
  - Uses the `rossjrw/pr-preview-action@v1` action to build and deploy previews
  - Configures appropriate permissions for writing to contents and pull requests
  - Implements concurrency controls to cancel in-progress preview builds for the same ref

## Implementation Details
- The workflow is configured to only run when the `website/**` paths are modified, avoiding unnecessary builds for unrelated changes
- Concurrency grouping ensures that only the latest preview build for a given PR ref is active, with older builds automatically cancelled
- The action is configured to use the `website` directory as the source for the preview build

https://claude.ai/code/session_01NBsTYTvxboFMUWU85idjYo