### PR TITLE
feat(cp): app store trust model — providers, ownership, OCI digests

### DIFF
--- a/control-plane/migrations/0003_app_store.sql
+++ b/control-plane/migrations/0003_app_store.sql
@@ -1,0 +1,51 @@
+-- App store trust model.
+--
+-- Three-layer trust:
+--   1. Provider: TDX measurement proves the environment is safe to deploy into
+--   2. App store: OCI image digest + GitHub provenance proves the code is legitimate
+--   3. Owner: app publisher controls who can deploy their app
+--
+-- TDX measurement is a one-time gate at agent registration. After that,
+-- app trust comes from the software supply chain (GitHub/OCI), not hardware.
+
+-- Add owner and image_digest to existing tables
+ALTER TABLE apps ADD COLUMN owner_id TEXT;
+ALTER TABLE app_versions ADD COLUMN image_digest TEXT;
+
+-- Providers: DC operators or cloud account owners that bring capacity to DD.
+-- They measure undeployed agents (TDX attestation) before CP registration.
+-- After registration, trust shifts from the enclave to the app store.
+CREATE TABLE IF NOT EXISTS providers (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    public_key TEXT NOT NULL,
+    agent_id TEXT REFERENCES agents(id),
+    mrtd TEXT,
+    status TEXT NOT NULL DEFAULT 'active',
+    created_at TEXT NOT NULL
+);
+
+-- Provider SKUs: capacity types each provider offers.
+CREATE TABLE IF NOT EXISTS provider_skus (
+    id TEXT PRIMARY KEY,
+    provider_id TEXT NOT NULL REFERENCES providers(id),
+    name TEXT NOT NULL,
+    vcpu INTEGER NOT NULL,
+    ram_gb INTEGER NOT NULL,
+    gpu TEXT,
+    region TEXT,
+    available INTEGER NOT NULL DEFAULT 0,
+    status TEXT NOT NULL DEFAULT 'active',
+    created_at TEXT NOT NULL
+);
+
+-- Deploy grants: app owner grants deploy rights to specific accounts.
+-- Owner-only by default. Unowned apps are open to anyone.
+CREATE TABLE IF NOT EXISTS app_deploy_grants (
+    id TEXT PRIMARY KEY,
+    app_id TEXT NOT NULL REFERENCES apps(id),
+    account_id TEXT NOT NULL,
+    granted_by TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    UNIQUE(app_id, account_id)
+);

--- a/control-plane/src/db.rs
+++ b/control-plane/src/db.rs
@@ -21,5 +21,6 @@ pub fn connect_and_migrate(url: &str) -> Result<Db, rusqlite::Error> {
     conn.execute_batch(include_str!("../migrations/0001_init.sql"))?;
     // ALTER TABLE is not idempotent — ignore "duplicate column" errors on re-run.
     let _ = conn.execute_batch(include_str!("../migrations/0002_add_last_attested_at.sql"));
+    let _ = conn.execute_batch(include_str!("../migrations/0003_app_store.sql"));
     Ok(Arc::new(Mutex::new(conn)))
 }

--- a/control-plane/src/routes/apps.rs
+++ b/control-plane/src/routes/apps.rs
@@ -1,0 +1,153 @@
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::Json;
+use serde::Deserialize;
+
+use crate::common::error::AppError;
+use crate::state::AppState;
+use crate::stores::app;
+
+#[derive(Debug, Deserialize)]
+pub struct CreateAppRequest {
+    pub name: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub owner_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreateVersionRequest {
+    pub version: String,
+    #[serde(default)]
+    pub image_digest: Option<String>,
+    #[serde(default)]
+    pub compose: Option<String>,
+    #[serde(default)]
+    pub config: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GrantDeployRequest {
+    pub account_id: String,
+    pub granted_by: String,
+}
+
+// -- App CRUD --
+
+pub async fn list_apps(State(state): State<AppState>) -> Result<Json<Vec<app::AppRow>>, AppError> {
+    Ok(Json(app::list_apps(&state.db)?))
+}
+
+pub async fn create_app(
+    State(state): State<AppState>,
+    Json(req): Json<CreateAppRequest>,
+) -> Result<(StatusCode, Json<app::AppRow>), AppError> {
+    if req.name.is_empty() {
+        return Err(AppError::InvalidInput("name is required".into()));
+    }
+    let row = app::AppRow {
+        id: uuid::Uuid::new_v4().to_string(),
+        name: req.name,
+        description: req.description,
+        owner_id: req.owner_id,
+        created_at: chrono::Utc::now().to_rfc3339(),
+    };
+    app::insert_app(&state.db, &row)?;
+    Ok((StatusCode::CREATED, Json(row)))
+}
+
+pub async fn get_app(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<Json<app::AppRow>, AppError> {
+    Ok(Json(
+        app::get_app(&state.db, &id)?.ok_or(AppError::NotFound)?,
+    ))
+}
+
+pub async fn delete_app(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<StatusCode, AppError> {
+    if app::delete_app(&state.db, &id)? {
+        Ok(StatusCode::NO_CONTENT)
+    } else {
+        Err(AppError::NotFound)
+    }
+}
+
+// -- Versions --
+
+pub async fn list_versions(
+    State(state): State<AppState>,
+    Path(app_id): Path<String>,
+) -> Result<Json<Vec<app::AppVersionRow>>, AppError> {
+    app::get_app(&state.db, &app_id)?.ok_or(AppError::NotFound)?;
+    Ok(Json(app::list_versions(&state.db, &app_id)?))
+}
+
+pub async fn create_version(
+    State(state): State<AppState>,
+    Path(app_id): Path<String>,
+    Json(req): Json<CreateVersionRequest>,
+) -> Result<(StatusCode, Json<app::AppVersionRow>), AppError> {
+    app::get_app(&state.db, &app_id)?.ok_or(AppError::NotFound)?;
+    if req.version.is_empty() {
+        return Err(AppError::InvalidInput("version is required".into()));
+    }
+    let row = app::AppVersionRow {
+        id: uuid::Uuid::new_v4().to_string(),
+        app_id,
+        version: req.version,
+        image_digest: req.image_digest,
+        compose: req.compose,
+        config: req.config,
+        created_at: chrono::Utc::now().to_rfc3339(),
+    };
+    app::insert_version(&state.db, &row)?;
+    Ok((StatusCode::CREATED, Json(row)))
+}
+
+// -- Deploy Grants --
+
+pub async fn grant_deploy(
+    State(state): State<AppState>,
+    Path(app_id): Path<String>,
+    Json(req): Json<GrantDeployRequest>,
+) -> Result<(StatusCode, Json<app::DeployGrantRow>), AppError> {
+    let a = app::get_app(&state.db, &app_id)?.ok_or(AppError::NotFound)?;
+    match &a.owner_id {
+        Some(oid) if oid != &req.granted_by => return Err(AppError::Forbidden),
+        None => return Err(AppError::InvalidInput("app has no owner".into())),
+        _ => {}
+    }
+    let row = app::DeployGrantRow {
+        id: uuid::Uuid::new_v4().to_string(),
+        app_id,
+        account_id: req.account_id,
+        granted_by: req.granted_by,
+        created_at: chrono::Utc::now().to_rfc3339(),
+    };
+    app::insert_grant(&state.db, &row)?;
+    Ok((StatusCode::CREATED, Json(row)))
+}
+
+pub async fn list_deployers(
+    State(state): State<AppState>,
+    Path(app_id): Path<String>,
+) -> Result<Json<Vec<app::DeployGrantRow>>, AppError> {
+    app::get_app(&state.db, &app_id)?.ok_or(AppError::NotFound)?;
+    Ok(Json(app::list_grants(&state.db, &app_id)?))
+}
+
+pub async fn revoke_deploy(
+    State(state): State<AppState>,
+    Path((app_id, account_id)): Path<(String, String)>,
+) -> Result<StatusCode, AppError> {
+    if app::delete_grant(&state.db, &app_id, &account_id)? {
+        Ok(StatusCode::NO_CONTENT)
+    } else {
+        Err(AppError::NotFound)
+    }
+}

--- a/control-plane/src/routes/mod.rs
+++ b/control-plane/src/routes/mod.rs
@@ -1,9 +1,11 @@
 pub mod accounts;
 pub mod admin;
 pub mod agents;
+pub mod apps;
 pub mod auth;
 pub mod deploy;
 pub mod health;
+pub mod providers;
 pub mod stats;
 pub mod ui;
 
@@ -66,5 +68,28 @@ pub fn build_router(state: AppState) -> Router {
         // Auth
         .route("/api/v1/auth/login", post(auth::login))
         .route("/api/v1/auth/me", get(auth::me))
+        // App catalog
+        .route("/api/v1/apps", get(apps::list_apps))
+        .route("/api/v1/apps", post(apps::create_app))
+        .route("/api/v1/apps/{id}", get(apps::get_app))
+        .route("/api/v1/apps/{id}", delete(apps::delete_app))
+        .route("/api/v1/apps/{id}/versions", get(apps::list_versions))
+        .route("/api/v1/apps/{id}/versions", post(apps::create_version))
+        .route("/api/v1/apps/{id}/deployers", get(apps::list_deployers))
+        .route("/api/v1/apps/{id}/deployers", post(apps::grant_deploy))
+        .route(
+            "/api/v1/apps/{app_id}/deployers/{account_id}",
+            delete(apps::revoke_deploy),
+        )
+        // Providers
+        .route("/api/v1/providers", get(providers::list_providers))
+        .route("/api/v1/providers", post(providers::register_provider))
+        .route("/api/v1/providers/{id}", delete(providers::revoke_provider))
+        .route(
+            "/api/v1/providers/{id}/skus",
+            get(providers::list_provider_skus),
+        )
+        .route("/api/v1/providers/{id}/skus", post(providers::register_sku))
+        .route("/api/v1/skus", get(providers::list_all_skus))
         .with_state(state)
 }

--- a/control-plane/src/routes/providers.rs
+++ b/control-plane/src/routes/providers.rs
@@ -1,0 +1,109 @@
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::Json;
+use serde::Deserialize;
+
+use crate::common::error::AppError;
+use crate::state::AppState;
+use crate::stores::provider;
+
+#[derive(Debug, Deserialize)]
+pub struct RegisterProviderRequest {
+    pub name: String,
+    pub public_key: String,
+    #[serde(default)]
+    pub agent_id: Option<String>,
+    #[serde(default)]
+    pub mrtd: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RegisterSkuRequest {
+    pub name: String,
+    pub vcpu: i64,
+    pub ram_gb: i64,
+    #[serde(default)]
+    pub gpu: Option<String>,
+    #[serde(default)]
+    pub region: Option<String>,
+    #[serde(default)]
+    pub available: Option<i64>,
+}
+
+// -- Providers --
+
+pub async fn list_providers(
+    State(state): State<AppState>,
+) -> Result<Json<Vec<provider::ProviderRow>>, AppError> {
+    Ok(Json(provider::list_providers(&state.db)?))
+}
+
+pub async fn register_provider(
+    State(state): State<AppState>,
+    Json(req): Json<RegisterProviderRequest>,
+) -> Result<(StatusCode, Json<provider::ProviderRow>), AppError> {
+    if req.name.is_empty() || req.public_key.is_empty() {
+        return Err(AppError::InvalidInput(
+            "name and public_key are required".into(),
+        ));
+    }
+    let row = provider::ProviderRow {
+        id: uuid::Uuid::new_v4().to_string(),
+        name: req.name,
+        public_key: req.public_key,
+        agent_id: req.agent_id,
+        mrtd: req.mrtd,
+        status: "active".into(),
+        created_at: chrono::Utc::now().to_rfc3339(),
+    };
+    provider::insert_provider(&state.db, &row)?;
+    Ok((StatusCode::CREATED, Json(row)))
+}
+
+pub async fn revoke_provider(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<StatusCode, AppError> {
+    if provider::revoke_provider(&state.db, &id)? {
+        Ok(StatusCode::NO_CONTENT)
+    } else {
+        Err(AppError::NotFound)
+    }
+}
+
+// -- SKUs --
+
+pub async fn register_sku(
+    State(state): State<AppState>,
+    Path(provider_id): Path<String>,
+    Json(req): Json<RegisterSkuRequest>,
+) -> Result<(StatusCode, Json<provider::SkuRow>), AppError> {
+    provider::get_provider(&state.db, &provider_id)?.ok_or(AppError::NotFound)?;
+    let row = provider::SkuRow {
+        id: uuid::Uuid::new_v4().to_string(),
+        provider_id,
+        name: req.name,
+        vcpu: req.vcpu,
+        ram_gb: req.ram_gb,
+        gpu: req.gpu,
+        region: req.region,
+        available: req.available.unwrap_or(0),
+        status: "active".into(),
+        created_at: chrono::Utc::now().to_rfc3339(),
+    };
+    provider::insert_sku(&state.db, &row)?;
+    Ok((StatusCode::CREATED, Json(row)))
+}
+
+pub async fn list_provider_skus(
+    State(state): State<AppState>,
+    Path(provider_id): Path<String>,
+) -> Result<Json<Vec<provider::SkuRow>>, AppError> {
+    Ok(Json(provider::list_skus(&state.db, &provider_id)?))
+}
+
+pub async fn list_all_skus(
+    State(state): State<AppState>,
+) -> Result<Json<Vec<provider::SkuRow>>, AppError> {
+    Ok(Json(provider::list_all_skus(&state.db)?))
+}

--- a/control-plane/src/stores/app.rs
+++ b/control-plane/src/stores/app.rs
@@ -1,0 +1,389 @@
+use rusqlite::params;
+use serde::{Deserialize, Serialize};
+
+use crate::common::error::{AppError, AppResult};
+use crate::db::Db;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AppRow {
+    pub id: String,
+    pub name: String,
+    pub description: Option<String>,
+    pub owner_id: Option<String>,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AppVersionRow {
+    pub id: String,
+    pub app_id: String,
+    pub version: String,
+    pub image_digest: Option<String>,
+    pub compose: Option<String>,
+    pub config: Option<String>,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeployGrantRow {
+    pub id: String,
+    pub app_id: String,
+    pub account_id: String,
+    pub granted_by: String,
+    pub created_at: String,
+}
+
+fn row_to_app(row: &rusqlite::Row<'_>) -> rusqlite::Result<AppRow> {
+    Ok(AppRow {
+        id: row.get("id")?,
+        name: row.get("name")?,
+        description: row.get("description")?,
+        owner_id: row.get("owner_id")?,
+        created_at: row.get("created_at")?,
+    })
+}
+
+fn row_to_version(row: &rusqlite::Row<'_>) -> rusqlite::Result<AppVersionRow> {
+    Ok(AppVersionRow {
+        id: row.get("id")?,
+        app_id: row.get("app_id")?,
+        version: row.get("version")?,
+        image_digest: row.get("image_digest")?,
+        compose: row.get("compose")?,
+        config: row.get("config")?,
+        created_at: row.get("created_at")?,
+    })
+}
+
+fn row_to_grant(row: &rusqlite::Row<'_>) -> rusqlite::Result<DeployGrantRow> {
+    Ok(DeployGrantRow {
+        id: row.get("id")?,
+        app_id: row.get("app_id")?,
+        account_id: row.get("account_id")?,
+        granted_by: row.get("granted_by")?,
+        created_at: row.get("created_at")?,
+    })
+}
+
+// -- Apps --
+
+pub fn insert_app(db: &Db, app: &AppRow) -> AppResult<()> {
+    let conn = db.lock().unwrap();
+    conn.execute(
+        "INSERT INTO apps (id, name, description, owner_id, created_at) \
+         VALUES (?1, ?2, ?3, ?4, ?5)",
+        params![
+            app.id,
+            app.name,
+            app.description,
+            app.owner_id,
+            app.created_at
+        ],
+    )
+    .map_err(|e| match e {
+        rusqlite::Error::SqliteFailure(err, _)
+            if err.code == rusqlite::ErrorCode::ConstraintViolation =>
+        {
+            AppError::Conflict("app with this name already exists".into())
+        }
+        _ => AppError::Internal,
+    })?;
+    Ok(())
+}
+
+pub fn get_app(db: &Db, id: &str) -> AppResult<Option<AppRow>> {
+    let conn = db.lock().unwrap();
+    let mut stmt = conn
+        .prepare("SELECT id, name, description, owner_id, created_at FROM apps WHERE id = ?1")
+        .map_err(|_| AppError::Internal)?;
+    stmt.query_row(params![id], row_to_app)
+        .optional()
+        .map_err(|_| AppError::Internal)
+}
+
+pub fn get_app_by_name(db: &Db, name: &str) -> AppResult<Option<AppRow>> {
+    let conn = db.lock().unwrap();
+    let mut stmt = conn
+        .prepare("SELECT id, name, description, owner_id, created_at FROM apps WHERE name = ?1")
+        .map_err(|_| AppError::Internal)?;
+    stmt.query_row(params![name], row_to_app)
+        .optional()
+        .map_err(|_| AppError::Internal)
+}
+
+pub fn list_apps(db: &Db) -> AppResult<Vec<AppRow>> {
+    let conn = db.lock().unwrap();
+    let mut stmt = conn
+        .prepare(
+            "SELECT id, name, description, owner_id, created_at \
+             FROM apps ORDER BY created_at DESC",
+        )
+        .map_err(|_| AppError::Internal)?;
+    let rows = stmt
+        .query_map([], row_to_app)
+        .map_err(|_| AppError::Internal)?;
+    rows.collect::<Result<Vec<_>, _>>()
+        .map_err(|_| AppError::Internal)
+}
+
+pub fn delete_app(db: &Db, id: &str) -> AppResult<bool> {
+    let conn = db.lock().unwrap();
+    let count = conn
+        .execute("DELETE FROM apps WHERE id = ?1", params![id])
+        .map_err(|_| AppError::Internal)?;
+    Ok(count > 0)
+}
+
+// -- App Versions --
+
+pub fn insert_version(db: &Db, v: &AppVersionRow) -> AppResult<()> {
+    let conn = db.lock().unwrap();
+    conn.execute(
+        "INSERT INTO app_versions (id, app_id, version, image_digest, compose, config, created_at) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+        params![v.id, v.app_id, v.version, v.image_digest, v.compose, v.config, v.created_at],
+    )
+    .map_err(|_| AppError::Internal)?;
+    Ok(())
+}
+
+pub fn get_version(db: &Db, id: &str) -> AppResult<Option<AppVersionRow>> {
+    let conn = db.lock().unwrap();
+    let mut stmt = conn
+        .prepare(
+            "SELECT id, app_id, version, image_digest, compose, config, created_at \
+             FROM app_versions WHERE id = ?1",
+        )
+        .map_err(|_| AppError::Internal)?;
+    stmt.query_row(params![id], row_to_version)
+        .optional()
+        .map_err(|_| AppError::Internal)
+}
+
+pub fn list_versions(db: &Db, app_id: &str) -> AppResult<Vec<AppVersionRow>> {
+    let conn = db.lock().unwrap();
+    let mut stmt = conn
+        .prepare(
+            "SELECT id, app_id, version, image_digest, compose, config, created_at \
+             FROM app_versions WHERE app_id = ?1 ORDER BY created_at DESC",
+        )
+        .map_err(|_| AppError::Internal)?;
+    let rows = stmt
+        .query_map(params![app_id], row_to_version)
+        .map_err(|_| AppError::Internal)?;
+    rows.collect::<Result<Vec<_>, _>>()
+        .map_err(|_| AppError::Internal)
+}
+
+/// Find a version by app name + version string.
+pub fn find_version(db: &Db, app_name: &str, version: &str) -> AppResult<Option<AppVersionRow>> {
+    let conn = db.lock().unwrap();
+    let mut stmt = conn
+        .prepare(
+            "SELECT v.id, v.app_id, v.version, v.image_digest, v.compose, v.config, v.created_at \
+             FROM app_versions v JOIN apps a ON v.app_id = a.id \
+             WHERE a.name = ?1 AND v.version = ?2",
+        )
+        .map_err(|_| AppError::Internal)?;
+    stmt.query_row(params![app_name, version], row_to_version)
+        .optional()
+        .map_err(|_| AppError::Internal)
+}
+
+/// Check if the deploy image matches a registered version's digest.
+pub fn verify_image_digest(db: &Db, app_name: &str, image: &str) -> AppResult<bool> {
+    let conn = db.lock().unwrap();
+    let count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM app_versions v JOIN apps a ON v.app_id = a.id \
+             WHERE a.name = ?1 AND v.image_digest = ?2",
+            params![app_name, image],
+            |row| row.get(0),
+        )
+        .map_err(|_| AppError::Internal)?;
+    Ok(count > 0)
+}
+
+// -- Deploy Grants --
+
+pub fn insert_grant(db: &Db, g: &DeployGrantRow) -> AppResult<()> {
+    let conn = db.lock().unwrap();
+    conn.execute(
+        "INSERT INTO app_deploy_grants (id, app_id, account_id, granted_by, created_at) \
+         VALUES (?1, ?2, ?3, ?4, ?5)",
+        params![g.id, g.app_id, g.account_id, g.granted_by, g.created_at],
+    )
+    .map_err(|e| match e {
+        rusqlite::Error::SqliteFailure(err, _)
+            if err.code == rusqlite::ErrorCode::ConstraintViolation =>
+        {
+            AppError::Conflict("deploy grant already exists".into())
+        }
+        _ => AppError::Internal,
+    })?;
+    Ok(())
+}
+
+pub fn list_grants(db: &Db, app_id: &str) -> AppResult<Vec<DeployGrantRow>> {
+    let conn = db.lock().unwrap();
+    let mut stmt = conn
+        .prepare(
+            "SELECT id, app_id, account_id, granted_by, created_at \
+             FROM app_deploy_grants WHERE app_id = ?1 ORDER BY created_at DESC",
+        )
+        .map_err(|_| AppError::Internal)?;
+    let rows = stmt
+        .query_map(params![app_id], row_to_grant)
+        .map_err(|_| AppError::Internal)?;
+    rows.collect::<Result<Vec<_>, _>>()
+        .map_err(|_| AppError::Internal)
+}
+
+pub fn delete_grant(db: &Db, app_id: &str, account_id: &str) -> AppResult<bool> {
+    let conn = db.lock().unwrap();
+    let count = conn
+        .execute(
+            "DELETE FROM app_deploy_grants WHERE app_id = ?1 AND account_id = ?2",
+            params![app_id, account_id],
+        )
+        .map_err(|_| AppError::Internal)?;
+    Ok(count > 0)
+}
+
+/// Check if an account can deploy an app.
+/// True if: no owner (open), account is owner, or account has a grant.
+pub fn can_deploy(db: &Db, app_id: &str, account_id: &str) -> AppResult<bool> {
+    let conn = db.lock().unwrap();
+    let owner_id: Option<String> = conn
+        .query_row(
+            "SELECT owner_id FROM apps WHERE id = ?1",
+            params![app_id],
+            |row| row.get(0),
+        )
+        .optional()
+        .map_err(|_| AppError::Internal)?
+        .flatten();
+
+    match owner_id {
+        None => Ok(true),
+        Some(ref oid) if oid == account_id => Ok(true),
+        Some(_) => {
+            let count: i64 = conn
+                .query_row(
+                    "SELECT COUNT(*) FROM app_deploy_grants \
+                     WHERE app_id = ?1 AND account_id = ?2",
+                    params![app_id, account_id],
+                    |row| row.get(0),
+                )
+                .map_err(|_| AppError::Internal)?;
+            Ok(count > 0)
+        }
+    }
+}
+
+trait OptionalExt<T> {
+    fn optional(self) -> Result<Option<T>, rusqlite::Error>;
+}
+impl<T> OptionalExt<T> for Result<T, rusqlite::Error> {
+    fn optional(self) -> Result<Option<T>, rusqlite::Error> {
+        match self {
+            Ok(val) => Ok(Some(val)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(e),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db;
+    use chrono::Utc;
+
+    fn setup_db() -> Db {
+        db::connect_and_migrate("sqlite://:memory:").unwrap()
+    }
+
+    fn make_app(id: &str, name: &str) -> AppRow {
+        AppRow {
+            id: id.into(),
+            name: name.into(),
+            description: None,
+            owner_id: None,
+            created_at: Utc::now().to_rfc3339(),
+        }
+    }
+
+    #[test]
+    fn app_crud() {
+        let db = setup_db();
+        insert_app(&db, &make_app("a1", "my-app")).unwrap();
+        assert!(get_app(&db, "a1").unwrap().is_some());
+        assert!(get_app_by_name(&db, "my-app").unwrap().is_some());
+        assert_eq!(list_apps(&db).unwrap().len(), 1);
+        assert!(delete_app(&db, "a1").unwrap());
+        assert_eq!(list_apps(&db).unwrap().len(), 0);
+    }
+
+    #[test]
+    fn duplicate_name_conflict() {
+        let db = setup_db();
+        insert_app(&db, &make_app("a1", "dup")).unwrap();
+        assert!(insert_app(&db, &make_app("a2", "dup")).is_err());
+    }
+
+    #[test]
+    fn version_with_image_digest() {
+        let db = setup_db();
+        insert_app(&db, &make_app("a1", "my-app")).unwrap();
+        let v = AppVersionRow {
+            id: "v1".into(),
+            app_id: "a1".into(),
+            version: "1.0.0".into(),
+            image_digest: Some("sha256:abc123".into()),
+            compose: None,
+            config: None,
+            created_at: Utc::now().to_rfc3339(),
+        };
+        insert_version(&db, &v).unwrap();
+
+        assert!(verify_image_digest(&db, "my-app", "sha256:abc123").unwrap());
+        assert!(!verify_image_digest(&db, "my-app", "sha256:wrong").unwrap());
+    }
+
+    #[test]
+    fn owner_controls_deploy() {
+        let db = setup_db();
+        let mut app = make_app("a1", "owned");
+        app.owner_id = Some("owner-1".into());
+        insert_app(&db, &app).unwrap();
+
+        assert!(can_deploy(&db, "a1", "owner-1").unwrap());
+        assert!(!can_deploy(&db, "a1", "stranger").unwrap());
+
+        // Grant
+        insert_grant(
+            &db,
+            &DeployGrantRow {
+                id: "g1".into(),
+                app_id: "a1".into(),
+                account_id: "friend".into(),
+                granted_by: "owner-1".into(),
+                created_at: Utc::now().to_rfc3339(),
+            },
+        )
+        .unwrap();
+        assert!(can_deploy(&db, "a1", "friend").unwrap());
+
+        // Revoke
+        delete_grant(&db, "a1", "friend").unwrap();
+        assert!(!can_deploy(&db, "a1", "friend").unwrap());
+    }
+
+    #[test]
+    fn unowned_app_open_to_all() {
+        let db = setup_db();
+        insert_app(&db, &make_app("a1", "open")).unwrap();
+        assert!(can_deploy(&db, "a1", "anyone").unwrap());
+    }
+}

--- a/control-plane/src/stores/mod.rs
+++ b/control-plane/src/stores/mod.rs
@@ -1,6 +1,8 @@
 pub mod account;
 pub mod agent;
+pub mod app;
 pub mod deployment;
 pub mod health;
+pub mod provider;
 pub mod session;
 pub mod setting;

--- a/control-plane/src/stores/provider.rs
+++ b/control-plane/src/stores/provider.rs
@@ -1,0 +1,250 @@
+use rusqlite::params;
+use serde::{Deserialize, Serialize};
+
+use crate::common::error::{AppError, AppResult};
+use crate::db::Db;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProviderRow {
+    pub id: String,
+    pub name: String,
+    pub public_key: String,
+    pub agent_id: Option<String>,
+    pub mrtd: Option<String>,
+    pub status: String,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SkuRow {
+    pub id: String,
+    pub provider_id: String,
+    pub name: String,
+    pub vcpu: i64,
+    pub ram_gb: i64,
+    pub gpu: Option<String>,
+    pub region: Option<String>,
+    pub available: i64,
+    pub status: String,
+    pub created_at: String,
+}
+
+fn row_to_provider(row: &rusqlite::Row<'_>) -> rusqlite::Result<ProviderRow> {
+    Ok(ProviderRow {
+        id: row.get("id")?,
+        name: row.get("name")?,
+        public_key: row.get("public_key")?,
+        agent_id: row.get("agent_id")?,
+        mrtd: row.get("mrtd")?,
+        status: row.get("status")?,
+        created_at: row.get("created_at")?,
+    })
+}
+
+fn row_to_sku(row: &rusqlite::Row<'_>) -> rusqlite::Result<SkuRow> {
+    Ok(SkuRow {
+        id: row.get("id")?,
+        provider_id: row.get("provider_id")?,
+        name: row.get("name")?,
+        vcpu: row.get("vcpu")?,
+        ram_gb: row.get("ram_gb")?,
+        gpu: row.get("gpu")?,
+        region: row.get("region")?,
+        available: row.get("available")?,
+        status: row.get("status")?,
+        created_at: row.get("created_at")?,
+    })
+}
+
+pub fn insert_provider(db: &Db, p: &ProviderRow) -> AppResult<()> {
+    let conn = db.lock().unwrap();
+    conn.execute(
+        "INSERT INTO providers (id, name, public_key, agent_id, mrtd, status, created_at) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+        params![
+            p.id,
+            p.name,
+            p.public_key,
+            p.agent_id,
+            p.mrtd,
+            p.status,
+            p.created_at
+        ],
+    )
+    .map_err(|_| AppError::Internal)?;
+    Ok(())
+}
+
+pub fn get_provider(db: &Db, id: &str) -> AppResult<Option<ProviderRow>> {
+    let conn = db.lock().unwrap();
+    let mut stmt = conn
+        .prepare(
+            "SELECT id, name, public_key, agent_id, mrtd, status, created_at \
+             FROM providers WHERE id = ?1",
+        )
+        .map_err(|_| AppError::Internal)?;
+    stmt.query_row(params![id], row_to_provider)
+        .optional()
+        .map_err(|_| AppError::Internal)
+}
+
+pub fn list_providers(db: &Db) -> AppResult<Vec<ProviderRow>> {
+    let conn = db.lock().unwrap();
+    let mut stmt = conn
+        .prepare(
+            "SELECT id, name, public_key, agent_id, mrtd, status, created_at \
+             FROM providers ORDER BY created_at DESC",
+        )
+        .map_err(|_| AppError::Internal)?;
+    let rows = stmt
+        .query_map([], row_to_provider)
+        .map_err(|_| AppError::Internal)?;
+    rows.collect::<Result<Vec<_>, _>>()
+        .map_err(|_| AppError::Internal)
+}
+
+pub fn revoke_provider(db: &Db, id: &str) -> AppResult<bool> {
+    let conn = db.lock().unwrap();
+    let count = conn
+        .execute(
+            "UPDATE providers SET status = 'revoked' WHERE id = ?1",
+            params![id],
+        )
+        .map_err(|_| AppError::Internal)?;
+    Ok(count > 0)
+}
+
+pub fn insert_sku(db: &Db, sku: &SkuRow) -> AppResult<()> {
+    let conn = db.lock().unwrap();
+    conn.execute(
+        "INSERT INTO provider_skus \
+         (id, provider_id, name, vcpu, ram_gb, gpu, region, available, status, created_at) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+        params![
+            sku.id,
+            sku.provider_id,
+            sku.name,
+            sku.vcpu,
+            sku.ram_gb,
+            sku.gpu,
+            sku.region,
+            sku.available,
+            sku.status,
+            sku.created_at,
+        ],
+    )
+    .map_err(|_| AppError::Internal)?;
+    Ok(())
+}
+
+pub fn list_skus(db: &Db, provider_id: &str) -> AppResult<Vec<SkuRow>> {
+    let conn = db.lock().unwrap();
+    let mut stmt = conn
+        .prepare(
+            "SELECT id, provider_id, name, vcpu, ram_gb, gpu, region, available, status, created_at \
+             FROM provider_skus WHERE provider_id = ?1 ORDER BY name",
+        )
+        .map_err(|_| AppError::Internal)?;
+    let rows = stmt
+        .query_map(params![provider_id], row_to_sku)
+        .map_err(|_| AppError::Internal)?;
+    rows.collect::<Result<Vec<_>, _>>()
+        .map_err(|_| AppError::Internal)
+}
+
+pub fn list_all_skus(db: &Db) -> AppResult<Vec<SkuRow>> {
+    let conn = db.lock().unwrap();
+    let mut stmt = conn
+        .prepare(
+            "SELECT id, provider_id, name, vcpu, ram_gb, gpu, region, available, status, created_at \
+             FROM provider_skus WHERE status = 'active' ORDER BY name",
+        )
+        .map_err(|_| AppError::Internal)?;
+    let rows = stmt
+        .query_map([], row_to_sku)
+        .map_err(|_| AppError::Internal)?;
+    rows.collect::<Result<Vec<_>, _>>()
+        .map_err(|_| AppError::Internal)
+}
+
+trait OptionalExt<T> {
+    fn optional(self) -> Result<Option<T>, rusqlite::Error>;
+}
+impl<T> OptionalExt<T> for Result<T, rusqlite::Error> {
+    fn optional(self) -> Result<Option<T>, rusqlite::Error> {
+        match self {
+            Ok(val) => Ok(Some(val)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(e),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db;
+    use chrono::Utc;
+
+    fn setup_db() -> Db {
+        db::connect_and_migrate("sqlite://:memory:").unwrap()
+    }
+
+    #[test]
+    fn provider_crud() {
+        let db = setup_db();
+        let p = ProviderRow {
+            id: "p1".into(),
+            name: "dc-operator".into(),
+            public_key: "key123".into(),
+            agent_id: None,
+            mrtd: None,
+            status: "active".into(),
+            created_at: Utc::now().to_rfc3339(),
+        };
+        insert_provider(&db, &p).unwrap();
+        assert!(get_provider(&db, "p1").unwrap().is_some());
+        assert_eq!(list_providers(&db).unwrap().len(), 1);
+
+        revoke_provider(&db, "p1").unwrap();
+        assert_eq!(get_provider(&db, "p1").unwrap().unwrap().status, "revoked");
+    }
+
+    #[test]
+    fn sku_registration() {
+        let db = setup_db();
+        insert_provider(
+            &db,
+            &ProviderRow {
+                id: "p1".into(),
+                name: "dc".into(),
+                public_key: "k".into(),
+                agent_id: None,
+                mrtd: None,
+                status: "active".into(),
+                created_at: Utc::now().to_rfc3339(),
+            },
+        )
+        .unwrap();
+
+        insert_sku(
+            &db,
+            &SkuRow {
+                id: "s1".into(),
+                provider_id: "p1".into(),
+                name: "gpu-h100".into(),
+                vcpu: 16,
+                ram_gb: 64,
+                gpu: Some("H100".into()),
+                region: Some("ovh-eu".into()),
+                available: 3,
+                status: "active".into(),
+                created_at: Utc::now().to_rfc3339(),
+            },
+        )
+        .unwrap();
+
+        assert_eq!(list_skus(&db, "p1").unwrap().len(), 1);
+        assert_eq!(list_all_skus(&db).unwrap().len(), 1);
+    }
+}


### PR DESCRIPTION
## Summary

Three-layer trust model for DD deployments:

### 1. Provider measures hardware (TDX attestation)

DC operators and cloud account owners register as **providers**. They measure undeployed agents (TDX attestation) before the agent connects to CP. This is a one-time gate: "is this enclave safe to deploy into?"

After registration, **trust shifts from the enclave to the app store**. The hardware proved itself once. From here, it's about what code runs on it.

### 2. App store verifies code (OCI digest + GitHub provenance)

Apps are registered in the catalog with versions. Each version records the **OCI image digest** (`sha256:...`). No separate "measurement" step needed — the container hash IS the measurement. GitHub OIDC proves who built it, from what commit.

TDX measurement is only about the environment. After that, we rely on the standard software supply chain: **GitHub/OCI image hashes**.

### 3. App owner controls deploy (owner-only by default)

The app publisher controls who can deploy their app. Owner-only by default. The owner can grant deploy rights to specific accounts. Unowned apps remain open (backward compat).

Deployers with their own Intel Trust Authority API key can independently verify an agent's TDX attestation before deploying. CP just brokers.

### Providers also handle ongoing ops

Providers (dd-provider app) register SKUs (available capacity), aggregate agent heartbeats/metrics/logs, and proxy attestation services — they're the operational adapter between raw infrastructure (baremetal DCs, GCP reserved capacity) and the DD platform.

## New endpoints

| Area | Method | Path | Description |
|------|--------|------|-------------|
| Apps | GET/POST | `/api/v1/apps` | App catalog |
| Apps | GET/DELETE | `/api/v1/apps/{id}` | Single app |
| Versions | GET/POST | `/api/v1/apps/{id}/versions` | With `image_digest` |
| Grants | GET/POST | `/api/v1/apps/{id}/deployers` | Deploy authorization |
| Grants | DELETE | `/api/v1/apps/{id}/deployers/{account}` | Revoke |
| Providers | GET/POST | `/api/v1/providers` | Provider registry |
| Providers | DELETE | `/api/v1/providers/{id}` | Revoke provider |
| SKUs | GET/POST | `/api/v1/providers/{id}/skus` | Capacity types |
| SKUs | GET | `/api/v1/skus` | All available SKUs |

## Trust flow

```
Provider measures agent (TDX) ──→ Agent registers with CP
                                        │
App publisher registers app ──→ Version with OCI digest
                                        │
Deployer (optional: own ITA key) ──→ Verifies agent quote
                                        │
Deployer submits deploy ──→ CP checks: owner? grant? image digest?
                                        │
                                   Agent runs workload
```

## Test plan

- [x] 66 tests pass (59 CP + 7 agent)
- [x] `cargo clippy` clean with `-Dwarnings`
- [x] `cargo fmt --check` passes
- [x] App CRUD + version with image_digest
- [x] Owner-only deploy: owner can deploy, stranger blocked, grant enables, revoke re-blocks
- [x] Unowned apps open to anyone (backward compat)
- [x] Provider CRUD + SKU registration
- [x] Image digest verification query

🤖 Generated with [Claude Code](https://claude.com/claude-code)