### PR TITLE
ci: harden website workflows

### DIFF
--- a/.github/workflows/website-preview.yml
+++ b/.github/workflows/website-preview.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     paths: ["website/**", "README.md"]
 
+permissions:
+  contents: read
+
 jobs:
   preview:
     runs-on: ubuntu-latest
@@ -13,3 +16,4 @@ jobs:
         with:
           name: website-preview
           path: website/
+          retention-days: 7

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -10,6 +10,10 @@ permissions:
   pages: write
   id-token: write
 
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add `concurrency` group to Pages deploy workflow to prevent overlapping deploys
- Add explicit `permissions` and `retention-days` to PR preview workflow
- Tests both the PR preview artifact upload and (on merge) the production Pages deploy

## Test plan
- [ ] Website Preview workflow runs on this PR and uploads an artifact
- [ ] After merge, Website workflow deploys to GitHub Pages successfully
- [ ] Site is live at devopsdefender.com

https://claude.ai/code/session_016NjiRXkCjBnzNcstiYL5sf