### PR TITLE
fix: GCP agents register with hostname 'unknown' instead of their VM name

### DIFF
--- a/infra/ansible/playbooks/templates/agent-startup.sh.j2
+++ b/infra/ansible/playbooks/templates/agent-startup.sh.j2
@@ -8,4 +8,6 @@ chmod 0600 /etc/devopsdefender/agent.json
 systemctl daemon-reload || true
 systemctl disable --now devopsdefender-control-plane.service || true
 systemctl enable devopsdefender-agent.service || true
+HOSTNAME=$(curl -sf -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/name || hostname)
+hostnamectl set-hostname "$HOSTNAME"
 systemctl restart devopsdefender-agent.service || true


### PR DESCRIPTION
## Problem

When GCP agents register with the control plane, they report their hostname as `unknown`. This means the control plane creates DNS records like `unknown.devopsdefender.com` instead of proper names like `dd-agent-staging-abc123.devopsdefender.com`.

## Root Cause

The agent reads `/etc/hostname` to get its `vm_name` during registration. On GCP VMs, `/etc/hostname` defaults to `unknown` because the agent startup script never sets the hostname from the instance metadata.

## Fix

In `infra/ansible/playbooks/templates/agent-startup.sh.j2`, before the agent service starts, fetch the instance name from the GCP metadata server and set it via `hostnamectl`:

```bash
HOSTNAME=$(curl -sf -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/name || hostname)
hostnamectl set-hostname "$HOSTNAME"
```

Falls back to the current hostname if the metadata server is unreachable (e.g., non-GCP environments).

## How to Verify

1. Deploy to staging via the staging pipeline
2. Check the agent list in the control plane — agents should register with their GCP instance name (e.g., `dd-agent-staging-abc123`) instead of `unknown`
3. Verify the Cloudflare DNS record is created with the correct hostname

https://claude.ai/code/session_01RuPipBLEhRDJN3uKgVsFXH