### PR TITLE
Implement GET /api/v1/apps endpoint

### DIFF
--- a/control-plane/src/routes/apps.rs
+++ b/control-plane/src/routes/apps.rs
@@ -1,0 +1,14 @@
+use axum::extract::State;
+use axum::Json;
+
+use crate::common::error::AppError;
+use crate::state::AppState;
+use crate::stores::app as app_store;
+
+/// GET /api/v1/apps
+pub async fn list_apps(
+    State(state): State<AppState>,
+) -> Result<Json<Vec<app_store::AppRow>>, AppError> {
+    let apps = app_store::list_apps(&state.db)?;
+    Ok(Json(apps))
+}

--- a/control-plane/src/routes/mod.rs
+++ b/control-plane/src/routes/mod.rs
@@ -1,6 +1,7 @@
 pub mod accounts;
 pub mod admin;
 pub mod agents;
+pub mod apps;
 pub mod auth;
 pub mod deploy;
 pub mod health;
@@ -22,6 +23,8 @@ pub fn build_router(state: AppState) -> Router {
         // Agent challenge & registration
         .route("/api/v1/agents/challenge", get(agents::agent_challenge))
         .route("/api/v1/agents/register", post(agents::agent_register))
+        // Apps
+        .route("/api/v1/apps", get(apps::list_apps))
         // Agent CRUD
         .route("/api/v1/agents", get(agents::list_agents))
         .route("/api/v1/agents/{id}", get(agents::get_agent))

--- a/control-plane/src/stores/app.rs
+++ b/control-plane/src/stores/app.rs
@@ -1,0 +1,84 @@
+use serde::{Deserialize, Serialize};
+
+use crate::common::error::{AppError, AppResult};
+use crate::db::Db;
+
+/// App record as stored in the database.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AppRow {
+    pub id: String,
+    pub name: String,
+    pub description: Option<String>,
+    pub created_at: String,
+}
+
+fn row_to_app(row: &rusqlite::Row<'_>) -> rusqlite::Result<AppRow> {
+    Ok(AppRow {
+        id: row.get("id")?,
+        name: row.get("name")?,
+        description: row.get("description")?,
+        created_at: row.get("created_at")?,
+    })
+}
+
+/// List all apps.
+pub fn list_apps(db: &Db) -> AppResult<Vec<AppRow>> {
+    let conn = db.lock().unwrap();
+    let mut stmt = conn
+        .prepare("SELECT id, name, description, created_at FROM apps ORDER BY created_at DESC")
+        .map_err(|_| AppError::Internal)?;
+
+    let rows = stmt
+        .query_map([], row_to_app)
+        .map_err(|_| AppError::Internal)?;
+
+    let mut apps = Vec::new();
+    for row in rows {
+        apps.push(row.map_err(|_| AppError::Internal)?);
+    }
+    Ok(apps)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db;
+    use rusqlite::params;
+
+    fn setup_db() -> Db {
+        db::connect_and_migrate("sqlite://:memory:").unwrap()
+    }
+
+    #[test]
+    fn list_apps_empty() {
+        let db = setup_db();
+        let apps = list_apps(&db).unwrap();
+        assert!(apps.is_empty());
+    }
+
+    #[test]
+    fn list_apps_returns_inserted() {
+        let db = setup_db();
+        {
+            let conn = db.lock().unwrap();
+            conn.execute(
+                "INSERT INTO apps (id, name, description, created_at) VALUES (?1, ?2, ?3, ?4)",
+                params!["app-1", "my-app", "A test app", "2025-01-01T00:00:00Z"],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO apps (id, name, description, created_at) VALUES (?1, ?2, ?3, ?4)",
+                params!["app-2", "other-app", None::<String>, "2025-01-02T00:00:00Z"],
+            )
+            .unwrap();
+        }
+
+        let apps = list_apps(&db).unwrap();
+        assert_eq!(apps.len(), 2);
+        // Ordered by created_at DESC
+        assert_eq!(apps[0].name, "other-app");
+        assert_eq!(apps[1].name, "my-app");
+        assert!(apps[0].description.is_none());
+        assert_eq!(apps[1].description.as_deref(), Some("A test app"));
+    }
+}

--- a/control-plane/src/stores/mod.rs
+++ b/control-plane/src/stores/mod.rs
@@ -1,5 +1,6 @@
 pub mod account;
 pub mod agent;
+pub mod app;
 pub mod deployment;
 pub mod health;
 pub mod session;


### PR DESCRIPTION
Add the missing apps list endpoint that was documented in the UI but
not implemented. Creates app store (with tests) and route handler
following the existing agent/deployment patterns.

https://claude.ai/code/session_016sNWmVVd7nrjfEFxyQQXcC