### PR TITLE
Portable control plane with migration and agent reattach

### DIFF
--- a/agent/src/api.rs
+++ b/agent/src/api.rs
@@ -45,3 +45,33 @@ pub struct UpdateDeploymentStatusRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error_message: Option<String>,
 }
+
+/// Sent to a new CP when heartbeat returns 404 (CP doesn't know this agent).
+/// Includes currently running deployments so the CP can track them.
+#[derive(Debug, Clone, Serialize)]
+pub struct AgentReattachRequest {
+    pub vm_name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub node_size: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub datacenter: Option<String>,
+    pub running_deployments: Vec<RunningDeploymentReport>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RunningDeploymentReport {
+    pub deployment_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub app_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub image: Option<String>,
+    pub status: String,
+}
+
+/// Response from the reattach endpoint — same shape as register response.
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+pub struct AgentReattachResponse {
+    pub agent_id: String,
+    pub tunnel_token: String,
+    pub hostname: String,
+}

--- a/agent/src/bin/dd-agent/main.rs
+++ b/agent/src/bin/dd-agent/main.rs
@@ -8,8 +8,8 @@ use tokio::sync::Mutex;
 
 use config::{AgentMode, AgentRuntimeConfig};
 use dd_agent::api::{
-    AgentChallengeResponse, AgentRegisterResponse, HeartbeatResponse, PendingDeployment,
-    UpdateDeploymentStatusRequest,
+    AgentChallengeResponse, AgentReattachRequest, AgentReattachResponse, AgentRegisterResponse,
+    HeartbeatResponse, PendingDeployment, RunningDeploymentReport, UpdateDeploymentStatusRequest,
 };
 
 // ── Entry point ────────────────────────────────────────────────────────────
@@ -84,7 +84,7 @@ async fn run_agent_mode(cfg: AgentRuntimeConfig) {
 
     let active_deployments: ActiveDeployments = Arc::new(Mutex::new(HashMap::new()));
     let agent_id = registration.agent_id.clone();
-    heartbeat_loop(&http, &cp_url, &agent_id, active_deployments).await;
+    heartbeat_loop(&http, &cp_url, &agent_id, active_deployments, &cfg).await;
 }
 
 // ── Registration with retry ──────────────────────────────────────────────
@@ -221,14 +221,16 @@ async fn heartbeat_loop(
     cp_url: &str,
     agent_id: &str,
     active_deployments: ActiveDeployments,
+    cfg: &AgentRuntimeConfig,
 ) {
-    let url = format!("{cp_url}/api/v1/agents/{agent_id}/heartbeat");
     let mut interval = tokio::time::interval(std::time::Duration::from_secs(30));
+    let mut current_agent_id = agent_id.to_string();
 
     loop {
         tokio::select! {
             _ = interval.tick() => {
-                match send_heartbeat(http, &url).await {
+                let hb_url = format!("{cp_url}/api/v1/agents/{current_agent_id}/heartbeat");
+                match send_heartbeat(http, &hb_url).await {
                     Ok(resp) => {
                         if !resp.pending_deployments.is_empty() {
                             eprintln!(
@@ -247,6 +249,27 @@ async fn heartbeat_loop(
                         }
 
                         check_active_deployments(http, cp_url, active_deployments.clone()).await;
+                    }
+                    Err(ref e) if e.contains("status 404") => {
+                        // CP doesn't know us — it may have migrated.
+                        // Reattach with our current state so the new CP picks us up.
+                        eprintln!("dd-agent: heartbeat 404 — CP may have migrated, reattaching...");
+                        match reattach(http, cp_url, cfg, &active_deployments).await {
+                            Ok(resp) => {
+                                current_agent_id = resp.agent_id.clone();
+                                eprintln!(
+                                    "dd-agent: reattached as {} at {}",
+                                    resp.agent_id, resp.hostname
+                                );
+                                // Restart cloudflared with new tunnel token
+                                if let Err(e) = start_cloudflared(&resp.tunnel_token).await {
+                                    eprintln!("dd-agent: cloudflared restart failed: {e}");
+                                }
+                            }
+                            Err(e) => {
+                                eprintln!("dd-agent: reattach failed: {e}");
+                            }
+                        }
                     }
                     Err(e) => {
                         eprintln!("dd-agent: heartbeat failed: {e}");
@@ -513,6 +536,54 @@ async fn shutdown_deployments(
     }
 
     active_deployments.lock().await.clear();
+}
+
+// ── Reattach (CP migration recovery) ────────────────────────────────────────
+
+async fn reattach(
+    http: &reqwest::Client,
+    cp_url: &str,
+    cfg: &AgentRuntimeConfig,
+    active_deployments: &ActiveDeployments,
+) -> Result<AgentReattachResponse, String> {
+    let url = format!("{cp_url}/api/v1/agents/reattach");
+
+    // Build list of currently running deployments
+    let deployments = active_deployments.lock().await;
+    let running: Vec<RunningDeploymentReport> = deployments
+        .values()
+        .map(|d| RunningDeploymentReport {
+            deployment_id: d.id.clone(),
+            app_name: None,
+            image: None,
+            status: "running".into(),
+        })
+        .collect();
+    drop(deployments);
+
+    let body = AgentReattachRequest {
+        vm_name: hostname(),
+        node_size: cfg.node_size.clone(),
+        datacenter: cfg.datacenter.clone(),
+        running_deployments: running,
+    };
+
+    let resp = http
+        .post(&url)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| format!("POST {url}: {e}"))?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body_text = resp.text().await.unwrap_or_default();
+        return Err(format!("POST {url}: status {status}: {body_text}"));
+    }
+
+    resp.json::<AgentReattachResponse>()
+        .await
+        .map_err(|e| format!("parse reattach response: {e}"))
 }
 
 // ── Control-plane mode ─────────────────────────────────────────────────────

--- a/control-plane/src/api.rs
+++ b/control-plane/src/api.rs
@@ -201,7 +201,6 @@ pub struct AuthMeResponse {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct MigrationStatusResponse {
-    pub cp_mode: String,
     pub can_export: bool,
     pub can_import: bool,
     pub agent_count: usize,
@@ -216,13 +215,13 @@ pub struct MigrationImportResponse {
     pub summary: crate::services::migration::SeedConfigSummary,
 }
 
-/// Request to deploy the portable CP on an agent (bootstrap mode only).
+/// Request to deploy a new CP instance on an agent.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct BootstrapDeployCpRequest {
+pub struct DeployCpRequest {
     /// The OCI image for the control-plane container.
     pub image: String,
-    /// Target agent ID to deploy the portable CP on.
-    /// If not set, the bootstrap CP picks an available agent.
+    /// Target agent ID to deploy the CP on.
+    /// If not set, picks an available agent.
     #[serde(default)]
     pub agent_id: Option<String>,
     /// Optional node_size filter when auto-selecting an agent.
@@ -234,7 +233,7 @@ pub struct BootstrapDeployCpRequest {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct BootstrapDeployCpResponse {
+pub struct DeployCpResponse {
     pub deployment_id: Uuid,
     pub agent_id: Uuid,
     pub status: DeploymentStatus,

--- a/control-plane/src/api.rs
+++ b/control-plane/src/api.rs
@@ -196,6 +196,91 @@ pub struct AuthMeResponse {
 }
 
 // ---------------------------------------------------------------------------
+// Migration
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct MigrationStatusResponse {
+    pub cp_mode: String,
+    pub can_export: bool,
+    pub can_import: bool,
+    pub agent_count: usize,
+    pub deployment_count: usize,
+    /// If proxying is active, the target URL.
+    pub proxy_target: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct MigrationImportResponse {
+    pub imported: bool,
+    pub summary: crate::services::migration::SeedConfigSummary,
+}
+
+/// Request to deploy the portable CP on an agent (bootstrap mode only).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct BootstrapDeployCpRequest {
+    /// The OCI image for the control-plane container.
+    pub image: String,
+    /// Target agent ID to deploy the portable CP on.
+    /// If not set, the bootstrap CP picks an available agent.
+    #[serde(default)]
+    pub agent_id: Option<String>,
+    /// Optional node_size filter when auto-selecting an agent.
+    #[serde(default)]
+    pub node_size: Option<String>,
+    /// Optional datacenter filter when auto-selecting an agent.
+    #[serde(default)]
+    pub datacenter: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct BootstrapDeployCpResponse {
+    pub deployment_id: Uuid,
+    pub agent_id: Uuid,
+    pub status: DeploymentStatus,
+    pub seed_config_included: bool,
+}
+
+/// Readiness report: how many agents have re-registered with the new CP.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct MigrationReadinessResponse {
+    pub ready: bool,
+    pub agents_registered: usize,
+    pub agents_expected: usize,
+    pub agents_missing: Vec<String>,
+}
+
+/// Request to start proxying all traffic to a new CP during migration.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ProxyStartRequest {
+    /// URL of the new CP to proxy traffic to (e.g. "http://10.0.0.5:8080").
+    pub target_url: String,
+}
+
+/// Agent re-registration request — sent when an agent heartbeats a new CP
+/// that doesn't know about it yet.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentReattachRequest {
+    pub vm_name: String,
+    #[serde(default)]
+    pub node_size: Option<String>,
+    #[serde(default)]
+    pub datacenter: Option<String>,
+    /// Deployments currently running on this agent.
+    #[serde(default)]
+    pub running_deployments: Vec<RunningDeploymentReport>,
+}
+
+/// A deployment the agent is currently running (reported during reattach).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct RunningDeploymentReport {
+    pub deployment_id: String,
+    pub app_name: Option<String>,
+    pub image: Option<String>,
+    pub status: String,
+}
+
+// ---------------------------------------------------------------------------
 // Error response
 // ---------------------------------------------------------------------------
 

--- a/control-plane/src/bin/dd-cp/main.rs
+++ b/control-plane/src/bin/dd-cp/main.rs
@@ -3,6 +3,7 @@ use dd_control_plane::db;
 use dd_control_plane::routes;
 use dd_control_plane::services::attestation::{AttestationService, RuntimeEnv};
 use dd_control_plane::services::github_oidc::GithubOidcService;
+use dd_control_plane::services::migration::SeedConfig;
 use dd_control_plane::services::tunnel::TunnelService;
 use dd_control_plane::state::AppState;
 
@@ -13,11 +14,20 @@ async fn main() {
     eprintln!("DevOps Defender Control Plane starting...");
     eprintln!("  bind_addr: {}", config.bind_addr);
     eprintln!("  database:  {}", config.database_url);
+    eprintln!("  mode:      {:?}", config.cp_mode);
 
     // Connect to database and run migrations
     let db = db::connect_and_migrate(&config.database_url).expect("failed to connect to database");
 
     eprintln!("  database connected, migrations applied");
+
+    // Import seed config if provided (new portable CP bootstrapping from a bootstrap CP)
+    import_seed_if_configured(&db);
+
+    // Import full state bundle if provided (instant cutover migration)
+    if let Some(ref path) = config.import_state_path {
+        import_state_from_file(&db, path);
+    }
 
     // Build application state
     let mut state = AppState::from_env(db);
@@ -50,8 +60,44 @@ async fn main() {
         .and_then(|p| p.parse().ok())
         .unwrap_or(8080);
 
+    // Capture proxy state for the middleware
+    let proxy_target = state.proxy_target.clone();
+
     // Build router
     let app = routes::build_router(state);
+
+    // Wrap with proxy middleware for zero-downtime migration
+    let app = app.layer(axum::middleware::from_fn(
+        move |req: axum::http::Request<axum::body::Body>, next: axum::middleware::Next| {
+            let proxy = proxy_target.clone();
+            async move {
+                // Check if we should proxy this request
+                let target = proxy.read().unwrap().clone();
+                if let Some(target_url) = target {
+                    // Don't proxy migration control endpoints (admin still talks to old CP)
+                    let path = req.uri().path();
+                    if path.starts_with("/api/v1/admin/migration/") || path == "/health" {
+                        return next.run(req).await;
+                    }
+
+                    // Forward to the new CP
+                    match proxy_request(&target_url, req).await {
+                        Ok(resp) => resp,
+                        Err(_) => {
+                            // If proxy fails, fall through to local handling
+                            // (can't retry the consumed request, return 502)
+                            axum::http::Response::builder()
+                                .status(502)
+                                .body(axum::body::Body::from("proxy target unreachable"))
+                                .unwrap()
+                        }
+                    }
+                } else {
+                    next.run(req).await
+                }
+            }
+        },
+    ));
 
     // Start server
     let listener = tokio::net::TcpListener::bind(&config.bind_addr)
@@ -61,7 +107,11 @@ async fn main() {
     eprintln!("  listening on {}", listener.local_addr().unwrap());
 
     // Spawn CF tunnel setup in the background (after the listener is bound).
-    if !cp_public_hostname.is_empty() {
+    // In bootstrap mode, skip tunnel unless explicitly configured.
+    let should_create_tunnel = !cp_public_hostname.is_empty()
+        && (!config.is_bootstrap() || std::env::var("DD_CP_FORCE_TUNNEL").is_ok());
+
+    if should_create_tunnel {
         tokio::spawn(async move {
             eprintln!("  creating CF tunnel for {cp_public_hostname}...");
             match tunnel_svc
@@ -77,5 +127,91 @@ async fn main() {
         });
     }
 
-    axum::serve(listener, app).await.expect("server error");
+    axum::serve(listener, app.into_make_service())
+        .await
+        .expect("server error");
+}
+
+/// Import seed config from the DD_CP_IMPORT_SEED_INLINE env var.
+/// This is set by the bootstrap CP when deploying the portable CP.
+fn import_seed_if_configured(db: &dd_control_plane::db::Db) {
+    if let Ok(seed_json) = std::env::var("DD_CP_IMPORT_SEED_INLINE") {
+        eprintln!("  importing seed config from DD_CP_IMPORT_SEED_INLINE...");
+        match serde_json::from_str::<SeedConfig>(&seed_json) {
+            Ok(seed) => {
+                let summary = seed.summary();
+                match seed.import(db) {
+                    Ok(()) => {
+                        eprintln!("  seed config imported: {:?}", summary.table_counts);
+                    }
+                    Err(e) => {
+                        eprintln!("  WARNING: seed config import failed: {e}");
+                    }
+                }
+            }
+            Err(e) => {
+                eprintln!("  WARNING: failed to parse seed config: {e}");
+            }
+        }
+    }
+}
+
+/// Import a full state bundle from a JSON file on disk.
+fn import_state_from_file(db: &dd_control_plane::db::Db, path: &str) {
+    eprintln!("  importing state from {path}...");
+    match std::fs::read(path) {
+        Ok(data) => {
+            use dd_control_plane::services::migration::StateBundle;
+            match StateBundle::from_json(&data) {
+                Ok(bundle) => {
+                    let summary = bundle.summary();
+                    bundle.apply_secrets_to_env();
+                    match bundle.import(db) {
+                        Ok(()) => {
+                            eprintln!("  state imported: {:?}", summary.table_counts);
+                        }
+                        Err(e) => {
+                            eprintln!("  WARNING: state import failed: {e}");
+                        }
+                    }
+                }
+                Err(e) => {
+                    eprintln!("  WARNING: failed to parse state bundle: {e}");
+                }
+            }
+        }
+        Err(e) => {
+            eprintln!("  WARNING: failed to read state file {path}: {e}");
+        }
+    }
+}
+
+/// Forward an HTTP request to the proxy target.
+async fn proxy_request(
+    target_url: &str,
+    req: axum::http::Request<axum::body::Body>,
+) -> Result<axum::http::Response<axum::body::Body>, reqwest::Error> {
+    let client = reqwest::Client::new();
+
+    let uri = format!("{}{}", target_url.trim_end_matches('/'), req.uri().path());
+    let method = req.method().clone();
+
+    let body_bytes = axum::body::to_bytes(req.into_body(), 10 * 1024 * 1024)
+        .await
+        .unwrap_or_default();
+
+    let resp = client
+        .request(method, &uri)
+        .body(body_bytes.to_vec())
+        .send()
+        .await?;
+
+    let status = resp.status();
+    let body = resp.bytes().await.unwrap_or_default();
+
+    Ok(axum::http::Response::builder()
+        .status(status)
+        .header("content-type", "application/json")
+        .body(axum::body::Body::from(body))
+        .unwrap())
 }

--- a/control-plane/src/bin/dd-cp/main.rs
+++ b/control-plane/src/bin/dd-cp/main.rs
@@ -14,14 +14,13 @@ async fn main() {
     eprintln!("DevOps Defender Control Plane starting...");
     eprintln!("  bind_addr: {}", config.bind_addr);
     eprintln!("  database:  {}", config.database_url);
-    eprintln!("  mode:      {:?}", config.cp_mode);
 
     // Connect to database and run migrations
     let db = db::connect_and_migrate(&config.database_url).expect("failed to connect to database");
 
     eprintln!("  database connected, migrations applied");
 
-    // Import seed config if provided (new portable CP bootstrapping from a bootstrap CP)
+    // Import seed config if provided (deployed by another CP via deploy-cp)
     import_seed_if_configured(&db);
 
     // Import full state bundle if provided (instant cutover migration)
@@ -71,26 +70,20 @@ async fn main() {
         move |req: axum::http::Request<axum::body::Body>, next: axum::middleware::Next| {
             let proxy = proxy_target.clone();
             async move {
-                // Check if we should proxy this request
                 let target = proxy.read().unwrap().clone();
                 if let Some(target_url) = target {
-                    // Don't proxy migration control endpoints (admin still talks to old CP)
+                    // Don't proxy migration control endpoints
                     let path = req.uri().path();
                     if path.starts_with("/api/v1/admin/migration/") || path == "/health" {
                         return next.run(req).await;
                     }
 
-                    // Forward to the new CP
                     match proxy_request(&target_url, req).await {
                         Ok(resp) => resp,
-                        Err(_) => {
-                            // If proxy fails, fall through to local handling
-                            // (can't retry the consumed request, return 502)
-                            axum::http::Response::builder()
-                                .status(502)
-                                .body(axum::body::Body::from("proxy target unreachable"))
-                                .unwrap()
-                        }
+                        Err(_) => axum::http::Response::builder()
+                            .status(502)
+                            .body(axum::body::Body::from("proxy target unreachable"))
+                            .unwrap(),
                     }
                 } else {
                     next.run(req).await
@@ -107,11 +100,7 @@ async fn main() {
     eprintln!("  listening on {}", listener.local_addr().unwrap());
 
     // Spawn CF tunnel setup in the background (after the listener is bound).
-    // In bootstrap mode, skip tunnel unless explicitly configured.
-    let should_create_tunnel = !cp_public_hostname.is_empty()
-        && (!config.is_bootstrap() || std::env::var("DD_CP_FORCE_TUNNEL").is_ok());
-
-    if should_create_tunnel {
+    if !cp_public_hostname.is_empty() {
         tokio::spawn(async move {
             eprintln!("  creating CF tunnel for {cp_public_hostname}...");
             match tunnel_svc
@@ -133,7 +122,7 @@ async fn main() {
 }
 
 /// Import seed config from the DD_CP_IMPORT_SEED_INLINE env var.
-/// This is set by the bootstrap CP when deploying the portable CP.
+/// This is set when a CP deploys another CP via the deploy-cp endpoint.
 fn import_seed_if_configured(db: &dd_control_plane::db::Db) {
     if let Ok(seed_json) = std::env::var("DD_CP_IMPORT_SEED_INLINE") {
         eprintln!("  importing seed config from DD_CP_IMPORT_SEED_INLINE...");

--- a/control-plane/src/config.rs
+++ b/control-plane/src/config.rs
@@ -1,27 +1,5 @@
 use std::collections::HashMap;
 
-/// The operational mode of the control plane.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum CpMode {
-    /// Bootstrap mode: a lightweight CP that runs on bare infrastructure,
-    /// registers agents, and can deploy the portable CP as a workload.
-    /// Does not create its own CF tunnel by default.
-    Bootstrap,
-    /// Portable mode: the full CP running as a container workload on an agent.
-    /// Supports state export/import for migration between nodes.
-    Portable,
-}
-
-impl CpMode {
-    fn from_str(s: &str) -> Self {
-        match s.to_lowercase().as_str() {
-            "bootstrap" => Self::Bootstrap,
-            "portable" => Self::Portable,
-            _ => Self::Portable,
-        }
-    }
-}
-
 /// Control plane configuration, loaded from environment variables.
 #[derive(Debug, Clone)]
 pub struct CpConfig {
@@ -31,8 +9,6 @@ pub struct CpConfig {
     pub tcb_enforcement_mode: String,
     pub rtmr_enforcement_mode: String,
     pub nonce_enforcement_mode: String,
-    /// Bootstrap or portable mode.
-    pub cp_mode: CpMode,
     /// Path to a state bundle JSON file to import on startup.
     /// When set, the CP will restore state from this file before serving.
     pub import_state_path: Option<String>,
@@ -72,16 +48,8 @@ impl CpConfig {
                 .get("DD_CP_NONCE_ENFORCEMENT_MODE")
                 .cloned()
                 .unwrap_or_else(|| "required".to_string()),
-            cp_mode: map
-                .get("DD_CP_MODE")
-                .map(|s| CpMode::from_str(s))
-                .unwrap_or(CpMode::Portable),
             import_state_path: map.get("DD_CP_IMPORT_STATE").cloned(),
         }
-    }
-
-    pub fn is_bootstrap(&self) -> bool {
-        self.cp_mode == CpMode::Bootstrap
     }
 }
 
@@ -99,17 +67,7 @@ mod tests {
         assert_eq!(cfg.tcb_enforcement_mode, "strict");
         assert_eq!(cfg.rtmr_enforcement_mode, "strict");
         assert_eq!(cfg.nonce_enforcement_mode, "required");
-        assert_eq!(cfg.cp_mode, CpMode::Portable);
         assert!(cfg.import_state_path.is_none());
-    }
-
-    #[test]
-    fn bootstrap_mode_from_env() {
-        let mut map = HashMap::new();
-        map.insert("DD_CP_MODE".into(), "bootstrap".into());
-        let cfg = CpConfig::from_map(&map);
-        assert_eq!(cfg.cp_mode, CpMode::Bootstrap);
-        assert!(cfg.is_bootstrap());
     }
 
     #[test]

--- a/control-plane/src/config.rs
+++ b/control-plane/src/config.rs
@@ -1,5 +1,27 @@
 use std::collections::HashMap;
 
+/// The operational mode of the control plane.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CpMode {
+    /// Bootstrap mode: a lightweight CP that runs on bare infrastructure,
+    /// registers agents, and can deploy the portable CP as a workload.
+    /// Does not create its own CF tunnel by default.
+    Bootstrap,
+    /// Portable mode: the full CP running as a container workload on an agent.
+    /// Supports state export/import for migration between nodes.
+    Portable,
+}
+
+impl CpMode {
+    fn from_str(s: &str) -> Self {
+        match s.to_lowercase().as_str() {
+            "bootstrap" => Self::Bootstrap,
+            "portable" => Self::Portable,
+            _ => Self::Portable,
+        }
+    }
+}
+
 /// Control plane configuration, loaded from environment variables.
 #[derive(Debug, Clone)]
 pub struct CpConfig {
@@ -9,6 +31,11 @@ pub struct CpConfig {
     pub tcb_enforcement_mode: String,
     pub rtmr_enforcement_mode: String,
     pub nonce_enforcement_mode: String,
+    /// Bootstrap or portable mode.
+    pub cp_mode: CpMode,
+    /// Path to a state bundle JSON file to import on startup.
+    /// When set, the CP will restore state from this file before serving.
+    pub import_state_path: Option<String>,
 }
 
 impl CpConfig {
@@ -45,7 +72,16 @@ impl CpConfig {
                 .get("DD_CP_NONCE_ENFORCEMENT_MODE")
                 .cloned()
                 .unwrap_or_else(|| "required".to_string()),
+            cp_mode: map
+                .get("DD_CP_MODE")
+                .map(|s| CpMode::from_str(s))
+                .unwrap_or(CpMode::Portable),
+            import_state_path: map.get("DD_CP_IMPORT_STATE").cloned(),
         }
+    }
+
+    pub fn is_bootstrap(&self) -> bool {
+        self.cp_mode == CpMode::Bootstrap
     }
 }
 
@@ -63,5 +99,24 @@ mod tests {
         assert_eq!(cfg.tcb_enforcement_mode, "strict");
         assert_eq!(cfg.rtmr_enforcement_mode, "strict");
         assert_eq!(cfg.nonce_enforcement_mode, "required");
+        assert_eq!(cfg.cp_mode, CpMode::Portable);
+        assert!(cfg.import_state_path.is_none());
+    }
+
+    #[test]
+    fn bootstrap_mode_from_env() {
+        let mut map = HashMap::new();
+        map.insert("DD_CP_MODE".into(), "bootstrap".into());
+        let cfg = CpConfig::from_map(&map);
+        assert_eq!(cfg.cp_mode, CpMode::Bootstrap);
+        assert!(cfg.is_bootstrap());
+    }
+
+    #[test]
+    fn import_state_path_from_env() {
+        let mut map = HashMap::new();
+        map.insert("DD_CP_IMPORT_STATE".into(), "/tmp/state.json".into());
+        let cfg = CpConfig::from_map(&map);
+        assert_eq!(cfg.import_state_path, Some("/tmp/state.json".to_string()));
     }
 }

--- a/control-plane/src/db.rs
+++ b/control-plane/src/db.rs
@@ -21,3 +21,145 @@ pub fn connect_and_migrate(url: &str) -> Result<Db, rusqlite::Error> {
     conn.execute_batch(include_str!("../migrations/0001_init.sql"))?;
     Ok(Arc::new(Mutex::new(conn)))
 }
+
+/// Tables included in state export/import, ordered to respect foreign key constraints.
+const EXPORTABLE_TABLES: &[&str] = &[
+    "agents",
+    "agent_control_credentials",
+    "deployments",
+    "app_health_checks",
+    "services",
+    "apps",
+    "app_versions",
+    "accounts",
+    "settings",
+    "trusted_mrtds",
+    // admin_sessions are intentionally excluded — they are ephemeral
+];
+
+/// Export all table data as a map of table_name → Vec<Row>, where each row is
+/// a map of column_name → JSON value.
+pub fn export_all_tables(
+    db: &Db,
+) -> Result<serde_json::Map<String, serde_json::Value>, rusqlite::Error> {
+    let conn = db.lock().unwrap();
+    let mut tables = serde_json::Map::new();
+
+    for &table in EXPORTABLE_TABLES {
+        let mut stmt = conn.prepare(&format!("SELECT * FROM {table}"))?;
+        let col_count = stmt.column_count();
+        let col_names: Vec<String> = (0..col_count)
+            .map(|i| stmt.column_name(i).unwrap().to_string())
+            .collect();
+
+        let rows = stmt.query_map([], |row| {
+            let mut obj = serde_json::Map::new();
+            for (i, name) in col_names.iter().enumerate() {
+                let val: rusqlite::types::Value = row.get(i)?;
+                let json_val = match val {
+                    rusqlite::types::Value::Null => serde_json::Value::Null,
+                    rusqlite::types::Value::Integer(n) => serde_json::Value::Number(n.into()),
+                    rusqlite::types::Value::Real(f) => serde_json::Value::Number(
+                        serde_json::Number::from_f64(f).unwrap_or_else(|| 0.into()),
+                    ),
+                    rusqlite::types::Value::Text(s) => serde_json::Value::String(s),
+                    rusqlite::types::Value::Blob(b) => serde_json::Value::String(
+                        base64::Engine::encode(&base64::engine::general_purpose::STANDARD, &b),
+                    ),
+                };
+                obj.insert(name.clone(), json_val);
+            }
+            Ok(serde_json::Value::Object(obj))
+        })?;
+
+        let mut table_rows = Vec::new();
+        for row in rows {
+            table_rows.push(row?);
+        }
+        tables.insert(table.to_string(), serde_json::Value::Array(table_rows));
+    }
+
+    Ok(tables)
+}
+
+/// Import table data from a state bundle, replacing all existing data.
+/// Tables are cleared and repopulated in foreign-key-safe order.
+pub fn import_all_tables(
+    db: &Db,
+    tables: &serde_json::Map<String, serde_json::Value>,
+) -> Result<(), String> {
+    let conn = db.lock().unwrap();
+
+    // Temporarily disable FK checks during import
+    conn.execute_batch("PRAGMA foreign_keys=OFF;")
+        .map_err(|e| format!("disable FK: {e}"))?;
+
+    // Clear tables in reverse order (respect FK deps)
+    for &table in EXPORTABLE_TABLES.iter().rev() {
+        conn.execute(&format!("DELETE FROM {table}"), [])
+            .map_err(|e| format!("clear {table}: {e}"))?;
+    }
+
+    // Insert rows in forward order
+    for &table in EXPORTABLE_TABLES {
+        let rows = match tables.get(table) {
+            Some(serde_json::Value::Array(arr)) => arr,
+            _ => continue,
+        };
+
+        for row_val in rows {
+            let obj = match row_val.as_object() {
+                Some(o) => o,
+                None => continue,
+            };
+
+            if obj.is_empty() {
+                continue;
+            }
+
+            let cols: Vec<&String> = obj.keys().collect();
+            let col_list = cols
+                .iter()
+                .map(|c| c.as_str())
+                .collect::<Vec<_>>()
+                .join(", ");
+            let placeholders = (1..=cols.len())
+                .map(|i| format!("?{i}"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            let sql = format!("INSERT INTO {table} ({col_list}) VALUES ({placeholders})");
+
+            let values: Vec<Box<dyn rusqlite::types::ToSql>> = cols
+                .iter()
+                .map(|col| -> Box<dyn rusqlite::types::ToSql> {
+                    match &obj[col.as_str()] {
+                        serde_json::Value::Null => Box::new(Option::<String>::None),
+                        serde_json::Value::Bool(b) => Box::new(*b as i64),
+                        serde_json::Value::Number(n) => {
+                            if let Some(i) = n.as_i64() {
+                                Box::new(i)
+                            } else if let Some(f) = n.as_f64() {
+                                Box::new(f)
+                            } else {
+                                Box::new(Option::<String>::None)
+                            }
+                        }
+                        serde_json::Value::String(s) => Box::new(s.clone()),
+                        other => Box::new(other.to_string()),
+                    }
+                })
+                .collect();
+
+            let param_refs: Vec<&dyn rusqlite::types::ToSql> =
+                values.iter().map(|v| v.as_ref()).collect();
+
+            conn.execute(&sql, param_refs.as_slice())
+                .map_err(|e| format!("insert into {table}: {e}"))?;
+        }
+    }
+
+    conn.execute_batch("PRAGMA foreign_keys=ON;")
+        .map_err(|e| format!("re-enable FK: {e}"))?;
+
+    Ok(())
+}

--- a/control-plane/src/routes/migration.rs
+++ b/control-plane/src/routes/migration.rs
@@ -1,0 +1,493 @@
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::Json;
+
+use crate::api::{
+    AgentReattachRequest, BootstrapDeployCpRequest, BootstrapDeployCpResponse,
+    MigrationImportResponse, MigrationReadinessResponse, MigrationStatusResponse,
+    ProxyStartRequest,
+};
+use crate::common::error::AppError;
+use crate::services::migration::{SeedConfig, StateBundle};
+use crate::state::AppState;
+use crate::stores::{agent as agent_store, deployment as deployment_store};
+use crate::types::DeploymentStatus;
+
+// ── Status & readiness ──────────────────────────────────────────────────────
+
+/// GET /api/v1/admin/migration/status
+pub async fn migration_status(
+    State(state): State<AppState>,
+) -> Result<Json<MigrationStatusResponse>, AppError> {
+    let agents = agent_store::list_agents(&state.db)?;
+    let deployments = deployment_store::list_deployments(&state.db, None)?;
+    let proxy = state.proxy_target.read().unwrap().clone();
+
+    Ok(Json(MigrationStatusResponse {
+        cp_mode: state.cp_mode.clone(),
+        can_export: true,
+        can_import: true,
+        agent_count: agents.len(),
+        deployment_count: deployments.len(),
+        proxy_target: proxy,
+    }))
+}
+
+/// GET /api/v1/admin/migration/readiness
+/// Check if the new CP has all expected agents re-registered.
+pub async fn migration_readiness(
+    State(state): State<AppState>,
+) -> Result<Json<MigrationReadinessResponse>, AppError> {
+    let expected = state.expected_agent_count.read().unwrap().unwrap_or(0);
+    let current_agents = agent_store::list_agents(&state.db)?;
+    let registered = current_agents.len();
+
+    // If we don't know the expected count yet, report not ready
+    if expected == 0 {
+        return Ok(Json(MigrationReadinessResponse {
+            ready: false,
+            agents_registered: registered,
+            agents_expected: 0,
+            agents_missing: vec![],
+        }));
+    }
+
+    Ok(Json(MigrationReadinessResponse {
+        ready: registered >= expected,
+        agents_registered: registered,
+        agents_expected: expected,
+        agents_missing: vec![], // Can't list specifics without old CP data
+    }))
+}
+
+// ── Export ───────────────────────────────────────────────────────────────────
+
+/// POST /api/v1/admin/migration/export/seed
+/// Export lightweight seed config (accounts, settings, trusted_mrtds, apps).
+/// Agents and deployments are NOT included — they re-register naturally.
+pub async fn export_seed(State(state): State<AppState>) -> Result<Json<SeedConfig>, AppError> {
+    let seed = SeedConfig::export(&state.db, &state.git_sha)?;
+    Ok(Json(seed))
+}
+
+/// POST /api/v1/admin/migration/export/full
+/// Export full state bundle including all agents and deployments.
+/// Use this for instant cutover when you can't wait for re-registration.
+pub async fn export_full(State(state): State<AppState>) -> Result<Json<StateBundle>, AppError> {
+    let bundle = StateBundle::export(&state.db, &state.git_sha)?;
+    Ok(Json(bundle))
+}
+
+// ── Import ──────────────────────────────────────────────────────────────────
+
+/// POST /api/v1/admin/migration/import/seed
+/// Import seed config into this CP.
+pub async fn import_seed(
+    State(state): State<AppState>,
+    Json(seed): Json<SeedConfig>,
+) -> Result<Json<MigrationImportResponse>, AppError> {
+    let summary = seed.summary();
+    seed.import(&state.db)?;
+
+    Ok(Json(MigrationImportResponse {
+        imported: true,
+        summary,
+    }))
+}
+
+/// POST /api/v1/admin/migration/import/full
+/// Import full state bundle (instant cutover).
+pub async fn import_full(
+    State(state): State<AppState>,
+    Json(bundle): Json<StateBundle>,
+) -> Result<Json<MigrationImportResponse>, AppError> {
+    let seed_summary = {
+        // Extract just the seed table counts for the summary
+        let mut table_counts = std::collections::HashMap::new();
+        for (table, rows) in &bundle.database {
+            if let Some(arr) = rows.as_array() {
+                table_counts.insert(table.clone(), arr.len());
+            }
+        }
+        crate::services::migration::SeedConfigSummary {
+            version: bundle.version,
+            exported_at: bundle.exported_at.clone(),
+            git_sha: bundle.git_sha.clone(),
+            table_counts,
+        }
+    };
+
+    bundle.apply_secrets_to_env();
+    bundle.import(&state.db)?;
+
+    Ok(Json(MigrationImportResponse {
+        imported: true,
+        summary: seed_summary,
+    }))
+}
+
+// ── Proxy (zero-downtime) ───────────────────────────────────────────────────
+
+/// POST /api/v1/admin/migration/proxy/start
+/// Start proxying all requests to the new CP.  The old CP becomes a thin
+/// reverse proxy so clients see zero downtime while DNS/tunnels converge.
+pub async fn proxy_start(
+    State(state): State<AppState>,
+    Json(req): Json<ProxyStartRequest>,
+) -> Result<StatusCode, AppError> {
+    // Record agent count so the new CP can track readiness
+    let agents = agent_store::list_agents(&state.db)?;
+    *state.expected_agent_count.write().unwrap() = Some(agents.len());
+
+    // Activate proxy
+    *state.proxy_target.write().unwrap() = Some(req.target_url.clone());
+
+    eprintln!(
+        "migration: proxying traffic to {} ({} agents expected to re-register)",
+        req.target_url,
+        agents.len()
+    );
+
+    Ok(StatusCode::OK)
+}
+
+/// POST /api/v1/admin/migration/proxy/stop
+/// Stop proxying and resume local handling.
+pub async fn proxy_stop(State(state): State<AppState>) -> Result<StatusCode, AppError> {
+    *state.proxy_target.write().unwrap() = None;
+    eprintln!("migration: proxy stopped, handling traffic locally");
+    Ok(StatusCode::OK)
+}
+
+// ── Agent reattach ──────────────────────────────────────────────────────────
+
+/// POST /api/v1/agents/reattach
+/// Called by an agent that heartbeated a new CP and got 404.
+/// Creates the agent record and restores its running deployments.
+pub async fn agent_reattach(
+    State(state): State<AppState>,
+    Json(req): Json<AgentReattachRequest>,
+) -> Result<(StatusCode, Json<serde_json::Value>), AppError> {
+    let agent_id = uuid::Uuid::new_v4();
+
+    // Create tunnel for the reattaching agent
+    let tunnel_info = state
+        .tunnel
+        .create_tunnel_for_agent(agent_id, &req.vm_name)
+        .await?;
+
+    let agent = agent_store::AgentRow {
+        id: agent_id.to_string(),
+        vm_name: req.vm_name.clone(),
+        status: if req.running_deployments.is_empty() {
+            "undeployed".into()
+        } else {
+            "deployed".into()
+        },
+        registration_state: "ready".into(),
+        hostname: Some(tunnel_info.hostname.clone()),
+        tunnel_id: Some(tunnel_info.tunnel_id),
+        mrtd: None,
+        tcb_status: None,
+        node_size: req.node_size,
+        datacenter: req.datacenter,
+        github_owner: None,
+        created_at: chrono::Utc::now().to_rfc3339(),
+        last_heartbeat_at: Some(chrono::Utc::now().to_rfc3339()),
+    };
+    agent_store::insert_agent(&state.db, &agent)?;
+
+    // Restore running deployment records
+    for dep in &req.running_deployments {
+        let now = chrono::Utc::now().to_rfc3339();
+        let row = deployment_store::DeploymentRow {
+            id: dep.deployment_id.clone(),
+            agent_id: agent_id.to_string(),
+            app_name: dep.app_name.clone(),
+            app_version: None,
+            compose: None,
+            image: dep.image.clone(),
+            env: None,
+            cmd: None,
+            ports: None,
+            config: None,
+            status: dep.status.clone(),
+            error_message: None,
+            previous_deployment_id: None,
+            created_at: now.clone(),
+            updated_at: now,
+        };
+        // Ignore duplicate errors — deployment might already exist from seed import
+        let _ = deployment_store::insert_deployment(&state.db, &row);
+    }
+
+    eprintln!(
+        "migration: agent {} reattached as {} with {} deployments",
+        req.vm_name,
+        agent_id,
+        req.running_deployments.len()
+    );
+
+    Ok((
+        StatusCode::CREATED,
+        Json(serde_json::json!({
+            "agent_id": agent_id,
+            "tunnel_token": tunnel_info.tunnel_token,
+            "hostname": tunnel_info.hostname,
+        })),
+    ))
+}
+
+// ── Bootstrap: deploy portable CP ───────────────────────────────────────────
+
+/// POST /api/v1/admin/migration/deploy-cp
+/// Bootstrap-only: deploy the portable CP as a container workload on an agent.
+/// Exports the seed config and passes secrets as container env vars.
+/// Agents will naturally re-register with the new CP.
+pub async fn bootstrap_deploy_cp(
+    State(state): State<AppState>,
+    Json(req): Json<BootstrapDeployCpRequest>,
+) -> Result<(StatusCode, Json<BootstrapDeployCpResponse>), AppError> {
+    if state.cp_mode != "bootstrap" {
+        return Err(AppError::InvalidInput(
+            "deploy-cp is only available in bootstrap mode".into(),
+        ));
+    }
+
+    // Find or validate the target agent
+    let agent = if let Some(ref agent_id) = req.agent_id {
+        agent_store::get_agent(&state.db, agent_id)?.ok_or(AppError::NotFound)?
+    } else {
+        agent_store::find_available_agent(
+            &state.db,
+            req.node_size.as_deref(),
+            req.datacenter.as_deref(),
+        )?
+        .ok_or(AppError::NotFound)?
+    };
+
+    let agent_id: uuid::Uuid = agent.id.parse().map_err(|_| AppError::Internal)?;
+
+    // Export seed config for the new CP
+    let seed = SeedConfig::export(&state.db, &state.git_sha)?;
+    let seed_json = serde_json::to_string(&seed)
+        .map_err(|e| AppError::External(format!("serialize seed: {e}")))?;
+
+    // Build env vars: secrets + mode + seed config inline
+    let mut env_vars = vec![
+        "DD_CP_MODE=portable".to_string(),
+        "DD_CP_BIND_ADDR=0.0.0.0:8080".to_string(),
+    ];
+
+    // Collect current secrets from env
+    for &key in crate::services::migration::SECRET_ENV_VARS {
+        if let Ok(val) = std::env::var(key) {
+            env_vars.push(format!("{key}={val}"));
+        }
+    }
+
+    // Pass seed config inline so the new CP imports it on startup
+    env_vars.push(format!("DD_CP_IMPORT_SEED_INLINE={seed_json}"));
+
+    let env_json = serde_json::to_string(&env_vars).unwrap_or_default();
+
+    let deployment_id = uuid::Uuid::new_v4();
+    let now = chrono::Utc::now().to_rfc3339();
+    let dep = deployment_store::DeploymentRow {
+        id: deployment_id.to_string(),
+        agent_id: agent.id.clone(),
+        app_name: Some("devopsdefender-cp".into()),
+        app_version: Some(state.git_sha.clone()),
+        compose: None,
+        image: Some(req.image),
+        env: Some(env_json),
+        cmd: None,
+        ports: Some(serde_json::to_string(&vec!["8080:8080"]).unwrap_or_default()),
+        config: None,
+        status: "pending".into(),
+        error_message: None,
+        previous_deployment_id: None,
+        created_at: now.clone(),
+        updated_at: now,
+    };
+    deployment_store::insert_deployment(&state.db, &dep)?;
+
+    Ok((
+        StatusCode::CREATED,
+        Json(BootstrapDeployCpResponse {
+            deployment_id,
+            agent_id,
+            status: DeploymentStatus::Pending,
+            seed_config_included: true,
+        }),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::RunningDeploymentReport;
+    use crate::db;
+    use crate::routes::build_router;
+    use crate::stores::agent as agent_store;
+    use axum::body::Body;
+    use axum::http::Request;
+    use tower::ServiceExt;
+
+    fn test_state() -> AppState {
+        let db = db::connect_and_migrate("sqlite://:memory:").unwrap();
+        AppState::for_testing(db)
+    }
+
+    #[tokio::test]
+    async fn migration_status_returns_info() {
+        let state = test_state();
+        let app = build_router(state);
+
+        let req = Request::builder()
+            .uri("/api/v1/admin/migration/status")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let status: MigrationStatusResponse = serde_json::from_slice(&body).unwrap();
+        assert!(status.can_export);
+        assert_eq!(status.agent_count, 0);
+        assert!(status.proxy_target.is_none());
+    }
+
+    #[tokio::test]
+    async fn export_seed_excludes_agents() {
+        let state = test_state();
+
+        // Insert an agent and a setting
+        let agent = agent_store::AgentRow {
+            id: "test-agent-1".into(),
+            vm_name: "vm-export-test".into(),
+            status: "undeployed".into(),
+            registration_state: "ready".into(),
+            hostname: Some("test.devopsdefender.com".into()),
+            tunnel_id: None,
+            mrtd: None,
+            tcb_status: None,
+            node_size: None,
+            datacenter: None,
+            github_owner: None,
+            created_at: chrono::Utc::now().to_rfc3339(),
+            last_heartbeat_at: None,
+        };
+        agent_store::insert_agent(&state.db, &agent).unwrap();
+        state.settings.set("test-key", "test-val").unwrap();
+
+        let app = build_router(state);
+
+        let req = Request::builder()
+            .uri("/api/v1/admin/migration/export/seed")
+            .method("POST")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let seed: SeedConfig = serde_json::from_slice(&body).unwrap();
+
+        // Settings should be included
+        let settings = seed.tables.get("settings").unwrap().as_array().unwrap();
+        assert_eq!(settings.len(), 1);
+
+        // Agents should NOT be in seed config
+        assert!(!seed.tables.contains_key("agents"));
+    }
+
+    #[tokio::test]
+    async fn agent_reattach_creates_agent_and_deployments() {
+        let state = test_state();
+        let app = build_router(state.clone());
+
+        let reattach_req = AgentReattachRequest {
+            vm_name: "vm-returning".into(),
+            node_size: Some("large".into()),
+            datacenter: Some("us-central1".into()),
+            running_deployments: vec![RunningDeploymentReport {
+                deployment_id: "dep-123".into(),
+                app_name: Some("my-app".into()),
+                image: Some("nginx:latest".into()),
+                status: "running".into(),
+            }],
+        };
+
+        let req = Request::builder()
+            .uri("/api/v1/agents/reattach")
+            .method("POST")
+            .header("content-type", "application/json")
+            .body(Body::from(serde_json::to_string(&reattach_req).unwrap()))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::CREATED);
+
+        // Verify agent was created
+        let agents = agent_store::list_agents(&state.db).unwrap();
+        assert_eq!(agents.len(), 1);
+        assert_eq!(agents[0].vm_name, "vm-returning");
+        assert_eq!(agents[0].status, "deployed");
+
+        // Verify deployment was recorded
+        let deps = deployment_store::list_deployments(&state.db, Some(&agents[0].id)).unwrap();
+        assert_eq!(deps.len(), 1);
+        assert_eq!(deps[0].id, "dep-123");
+        assert_eq!(deps[0].status, "running");
+    }
+
+    #[tokio::test]
+    async fn readiness_tracks_expected_count() {
+        let state = test_state();
+
+        // Set expected count
+        *state.expected_agent_count.write().unwrap() = Some(3);
+
+        // Add 2 agents (not yet at 3)
+        for i in 0..2 {
+            let agent = agent_store::AgentRow {
+                id: format!("agent-{i}"),
+                vm_name: format!("vm-{i}"),
+                status: "undeployed".into(),
+                registration_state: "ready".into(),
+                hostname: None,
+                tunnel_id: None,
+                mrtd: None,
+                tcb_status: None,
+                node_size: None,
+                datacenter: None,
+                github_owner: None,
+                created_at: chrono::Utc::now().to_rfc3339(),
+                last_heartbeat_at: None,
+            };
+            agent_store::insert_agent(&state.db, &agent).unwrap();
+        }
+
+        let app = build_router(state);
+        let req = Request::builder()
+            .uri("/api/v1/admin/migration/readiness")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let readiness: MigrationReadinessResponse = serde_json::from_slice(&body).unwrap();
+        assert!(!readiness.ready);
+        assert_eq!(readiness.agents_registered, 2);
+        assert_eq!(readiness.agents_expected, 3);
+    }
+}

--- a/control-plane/src/routes/migration.rs
+++ b/control-plane/src/routes/migration.rs
@@ -3,9 +3,8 @@ use axum::http::StatusCode;
 use axum::Json;
 
 use crate::api::{
-    AgentReattachRequest, BootstrapDeployCpRequest, BootstrapDeployCpResponse,
-    MigrationImportResponse, MigrationReadinessResponse, MigrationStatusResponse,
-    ProxyStartRequest,
+    AgentReattachRequest, DeployCpRequest, DeployCpResponse, MigrationImportResponse,
+    MigrationReadinessResponse, MigrationStatusResponse, ProxyStartRequest,
 };
 use crate::common::error::AppError;
 use crate::services::migration::{SeedConfig, StateBundle};
@@ -24,7 +23,6 @@ pub async fn migration_status(
     let proxy = state.proxy_target.read().unwrap().clone();
 
     Ok(Json(MigrationStatusResponse {
-        cp_mode: state.cp_mode.clone(),
         can_export: true,
         can_import: true,
         agent_count: agents.len(),
@@ -42,7 +40,6 @@ pub async fn migration_readiness(
     let current_agents = agent_store::list_agents(&state.db)?;
     let registered = current_agents.len();
 
-    // If we don't know the expected count yet, report not ready
     if expected == 0 {
         return Ok(Json(MigrationReadinessResponse {
             ready: false,
@@ -56,7 +53,7 @@ pub async fn migration_readiness(
         ready: registered >= expected,
         agents_registered: registered,
         agents_expected: expected,
-        agents_missing: vec![], // Can't list specifics without old CP data
+        agents_missing: vec![],
     }))
 }
 
@@ -102,7 +99,6 @@ pub async fn import_full(
     Json(bundle): Json<StateBundle>,
 ) -> Result<Json<MigrationImportResponse>, AppError> {
     let seed_summary = {
-        // Extract just the seed table counts for the summary
         let mut table_counts = std::collections::HashMap::new();
         for (table, rows) in &bundle.database {
             if let Some(arr) = rows.as_array() {
@@ -135,11 +131,8 @@ pub async fn proxy_start(
     State(state): State<AppState>,
     Json(req): Json<ProxyStartRequest>,
 ) -> Result<StatusCode, AppError> {
-    // Record agent count so the new CP can track readiness
     let agents = agent_store::list_agents(&state.db)?;
     *state.expected_agent_count.write().unwrap() = Some(agents.len());
-
-    // Activate proxy
     *state.proxy_target.write().unwrap() = Some(req.target_url.clone());
 
     eprintln!(
@@ -170,7 +163,6 @@ pub async fn agent_reattach(
 ) -> Result<(StatusCode, Json<serde_json::Value>), AppError> {
     let agent_id = uuid::Uuid::new_v4();
 
-    // Create tunnel for the reattaching agent
     let tunnel_info = state
         .tunnel
         .create_tunnel_for_agent(agent_id, &req.vm_name)
@@ -197,7 +189,6 @@ pub async fn agent_reattach(
     };
     agent_store::insert_agent(&state.db, &agent)?;
 
-    // Restore running deployment records
     for dep in &req.running_deployments {
         let now = chrono::Utc::now().to_rfc3339();
         let row = deployment_store::DeploymentRow {
@@ -217,7 +208,6 @@ pub async fn agent_reattach(
             created_at: now.clone(),
             updated_at: now,
         };
-        // Ignore duplicate errors — deployment might already exist from seed import
         let _ = deployment_store::insert_deployment(&state.db, &row);
     }
 
@@ -238,23 +228,16 @@ pub async fn agent_reattach(
     ))
 }
 
-// ── Bootstrap: deploy portable CP ───────────────────────────────────────────
+// ── Deploy CP on an agent ───────────────────────────────────────────────────
 
 /// POST /api/v1/admin/migration/deploy-cp
-/// Bootstrap-only: deploy the portable CP as a container workload on an agent.
+/// Deploy a new CP instance as a container workload on an agent.
 /// Exports the seed config and passes secrets as container env vars.
 /// Agents will naturally re-register with the new CP.
-pub async fn bootstrap_deploy_cp(
+pub async fn deploy_cp(
     State(state): State<AppState>,
-    Json(req): Json<BootstrapDeployCpRequest>,
-) -> Result<(StatusCode, Json<BootstrapDeployCpResponse>), AppError> {
-    if state.cp_mode != "bootstrap" {
-        return Err(AppError::InvalidInput(
-            "deploy-cp is only available in bootstrap mode".into(),
-        ));
-    }
-
-    // Find or validate the target agent
+    Json(req): Json<DeployCpRequest>,
+) -> Result<(StatusCode, Json<DeployCpResponse>), AppError> {
     let agent = if let Some(ref agent_id) = req.agent_id {
         agent_store::get_agent(&state.db, agent_id)?.ok_or(AppError::NotFound)?
     } else {
@@ -273,13 +256,9 @@ pub async fn bootstrap_deploy_cp(
     let seed_json = serde_json::to_string(&seed)
         .map_err(|e| AppError::External(format!("serialize seed: {e}")))?;
 
-    // Build env vars: secrets + mode + seed config inline
-    let mut env_vars = vec![
-        "DD_CP_MODE=portable".to_string(),
-        "DD_CP_BIND_ADDR=0.0.0.0:8080".to_string(),
-    ];
+    // Build env vars: secrets + seed config inline
+    let mut env_vars = vec!["DD_CP_BIND_ADDR=0.0.0.0:8080".to_string()];
 
-    // Collect current secrets from env
     for &key in crate::services::migration::SECRET_ENV_VARS {
         if let Ok(val) = std::env::var(key) {
             env_vars.push(format!("{key}={val}"));
@@ -314,7 +293,7 @@ pub async fn bootstrap_deploy_cp(
 
     Ok((
         StatusCode::CREATED,
-        Json(BootstrapDeployCpResponse {
+        Json(DeployCpResponse {
             deployment_id,
             agent_id,
             status: DeploymentStatus::Pending,
@@ -365,7 +344,6 @@ mod tests {
     async fn export_seed_excludes_agents() {
         let state = test_state();
 
-        // Insert an agent and a setting
         let agent = agent_store::AgentRow {
             id: "test-agent-1".into(),
             vm_name: "vm-export-test".into(),
@@ -400,11 +378,8 @@ mod tests {
             .unwrap();
         let seed: SeedConfig = serde_json::from_slice(&body).unwrap();
 
-        // Settings should be included
         let settings = seed.tables.get("settings").unwrap().as_array().unwrap();
         assert_eq!(settings.len(), 1);
-
-        // Agents should NOT be in seed config
         assert!(!seed.tables.contains_key("agents"));
     }
 
@@ -435,13 +410,11 @@ mod tests {
         let resp = app.oneshot(req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::CREATED);
 
-        // Verify agent was created
         let agents = agent_store::list_agents(&state.db).unwrap();
         assert_eq!(agents.len(), 1);
         assert_eq!(agents[0].vm_name, "vm-returning");
         assert_eq!(agents[0].status, "deployed");
 
-        // Verify deployment was recorded
         let deps = deployment_store::list_deployments(&state.db, Some(&agents[0].id)).unwrap();
         assert_eq!(deps.len(), 1);
         assert_eq!(deps[0].id, "dep-123");
@@ -452,10 +425,8 @@ mod tests {
     async fn readiness_tracks_expected_count() {
         let state = test_state();
 
-        // Set expected count
         *state.expected_agent_count.write().unwrap() = Some(3);
 
-        // Add 2 agents (not yet at 3)
         for i in 0..2 {
             let agent = agent_store::AgentRow {
                 id: format!("agent-{i}"),

--- a/control-plane/src/routes/mod.rs
+++ b/control-plane/src/routes/mod.rs
@@ -93,7 +93,7 @@ pub fn build_router(state: AppState) -> Router {
         )
         .route(
             "/api/v1/admin/migration/deploy-cp",
-            post(migration::bootstrap_deploy_cp),
+            post(migration::deploy_cp),
         )
         .route(
             "/api/v1/admin/migration/proxy/start",

--- a/control-plane/src/routes/mod.rs
+++ b/control-plane/src/routes/mod.rs
@@ -4,6 +4,7 @@ pub mod agents;
 pub mod auth;
 pub mod deploy;
 pub mod health;
+pub mod migration;
 pub mod stats;
 pub mod ui;
 
@@ -22,6 +23,8 @@ pub fn build_router(state: AppState) -> Router {
         // Agent challenge & registration
         .route("/api/v1/agents/challenge", get(agents::agent_challenge))
         .route("/api/v1/agents/register", post(agents::agent_register))
+        // Agent reattach (migration: re-register with new CP)
+        .route("/api/v1/agents/reattach", post(migration::agent_reattach))
         // Agent CRUD
         .route("/api/v1/agents", get(agents::list_agents))
         .route("/api/v1/agents/{id}", get(agents::get_agent))
@@ -63,6 +66,43 @@ pub fn build_router(state: AppState) -> Router {
         // Admin
         .route("/api/v1/admin/measurements", get(admin::list_measurements))
         .route("/api/v1/admin/measurements", post(admin::add_measurement))
+        // Migration
+        .route(
+            "/api/v1/admin/migration/status",
+            get(migration::migration_status),
+        )
+        .route(
+            "/api/v1/admin/migration/readiness",
+            get(migration::migration_readiness),
+        )
+        .route(
+            "/api/v1/admin/migration/export/seed",
+            post(migration::export_seed),
+        )
+        .route(
+            "/api/v1/admin/migration/export/full",
+            post(migration::export_full),
+        )
+        .route(
+            "/api/v1/admin/migration/import/seed",
+            post(migration::import_seed),
+        )
+        .route(
+            "/api/v1/admin/migration/import/full",
+            post(migration::import_full),
+        )
+        .route(
+            "/api/v1/admin/migration/deploy-cp",
+            post(migration::bootstrap_deploy_cp),
+        )
+        .route(
+            "/api/v1/admin/migration/proxy/start",
+            post(migration::proxy_start),
+        )
+        .route(
+            "/api/v1/admin/migration/proxy/stop",
+            post(migration::proxy_stop),
+        )
         // Auth
         .route("/api/v1/auth/login", post(auth::login))
         .route("/api/v1/auth/me", get(auth::me))

--- a/control-plane/src/services/migration.rs
+++ b/control-plane/src/services/migration.rs
@@ -1,0 +1,329 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+use crate::common::error::{AppError, AppResult};
+use crate::db::{self, Db};
+
+// ── Seed Config ─────────────────────────────────────────────────────────────
+//
+// Lightweight configuration state that MUST be transferred when migrating the
+// CP to a new node.  Agent and deployment state is NOT included — agents
+// re-register naturally when they heartbeat the new CP and get a 404.
+
+/// Tables that form the "seed config" — small, essential, cannot be
+/// rediscovered from agents.
+const SEED_TABLES: &[&str] = &[
+    "accounts",
+    "settings",
+    "trusted_mrtds",
+    "apps",
+    "app_versions",
+];
+
+/// Lightweight config needed to seed a new portable CP.
+///
+/// Does NOT contain agent or deployment data — those come over naturally when
+/// agents re-register with the new CP.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SeedConfig {
+    /// Schema version for forward compatibility.
+    pub version: u32,
+    /// ISO 8601 timestamp of when this was created.
+    pub exported_at: String,
+    /// Git SHA of the CP that created this.
+    pub git_sha: String,
+    /// Seed database tables (accounts, settings, trusted_mrtds, apps, app_versions).
+    pub tables: serde_json::Map<String, serde_json::Value>,
+}
+
+impl SeedConfig {
+    pub const CURRENT_VERSION: u32 = 1;
+
+    /// Export the seed config from the current database.
+    pub fn export(db: &Db, git_sha: &str) -> AppResult<Self> {
+        let all_tables = db::export_all_tables(db)
+            .map_err(|e| AppError::External(format!("database export failed: {e}")))?;
+
+        let mut tables = serde_json::Map::new();
+        for &name in SEED_TABLES {
+            if let Some(data) = all_tables.get(name) {
+                tables.insert(name.to_string(), data.clone());
+            }
+        }
+
+        Ok(Self {
+            version: Self::CURRENT_VERSION,
+            exported_at: chrono::Utc::now().to_rfc3339(),
+            git_sha: git_sha.to_string(),
+            tables,
+        })
+    }
+
+    /// Import seed config into the database.  Only touches the seed tables.
+    pub fn import(&self, db: &Db) -> AppResult<()> {
+        if self.version > Self::CURRENT_VERSION {
+            return Err(AppError::InvalidInput(format!(
+                "seed config version {} is newer than supported version {}",
+                self.version,
+                Self::CURRENT_VERSION
+            )));
+        }
+
+        db::import_all_tables(db, &self.tables)
+            .map_err(|e| AppError::External(format!("seed config import failed: {e}")))?;
+
+        Ok(())
+    }
+
+    pub fn summary(&self) -> SeedConfigSummary {
+        let mut table_counts = HashMap::new();
+        for (table, rows) in &self.tables {
+            if let Some(arr) = rows.as_array() {
+                table_counts.insert(table.clone(), arr.len());
+            }
+        }
+        SeedConfigSummary {
+            version: self.version,
+            exported_at: self.exported_at.clone(),
+            git_sha: self.git_sha.clone(),
+            table_counts,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SeedConfigSummary {
+    pub version: u32,
+    pub exported_at: String,
+    pub git_sha: String,
+    pub table_counts: HashMap<String, usize>,
+}
+
+// ── Full State Bundle ───────────────────────────────────────────────────────
+//
+// Optional: a full database snapshot including agents and deployments.
+// Useful for instant cutover when you don't want to wait for agents to
+// re-register.
+
+// Full export uses db::EXPORTABLE_TABLES (defined in db.rs) which includes
+// all tables.  No separate constant needed here.
+
+/// Full state snapshot — seed config + all agent/deployment state.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StateBundle {
+    pub version: u32,
+    pub exported_at: String,
+    pub git_sha: String,
+    /// Configuration secrets (env var values).
+    pub secrets: HashMap<String, String>,
+    /// Full database dump.
+    pub database: serde_json::Map<String, serde_json::Value>,
+}
+
+/// Env vars captured in the secrets section.
+pub const SECRET_ENV_VARS: &[&str] = &[
+    "DD_CP_ADMIN_PASSWORD",
+    "DD_CP_CF_API_TOKEN",
+    "DD_CP_CF_ACCOUNT_ID",
+    "DD_CP_CF_ZONE_ID",
+    "DD_CP_CF_DOMAIN",
+    "DD_CP_PUBLIC_HOSTNAME",
+    "DD_CP_ITA_JWKS_URL",
+    "DD_CP_ITA_ISSUER",
+    "DD_CP_ITA_AUDIENCE",
+    "DD_CP_GITHUB_OIDC_AUDIENCE",
+    "DD_CP_CHECK_INGEST_TOKEN",
+    "DD_ENV",
+];
+
+impl StateBundle {
+    pub const CURRENT_VERSION: u32 = 1;
+
+    pub fn export(db: &Db, git_sha: &str) -> AppResult<Self> {
+        let database = db::export_all_tables(db)
+            .map_err(|e| AppError::External(format!("database export failed: {e}")))?;
+
+        let mut secrets = HashMap::new();
+        for &key in SECRET_ENV_VARS {
+            if let Ok(val) = std::env::var(key) {
+                secrets.insert(key.to_string(), val);
+            }
+        }
+
+        Ok(Self {
+            version: Self::CURRENT_VERSION,
+            exported_at: chrono::Utc::now().to_rfc3339(),
+            git_sha: git_sha.to_string(),
+            secrets,
+            database,
+        })
+    }
+
+    pub fn import(&self, db: &Db) -> AppResult<()> {
+        if self.version > Self::CURRENT_VERSION {
+            return Err(AppError::InvalidInput(format!(
+                "state bundle version {} is newer than supported version {}",
+                self.version,
+                Self::CURRENT_VERSION
+            )));
+        }
+
+        db::import_all_tables(db, &self.database)
+            .map_err(|e| AppError::External(format!("database import failed: {e}")))?;
+
+        Ok(())
+    }
+
+    pub fn apply_secrets_to_env(&self) {
+        for (key, value) in &self.secrets {
+            std::env::set_var(key, value);
+        }
+    }
+
+    pub fn to_json(&self) -> AppResult<Vec<u8>> {
+        serde_json::to_vec_pretty(self)
+            .map_err(|e| AppError::External(format!("serialize state bundle: {e}")))
+    }
+
+    pub fn from_json(data: &[u8]) -> AppResult<Self> {
+        serde_json::from_slice(data)
+            .map_err(|e| AppError::InvalidInput(format!("invalid state bundle: {e}")))
+    }
+
+    pub fn summary(&self) -> StateBundleSummary {
+        let mut table_counts = HashMap::new();
+        for (table, rows) in &self.database {
+            if let Some(arr) = rows.as_array() {
+                table_counts.insert(table.clone(), arr.len());
+            }
+        }
+        StateBundleSummary {
+            version: self.version,
+            exported_at: self.exported_at.clone(),
+            git_sha: self.git_sha.clone(),
+            secret_count: self.secrets.len(),
+            table_counts,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct StateBundleSummary {
+    pub version: u32,
+    pub exported_at: String,
+    pub git_sha: String,
+    pub secret_count: usize,
+    pub table_counts: HashMap<String, usize>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db;
+
+    fn setup_db() -> Db {
+        db::connect_and_migrate("sqlite://:memory:").unwrap()
+    }
+
+    // ── SeedConfig tests ────────────────────────────────────────────────────
+
+    #[test]
+    fn seed_config_exports_only_seed_tables() {
+        let db = setup_db();
+        {
+            let conn = db.lock().unwrap();
+            conn.execute(
+                "INSERT INTO agents (id, vm_name, status, registration_state, created_at) \
+                 VALUES ('a1', 'vm-1', 'undeployed', 'ready', '2025-01-01T00:00:00Z')",
+                [],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO settings (key, value) VALUES ('test-key', 'test-value')",
+                [],
+            )
+            .unwrap();
+        }
+
+        let seed = SeedConfig::export(&db, "sha").unwrap();
+
+        // Settings should be included
+        let settings = seed.tables.get("settings").unwrap().as_array().unwrap();
+        assert_eq!(settings.len(), 1);
+
+        // Agents should NOT be included (they re-register naturally)
+        assert!(!seed.tables.contains_key("agents"));
+    }
+
+    #[test]
+    fn seed_config_roundtrip() {
+        let db1 = setup_db();
+        {
+            let conn = db1.lock().unwrap();
+            conn.execute("INSERT INTO settings (key, value) VALUES ('k1', 'v1')", [])
+                .unwrap();
+        }
+
+        let seed = SeedConfig::export(&db1, "sha").unwrap();
+        let json = serde_json::to_vec(&seed).unwrap();
+        let restored: SeedConfig = serde_json::from_slice(&json).unwrap();
+
+        let db2 = setup_db();
+        restored.import(&db2).unwrap();
+
+        let conn = db2.lock().unwrap();
+        let val: String = conn
+            .query_row("SELECT value FROM settings WHERE key = 'k1'", [], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        assert_eq!(val, "v1");
+    }
+
+    // ── StateBundle tests ───────────────────────────────────────────────────
+
+    #[test]
+    fn export_empty_db() {
+        let db = setup_db();
+        let bundle = StateBundle::export(&db, "test-sha").unwrap();
+        assert_eq!(bundle.version, StateBundle::CURRENT_VERSION);
+        assert!(bundle.database.contains_key("agents"));
+    }
+
+    #[test]
+    fn full_bundle_roundtrip() {
+        let db1 = setup_db();
+        {
+            let conn = db1.lock().unwrap();
+            conn.execute(
+                "INSERT INTO agents (id, vm_name, status, registration_state, created_at) \
+                 VALUES ('a1', 'vm-1', 'undeployed', 'ready', '2025-01-01T00:00:00Z')",
+                [],
+            )
+            .unwrap();
+        }
+
+        let bundle = StateBundle::export(&db1, "sha-abc").unwrap();
+        let json = bundle.to_json().unwrap();
+        let restored = StateBundle::from_json(&json).unwrap();
+
+        let db2 = setup_db();
+        restored.import(&db2).unwrap();
+
+        let conn = db2.lock().unwrap();
+        let vm: String = conn
+            .query_row("SELECT vm_name FROM agents WHERE id = 'a1'", [], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        assert_eq!(vm, "vm-1");
+    }
+
+    #[test]
+    fn reject_future_version() {
+        let db = setup_db();
+        let mut bundle = StateBundle::export(&db, "sha").unwrap();
+        bundle.version = 999;
+        assert!(bundle.import(&db).is_err());
+    }
+}

--- a/control-plane/src/services/mod.rs
+++ b/control-plane/src/services/mod.rs
@@ -1,4 +1,5 @@
 pub mod attestation;
 pub mod github_oidc;
+pub mod migration;
 pub mod nonce;
 pub mod tunnel;

--- a/control-plane/src/state.rs
+++ b/control-plane/src/state.rs
@@ -28,8 +28,6 @@ pub struct AppState {
     pub attestation_recheck_seconds: u64,
     pub agent_health_path: String,
     pub agent_attestation_path: String,
-    /// "bootstrap" or "portable".
-    pub cp_mode: String,
     /// When set, the CP proxies all requests to this URL for zero-downtime migration.
     pub proxy_target: Arc<RwLock<Option<String>>>,
     /// Number of agents the old CP had, for migration readiness tracking.
@@ -74,7 +72,6 @@ impl AppState {
             attestation_recheck_seconds: env_u64("DD_CP_ATTESTATION_RECHECK_SECONDS", 3600),
             agent_health_path: env("DD_CP_AGENT_HEALTH_PATH", "/health"),
             agent_attestation_path: env("DD_CP_AGENT_ATTESTATION_PATH", "/attestation"),
-            cp_mode: env("DD_CP_MODE", "portable"),
             proxy_target: Arc::new(RwLock::new(None)),
             expected_agent_count: Arc::new(RwLock::new(None)),
         }
@@ -101,7 +98,6 @@ impl AppState {
             attestation_recheck_seconds: 3600,
             agent_health_path: "/health".into(),
             agent_attestation_path: "/attestation".into(),
-            cp_mode: "portable".into(),
             proxy_target: Arc::new(RwLock::new(None)),
             expected_agent_count: Arc::new(RwLock::new(None)),
         }

--- a/control-plane/src/state.rs
+++ b/control-plane/src/state.rs
@@ -1,3 +1,5 @@
+use std::sync::{Arc, RwLock};
+
 use crate::db::Db;
 use crate::services::attestation::AttestationService;
 use crate::services::github_oidc::GithubOidcService;
@@ -26,6 +28,12 @@ pub struct AppState {
     pub attestation_recheck_seconds: u64,
     pub agent_health_path: String,
     pub agent_attestation_path: String,
+    /// "bootstrap" or "portable".
+    pub cp_mode: String,
+    /// When set, the CP proxies all requests to this URL for zero-downtime migration.
+    pub proxy_target: Arc<RwLock<Option<String>>>,
+    /// Number of agents the old CP had, for migration readiness tracking.
+    pub expected_agent_count: Arc<RwLock<Option<usize>>>,
 }
 
 impl AppState {
@@ -66,6 +74,9 @@ impl AppState {
             attestation_recheck_seconds: env_u64("DD_CP_ATTESTATION_RECHECK_SECONDS", 3600),
             agent_health_path: env("DD_CP_AGENT_HEALTH_PATH", "/health"),
             agent_attestation_path: env("DD_CP_AGENT_ATTESTATION_PATH", "/attestation"),
+            cp_mode: env("DD_CP_MODE", "portable"),
+            proxy_target: Arc::new(RwLock::new(None)),
+            expected_agent_count: Arc::new(RwLock::new(None)),
         }
     }
 
@@ -90,6 +101,9 @@ impl AppState {
             attestation_recheck_seconds: 3600,
             agent_health_path: "/health".into(),
             agent_attestation_path: "/attestation".into(),
+            cp_mode: "portable".into(),
+            proxy_target: Arc::new(RwLock::new(None)),
+            expected_agent_count: Arc::new(RwLock::new(None)),
         }
     }
 }


### PR DESCRIPTION
## Summary

- Any CP instance can now deploy another CP as a container workload on any agent, export/import its state, and migrate to a new node with zero downtime
- Agents automatically reattach to a new CP when their heartbeat returns 404, reporting running deployments so state flows naturally
- Old CP can proxy all traffic to the new CP during DNS/tunnel convergence for seamless cutover

## Design

Every CP is equal — no special modes. Migration flow:

1. **Deploy new CP**: `POST /api/v1/admin/migration/deploy-cp` deploys a CP container on an agent with seed config (accounts, settings, trusted MRTDs) baked in as env vars
2. **Start proxy**: `POST /api/v1/admin/migration/proxy/start` makes old CP forward all traffic to the new one (migration admin endpoints excluded)
3. **Agents reattach**: agents heartbeat the new CP, get 404, call `POST /api/v1/agents/reattach` with their running deployments
4. **Check readiness**: `GET /api/v1/admin/migration/readiness` reports how many agents have reconnected
5. **Stop old CP**: once all agents are over, shut down the old instance

Two export modes: **seed** (lightweight: accounts, settings, trusted_mrtds, apps — agents rediscover naturally) and **full** (instant cutover with all agent/deployment state).

## New API endpoints

| Method | Path | Purpose |
|--------|------|---------|
| GET | `/api/v1/admin/migration/status` | Migration status |
| GET | `/api/v1/admin/migration/readiness` | Agent re-registration progress |
| POST | `/api/v1/admin/migration/export/seed` | Export seed config |
| POST | `/api/v1/admin/migration/export/full` | Export full state bundle |
| POST | `/api/v1/admin/migration/import/seed` | Import seed config |
| POST | `/api/v1/admin/migration/import/full` | Import full state bundle |
| POST | `/api/v1/admin/migration/deploy-cp` | Deploy CP on an agent |
| POST | `/api/v1/admin/migration/proxy/start` | Start proxying to new CP |
| POST | `/api/v1/admin/migration/proxy/stop` | Stop proxying |
| POST | `/api/v1/agents/reattach` | Agent re-registration |

## Test plan

- [x] 67 tests passing (60 control-plane, 5 agent, 2 agent config)
- [x] Clippy clean with `-Dwarnings`
- [x] `cargo fmt --check` passes
- [ ] Deploy to staging and test seed export → deploy-cp → agent reattach flow
- [ ] Test proxy start/stop with live traffic