### PR TITLE
fix(cp): agent hostnames unreachable after redeploy + staging deploys on PRs

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -1,8 +1,8 @@
 name: Staging Deploy
 
 on:
-  push:
-    branches: [main, staging]
+  pull_request:
+    branches: [main]
     paths:
       - "agent/**"
       - "control-plane/**"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,23 +156,32 @@ Landing page for devopsdefender.com, deployed via GitHub Pages.
 ### Working on Changes
 
 1. **Always work on a feature branch.** Create a branch from `main` (e.g., `feat/my-change`, `fix/bug-description`).
-2. **Push your feature branch** and open a PR targeting `main`.
-3. **Wait for board approval** before merging. Never merge your own PR without an approving review.
+2. **Run checks before committing:** `cargo fmt --check`, `cargo clippy --all-targets`, `cargo test` (with `RUSTFLAGS="-Dwarnings"`). Fix any issues before pushing.
+3. **Push your feature branch** and open a PR targeting `main`.
+4. **Wait for board approval** before merging. Never merge your own PR without an approving review.
+
+### Pull Request Standards
+
+PRs must be written for a human reviewer, not a machine. Follow these rules:
+
+- **Title:** Describe the user-visible change, not the implementation. "Agent hostnames stop resolving after redeploy" not "add hostname check to stale cleanup loop".
+- **Body:** Problem → root cause → fix → how to verify. No jargon. A board member who doesn't write Rust should understand the PR.
+- **One logical change per PR.** Don't mix unrelated fixes. If a PR has both a bug fix and a feature, split them.
+- **Squash into one commit** unless commits represent genuinely separate logical steps (e.g., refactor then feature).
+- **Always lint and test before pushing.** CI will catch it, but don't waste reviewer time on clippy failures.
 
 ### Testing in Staging
 
-- The **`staging` branch** auto-deploys to the staging environment (`app-staging.devopsdefender.com`).
-- You can freely push to `staging` to test changes without approval.
-- To test: merge or push your feature branch into `staging`. This triggers the staging deploy pipeline.
-- The `staging` branch can be force-pushed or reset as needed — it is not protected.
+- **PRs targeting `main`** automatically deploy to staging (`app-staging.devopsdefender.com`).
+- Every PR gets a full staging integration test (build, deploy, smoke check, hello-world deploy) before review.
+- You can also trigger a staging deploy manually via `gh workflow run staging-deploy.yml`.
 
 ### Summary
 
 | Branch    | Protection | Deploys to  | Approval Required |
 |-----------|-----------|-------------|-------------------|
-| `main`    | Yes       | Production-ready | Yes — board review required |
-| `staging` | No        | Staging     | No — free to test |
-| Feature   | No        | —           | No — work freely  |
+| `main`    | Yes       | Production  | Yes — board review required |
+| Feature   | No        | Staging (via PR) | No — work freely  |
 
 ## Build & Development
 
@@ -223,7 +232,7 @@ cargo run --bin dd-admin -- hash-password
 
 All infrastructure is managed through GitHub Actions. **Never SSH into hosts, run Ansible locally, or attempt manual fixes on VMs.** If staging or production is down, trigger the appropriate GitHub Actions workflow.
 
-**Staging** (`staging-deploy.yml`) — auto-deploys on push to `main` or `staging`. Pipeline: build → bake GCP agent image → cleanup old VMs → deploy via Ansible → smoke check `app-staging.devopsdefender.com/health`.
+**Staging** (`staging-deploy.yml`) — runs on PRs targeting `main` (and manual dispatch). Pipeline: build → bake GCP agent image → cleanup old VMs → deploy via Ansible → smoke check `app-staging.devopsdefender.com/health` → hello-world integration test.
 
 **Production** (`production-deploy.yml`) — auto-deploys on push to `main`, also supports manual trigger (`workflow_dispatch`). Same pipeline as staging, uses `dd-agent-prod` image family.
 

--- a/control-plane/src/bin/dd-cp/main.rs
+++ b/control-plane/src/bin/dd-cp/main.rs
@@ -105,8 +105,28 @@ async fn main() {
                                 agent.id
                             );
                         }
+                        // Only delete the DNS record if no other active agent
+                        // shares the same hostname. When a VM is replaced, the
+                        // new agent inherits the hostname and we must not nuke
+                        // its DNS record while cleaning up the old one.
                         if let Some(ref hostname) = agent.hostname {
-                            if let Err(e) = cleanup_tunnel_svc.delete_dns_record(hostname).await {
+                            let hostname_in_use = agent_store::list_agents(&cleanup_db)
+                                .map(|agents| {
+                                    agents.iter().any(|a| {
+                                        a.id != agent.id
+                                            && a.hostname.as_deref() == Some(hostname.as_str())
+                                    })
+                                })
+                                .unwrap_or(false);
+
+                            if hostname_in_use {
+                                eprintln!(
+                                    "dd-cp: skipping DNS cleanup for {} -- hostname {} still in use by another agent",
+                                    agent.id, hostname
+                                );
+                            } else if let Err(e) =
+                                cleanup_tunnel_svc.delete_dns_record(hostname).await
+                            {
                                 eprintln!(
                                     "dd-cp: warning: DNS cleanup for stale agent {} failed: {e}",
                                     agent.id

--- a/control-plane/src/services/tunnel.rs
+++ b/control-plane/src/services/tunnel.rs
@@ -116,11 +116,15 @@ impl TunnelService {
         let hostname = format!("{vm_name}.{}", self.domain);
 
         // Configure tunnel ingress to route to agent's default port
+        eprintln!("dd-cp: tunnel {tunnel_name}: configuring ingress for {hostname}");
         self.configure_tunnel_ingress(&tunnel_id, &hostname, "http://localhost:8080")
             .await?;
+        eprintln!("dd-cp: tunnel {tunnel_name}: ingress configured");
 
         // Create DNS record
+        eprintln!("dd-cp: tunnel {tunnel_name}: creating DNS CNAME for {hostname}");
         self.create_dns_record(&tunnel_id, &hostname).await?;
+        eprintln!("dd-cp: tunnel {tunnel_name}: DNS CNAME created");
 
         Ok(TunnelInfo {
             tunnel_id,
@@ -333,12 +337,15 @@ impl TunnelService {
         let tunnel_content = format!("{tunnel_id}.cfargotunnel.com");
         let client = reqwest::Client::new();
 
+        eprintln!("dd-cp: DNS: creating CNAME {hostname} -> {tunnel_content} (zone_id={zone_id})");
+
         // Check if a CNAME record already exists for this hostname.
         let existing_id = self
             .find_dns_record_id(&client, api_token, zone_id, hostname)
             .await?;
 
-        if let Some(record_id) = existing_id {
+        if let Some(ref record_id) = existing_id {
+            eprintln!("dd-cp: DNS: found existing record {record_id}, updating");
             // Update the existing record to point to the new tunnel.
             let resp = client
                 .put(format!(
@@ -355,11 +362,14 @@ impl TunnelService {
                 .await
                 .map_err(|e| AppError::External(format!("CF DNS update failed: {e}")))?;
 
-            if !resp.status().is_success() {
-                let body = resp.text().await.unwrap_or_default();
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            eprintln!("dd-cp: DNS: update response {status}: {body}");
+            if !status.is_success() {
                 return Err(AppError::External(format!("CF DNS update failed: {body}")));
             }
         } else {
+            eprintln!("dd-cp: DNS: no existing record, creating new CNAME");
             // Create a new record.
             let resp = client
                 .post(format!(
@@ -376,8 +386,10 @@ impl TunnelService {
                 .await
                 .map_err(|e| AppError::External(format!("CF DNS create failed: {e}")))?;
 
-            if !resp.status().is_success() {
-                let body = resp.text().await.unwrap_or_default();
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            eprintln!("dd-cp: DNS: create response {status}: {body}");
+            if !status.is_success() {
                 return Err(AppError::External(format!("CF DNS create failed: {body}")));
             }
         }
@@ -432,16 +444,20 @@ impl TunnelService {
         zone_id: &str,
         hostname: &str,
     ) -> AppResult<Option<String>> {
+        let url = format!(
+            "https://api.cloudflare.com/client/v4/zones/{zone_id}/dns_records?type=CNAME&name={hostname}"
+        );
         let resp = client
-            .get(format!(
-                "https://api.cloudflare.com/client/v4/zones/{zone_id}/dns_records?type=CNAME&name={hostname}"
-            ))
+            .get(&url)
             .header("Authorization", format!("Bearer {api_token}"))
             .send()
             .await
             .map_err(|e| AppError::External(format!("CF DNS lookup failed: {e}")))?;
 
-        if !resp.status().is_success() {
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            eprintln!("dd-cp: DNS lookup failed (HTTP {status}): {body}");
             // Non-fatal: if lookup fails, fall through to create.
             return Ok(None);
         }
@@ -451,11 +467,18 @@ impl TunnelService {
             .await
             .map_err(|e| AppError::External(format!("CF DNS lookup parse: {e}")))?;
 
-        Ok(body["result"]
+        let result = body["result"]
             .as_array()
             .and_then(|arr| arr.first())
             .and_then(|rec| rec["id"].as_str())
-            .map(|s| s.to_string()))
+            .map(|s| s.to_string());
+
+        eprintln!(
+            "dd-cp: DNS lookup for {hostname}: found={}",
+            result.is_some()
+        );
+
+        Ok(result)
     }
 
     /// Configure tunnel ingress rules via the Cloudflare API.


### PR DESCRIPTION
## Problem

Agent tunnel hostnames (e.g. dd-agent-staging.devopsdefender.com) become unreachable after redeploying, even though the tunnel is connected and the container is running. Also, staging was only tested after merge -- PRs had no staging integration test.

## Root cause

When an agent is replaced, the new one registers with the same hostname. The stale agent cleanup then deletes the DNS record by hostname, nuking the record the new agent is using.

## Changes

1. **DNS fix:** Before deleting a DNS record during stale cleanup, check if another active agent still uses that hostname. Skip deletion if so.
2. **Staging on PRs:** Changed staging deploy to trigger on PRs targeting main (removed the staging branch trigger). Every PR now gets a full staging deploy + integration test before review.
3. **Logging:** Added logging to the DNS creation path so CF API issues show up in CP logs.
4. **CLAUDE.md:** Added PR quality standards and updated staging workflow docs.

## How to verify

- This PR itself should trigger a staging deploy
- After deploy: `dig dd-agent-staging.devopsdefender.com` returns a CNAME
- After deploy: `curl https://dd-agent-staging.devopsdefender.com` reaches the app