### PR TITLE
Simplify mobile admin and session pages

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -105,6 +105,9 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.DD_CP_CF_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.DD_CP_CF_ACCOUNT_ID }}
           CLOUDFLARE_ZONE_ID: ${{ secrets.DD_CP_CF_ZONE_ID }}
+          DD_GITHUB_CLIENT_ID: ${{ vars.DD_GITHUB_CLIENT_ID }}
+          DD_GITHUB_CALLBACK_URL: ${{ vars.DD_GITHUB_CALLBACK_URL }}
+          DD_GITHUB_CLIENT_SECRET: ${{ secrets.DD_GITHUB_CLIENT_SECRET }}
           BINARY_URL: ${{ needs.build.outputs.binary_url }}
         run: |
           set -euo pipefail
@@ -130,6 +133,9 @@ jobs:
           export DD_CF_ZONE_ID=${CLOUDFLARE_ZONE_ID}
           export DD_CF_DOMAIN=${DD_DOMAIN}
           export DD_HOSTNAME=${HOSTNAME}
+          export DD_GITHUB_CLIENT_ID=${DD_GITHUB_CLIENT_ID}
+          export DD_GITHUB_CLIENT_SECRET=${DD_GITHUB_CLIENT_SECRET}
+          export DD_GITHUB_CALLBACK_URL=${DD_GITHUB_CALLBACK_URL}
 
           nohup /usr/local/bin/dd-agent > /var/log/dd-agent.log 2>&1 &
           STARTUP

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -105,7 +105,7 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.DD_CP_CF_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.DD_CP_CF_ACCOUNT_ID }}
           CLOUDFLARE_ZONE_ID: ${{ secrets.DD_CP_CF_ZONE_ID }}
-          DD_GITHUB_CLIENT_ID: ${{ vars.DD_GITHUB_CLIENT_ID }}
+          DD_GITHUB_CLIENT_ID: ${{ vars.DD_GITHUB_CLIENT_ID || secrets.DD_GITHUB_CLIENT_ID }}
           DD_GITHUB_CALLBACK_URL: ${{ vars.DD_GITHUB_CALLBACK_URL }}
           DD_GITHUB_CLIENT_SECRET: ${{ secrets.DD_GITHUB_CLIENT_SECRET }}
           BINARY_URL: ${{ needs.build.outputs.binary_url }}

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -112,7 +112,7 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.DD_CP_CF_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.DD_CP_CF_ACCOUNT_ID }}
           CLOUDFLARE_ZONE_ID: ${{ secrets.DD_CP_CF_ZONE_ID }}
-          DD_GITHUB_CLIENT_ID: ${{ vars.DD_GITHUB_CLIENT_ID }}
+          DD_GITHUB_CLIENT_ID: ${{ vars.DD_GITHUB_CLIENT_ID || secrets.DD_GITHUB_CLIENT_ID }}
           DD_GITHUB_CALLBACK_URL: ${{ vars.DD_GITHUB_CALLBACK_URL }}
           DD_GITHUB_CLIENT_SECRET: ${{ secrets.DD_GITHUB_CLIENT_SECRET }}
           BINARY_URL: ${{ needs.build.outputs.binary_url }}

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -112,6 +112,9 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.DD_CP_CF_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.DD_CP_CF_ACCOUNT_ID }}
           CLOUDFLARE_ZONE_ID: ${{ secrets.DD_CP_CF_ZONE_ID }}
+          DD_GITHUB_CLIENT_ID: ${{ vars.DD_GITHUB_CLIENT_ID }}
+          DD_GITHUB_CALLBACK_URL: ${{ vars.DD_GITHUB_CALLBACK_URL }}
+          DD_GITHUB_CLIENT_SECRET: ${{ secrets.DD_GITHUB_CLIENT_SECRET }}
           BINARY_URL: ${{ needs.build.outputs.binary_url }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
         run: |
@@ -138,6 +141,9 @@ jobs:
           export DD_CF_ZONE_ID=${CLOUDFLARE_ZONE_ID}
           export DD_CF_DOMAIN=${DD_DOMAIN}
           export DD_HOSTNAME=${HOSTNAME}
+          export DD_GITHUB_CLIENT_ID=${DD_GITHUB_CLIENT_ID}
+          export DD_GITHUB_CLIENT_SECRET=${DD_GITHUB_CLIENT_SECRET}
+          export DD_GITHUB_CALLBACK_URL=${DD_GITHUB_CALLBACK_URL}
 
           # Boot a shell as the demo workload
           export DD_BOOT_CMD=bash
@@ -204,9 +210,10 @@ jobs:
             sleep 5
           done
 
-          # 3. Web terminal page loads
-          page=$(curl -fsS "${url}/session/demo")
-          echo "$page" | grep -q "xterm" && echo "✓ Web terminal page serves xterm.js"
+          # 3. Protected session page redirects into GitHub login
+          headers=$(curl -fsSI "${url}/session/demo")
+          echo "$headers" | grep -iq '^location: /auth/github/start?next=%2Fsession%2Fdemo' && \
+            echo "✓ Web terminal page requires GitHub login"
 
           # 4. Deployments endpoint works
           deps=$(curl -fsS "${url}/deployments" -H "Authorization: Bearer dummy" 2>/dev/null || echo "[]")

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -211,9 +211,18 @@ jobs:
           done
 
           # 3. Protected session page redirects into GitHub login
-          headers=$(curl -fsSI "${url}/session/demo")
-          echo "$headers" | grep -iq '^location: /auth/github/start?next=%2Fsession%2Fdemo' && \
-            echo "✓ Web terminal page requires GitHub login"
+          auth_ok=0
+          for i in $(seq 1 12); do
+            headers=$(curl -sSI "${url}/session/demo" || true)
+            if echo "$headers" | grep -iq '^location: /auth/github/start?next=%2Fsession%2Fdemo'; then
+              echo "✓ Web terminal page requires GitHub login"
+              auth_ok=1
+              break
+            fi
+            echo "  waiting for auth redirect... attempt ${i}/12"
+            sleep 5
+          done
+          [ "$auth_ok" -eq 1 ] || { echo "::error::Protected session page did not redirect to GitHub login"; exit 1; }
 
           # 4. Deployments endpoint works
           deps=$(curl -fsS "${url}/deployments" -H "Authorization: Bearer dummy" 2>/dev/null || echo "[]")

--- a/agent/src/bin/dd-agent/main.rs
+++ b/agent/src/bin/dd-agent/main.rs
@@ -49,6 +49,13 @@ async fn run_agent_mode(cfg: AgentRuntimeConfig) {
         eprintln!("dd-agent: DD_OWNER not set");
         std::process::exit(1);
     });
+    let oauth = match dd_agent::server::GithubOAuthConfig::from_env() {
+        Ok(config) => config,
+        Err(error) => {
+            eprintln!("dd-agent: configuration error: {error}");
+            std::process::exit(1);
+        }
+    };
 
     // Ensure workloads directory exists
     let _ = tokio::fs::create_dir_all("/var/lib/dd/workloads/logs").await;
@@ -95,6 +102,9 @@ async fn run_agent_mode(cfg: AgentRuntimeConfig) {
 
     let deployments: Deployments = Arc::new(Mutex::new(HashMap::new()));
     let process_handles: dd_agent::server::ProcessHandles = Arc::new(Mutex::new(HashMap::new()));
+    let browser_sessions: dd_agent::server::BrowserSessions = Arc::new(Mutex::new(HashMap::new()));
+    let pending_oauth_states: dd_agent::server::PendingOauthStates =
+        Arc::new(Mutex::new(HashMap::new()));
 
     // Auto-deploy boot workload if configured
     // DD_BOOT_CMD="bash" — run a direct command (no OCI pull)
@@ -182,6 +192,9 @@ async fn run_agent_mode(cfg: AgentRuntimeConfig) {
         deployments: deployments.clone(),
         process_handles,
         started_at: std::time::Instant::now(),
+        oauth,
+        browser_sessions,
+        pending_oauth_states,
     };
 
     // HTTP server (read-only: health, list deployments, logs)

--- a/agent/src/server.rs
+++ b/agent/src/server.rs
@@ -1,13 +1,15 @@
 use axum::extract::ws::{Message, WebSocket};
-use axum::extract::{Path, State, WebSocketUpgrade};
-use axum::http::HeaderMap;
-use axum::response::{Html, IntoResponse};
+use axum::extract::{OriginalUri, Path, State, WebSocketUpgrade};
+use axum::http::header::{COOKIE, SET_COOKIE};
+use axum::http::{HeaderMap, HeaderValue, Uri};
+use axum::response::{Html, IntoResponse, Redirect, Response};
 use axum::routing::get;
 use axum::{Json, Router};
 use futures_util::{SinkExt, StreamExt};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::sync::Mutex;
 
@@ -54,6 +56,8 @@ pub struct HealthResponse {
 }
 
 pub type Deployments = Arc<Mutex<HashMap<String, DeploymentInfo>>>;
+pub type BrowserSessions = Arc<Mutex<HashMap<String, BrowserSession>>>;
+pub type PendingOauthStates = Arc<Mutex<HashMap<String, PendingOauthState>>>;
 
 /// Per-process I/O handles for interactive sessions.
 pub struct ProcessIO {
@@ -62,6 +66,48 @@ pub struct ProcessIO {
 }
 
 pub type ProcessHandles = Arc<Mutex<HashMap<String, ProcessIO>>>;
+
+#[derive(Debug, Clone)]
+pub struct GithubOAuthConfig {
+    pub client_id: String,
+    pub client_secret: String,
+    pub callback_url: String,
+    pub secure_cookies: bool,
+}
+
+impl GithubOAuthConfig {
+    pub fn from_env() -> Result<Option<Self>, String> {
+        let client_id = std::env::var("DD_GITHUB_CLIENT_ID").ok();
+        let client_secret = std::env::var("DD_GITHUB_CLIENT_SECRET").ok();
+        let callback_url = std::env::var("DD_GITHUB_CALLBACK_URL").ok();
+
+        match (client_id, client_secret, callback_url) {
+            (None, None, None) => Ok(None),
+            (Some(client_id), Some(client_secret), Some(callback_url)) => Ok(Some(Self {
+                client_id,
+                client_secret,
+                secure_cookies: callback_url.starts_with("https://"),
+                callback_url,
+            })),
+            _ => Err(
+                "DD_GITHUB_CLIENT_ID, DD_GITHUB_CLIENT_SECRET, and DD_GITHUB_CALLBACK_URL must all be set"
+                    .into(),
+            ),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct BrowserSession {
+    pub token: String,
+    pub expires_at: Instant,
+}
+
+#[derive(Debug, Clone)]
+pub struct PendingOauthState {
+    pub next_path: String,
+    pub expires_at: Instant,
+}
 
 #[derive(Clone)]
 pub struct AgentState {
@@ -72,9 +118,16 @@ pub struct AgentState {
     pub deployments: Deployments,
     pub process_handles: ProcessHandles,
     pub started_at: std::time::Instant,
+    pub oauth: Option<GithubOAuthConfig>,
+    pub browser_sessions: BrowserSessions,
+    pub pending_oauth_states: PendingOauthStates,
 }
 
 // ── Auth ──────────────────────────────────────────────────────────────────
+
+const SESSION_COOKIE: &str = "dd_session";
+const SESSION_TTL: Duration = Duration::from_secs(8 * 60 * 60);
+const OAUTH_STATE_TTL: Duration = Duration::from_secs(10 * 60);
 
 fn extract_auth(headers: &HeaderMap) -> Option<String> {
     let value = headers.get("authorization")?.to_str().ok()?;
@@ -84,12 +137,112 @@ fn extract_auth(headers: &HeaderMap) -> Option<String> {
     Some(token.to_string())
 }
 
-async fn verify_owner(state: &AgentState, headers: &HeaderMap) -> Result<(), AppError> {
-    if state.owner.is_empty() {
-        return Ok(());
+fn extract_cookie(headers: &HeaderMap, name: &str) -> Option<String> {
+    let cookies = headers.get(COOKIE)?.to_str().ok()?;
+    for cookie in cookies.split(';') {
+        let mut parts = cookie.trim().splitn(2, '=');
+        let key = parts.next()?.trim();
+        let value = parts.next()?.trim();
+        if key == name {
+            return Some(value.to_string());
+        }
     }
-    let token = extract_auth(headers).ok_or(AppError::Unauthorized)?;
-    verify_github_token(&token, &state.owner).await
+    None
+}
+
+fn sanitize_next_path(next: Option<&str>) -> String {
+    match next {
+        Some(path) if path.starts_with('/') && !path.starts_with("//") => path.to_string(),
+        _ => "/".to_string(),
+    }
+}
+
+fn github_oauth_redirect(next: &Uri) -> Redirect {
+    let mut url = reqwest::Url::parse("http://localhost/auth/github/start").unwrap();
+    let next_path = next
+        .path_and_query()
+        .map(|value| value.as_str())
+        .unwrap_or("/");
+    url.query_pairs_mut().append_pair("next", next_path);
+    let location = format!("{}?{}", url.path(), url.query().unwrap_or_default());
+    Redirect::to(&location)
+}
+
+fn build_session_cookie(state: &AgentState, session_id: &str, max_age: u64) -> String {
+    let mut cookie =
+        format!("{SESSION_COOKIE}={session_id}; Path=/; HttpOnly; SameSite=Lax; Max-Age={max_age}");
+    if state
+        .oauth
+        .as_ref()
+        .map(|oauth| oauth.secure_cookies)
+        .unwrap_or(false)
+    {
+        cookie.push_str("; Secure");
+    }
+    cookie
+}
+
+fn response_with_cookie(response: impl IntoResponse, cookie: String) -> Response {
+    let mut response = response.into_response();
+    if let Ok(value) = HeaderValue::from_str(&cookie) {
+        response.headers_mut().append(SET_COOKIE, value);
+    }
+    response
+}
+
+async fn session_token_from_cookie(state: &AgentState, headers: &HeaderMap) -> Option<String> {
+    let session_id = extract_cookie(headers, SESSION_COOKIE)?;
+    let mut sessions = state.browser_sessions.lock().await;
+    let now = Instant::now();
+    sessions.retain(|_, session| session.expires_at > now);
+    sessions
+        .get(&session_id)
+        .map(|session| session.token.clone())
+}
+
+async fn resolve_github_token(
+    state: &AgentState,
+    headers: &HeaderMap,
+    query_token: Option<&str>,
+) -> Result<Option<String>, AppError> {
+    if state.owner.is_empty() {
+        return Ok(None);
+    }
+
+    if let Some(token) = query_token.filter(|token| !token.is_empty()) {
+        verify_github_token(token, &state.owner).await?;
+        return Ok(Some(token.to_string()));
+    }
+
+    if let Some(token) = extract_auth(headers) {
+        verify_github_token(&token, &state.owner).await?;
+        return Ok(Some(token));
+    }
+
+    if let Some(token) = session_token_from_cookie(state, headers).await {
+        return Ok(Some(token));
+    }
+
+    Err(AppError::Unauthorized)
+}
+
+async fn require_browser_token(
+    state: &AgentState,
+    headers: &HeaderMap,
+    query_token: Option<&str>,
+    current_uri: &Uri,
+) -> Result<Option<String>, Response> {
+    match resolve_github_token(state, headers, query_token).await {
+        Ok(token) => Ok(token),
+        Err(AppError::Unauthorized) if state.oauth.is_some() => {
+            Err(github_oauth_redirect(current_uri).into_response())
+        }
+        Err(err) => Err(err.into_response()),
+    }
+}
+
+async fn verify_owner(state: &AgentState, headers: &HeaderMap) -> Result<(), AppError> {
+    resolve_github_token(state, headers, None).await.map(|_| ())
 }
 
 // ── HTTP Handlers (read-only) ────────────────────────────────────────────
@@ -105,6 +258,26 @@ async fn health(State(state): State<AgentState>) -> Json<HealthResponse> {
         deployment_count,
         uptime_seconds: state.started_at.elapsed().as_secs(),
     })
+}
+
+async fn logged_out_page() -> Html<&'static str> {
+    Html(
+        r#"<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>DD — Signed Out</title>
+</head>
+<body>
+<main>
+  <h1>Signed out</h1>
+  <p>Your browser session has been cleared.</p>
+  <p><a href="/">Return to dashboard</a></p>
+</main>
+</body>
+</html>"#,
+    )
 }
 
 async fn list_deployments(
@@ -161,9 +334,22 @@ async fn deployment_logs(
 
 // ── Web terminal ─────────────────────────────────────────────────────────
 
-async fn session_page(Path(app_name): Path<String>) -> Html<String> {
+async fn session_page(
+    State(state): State<AgentState>,
+    Path(app_name): Path<String>,
+    query: axum::extract::Query<SessionQuery>,
+    headers: HeaderMap,
+    OriginalUri(uri): OriginalUri,
+) -> Result<Response, AppError> {
+    if !state.owner.is_empty() {
+        match require_browser_token(&state, &headers, query.token.as_deref(), &uri).await {
+            Ok(_) => {}
+            Err(response) => return Ok(response),
+        }
+    }
+
     let html = include_str!("../web/terminal.html");
-    Html(html.replace("DD Terminal", &format!("DD — {app_name}")))
+    Ok(Html(html.replace("DD Terminal", &format!("DD — {app_name}"))).into_response())
 }
 
 #[derive(Debug, serde::Deserialize)]
@@ -175,14 +361,145 @@ async fn ws_session(
     State(state): State<AgentState>,
     Path(app_name): Path<String>,
     query: axum::extract::Query<SessionQuery>,
+    headers: HeaderMap,
     ws: WebSocketUpgrade,
 ) -> Result<impl IntoResponse, AppError> {
-    // Verify GitHub token if owner is set
-    if !state.owner.is_empty() {
-        let token = query.token.as_deref().ok_or(AppError::Unauthorized)?;
-        verify_github_token(token, &state.owner).await?;
-    }
+    resolve_github_token(&state, &headers, query.token.as_deref()).await?;
     Ok(ws.on_upgrade(move |socket| handle_ws_session(socket, state, app_name)))
+}
+
+#[derive(Debug, Deserialize)]
+struct AuthStartQuery {
+    next: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GithubCallbackQuery {
+    code: Option<String>,
+    state: Option<String>,
+    error: Option<String>,
+    error_description: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GithubTokenResponse {
+    access_token: Option<String>,
+}
+
+async fn github_auth_start(
+    State(state): State<AgentState>,
+    query: axum::extract::Query<AuthStartQuery>,
+) -> Result<Redirect, AppError> {
+    let oauth = state
+        .oauth
+        .as_ref()
+        .ok_or_else(|| AppError::Config("GitHub OAuth is not configured".into()))?;
+    let next_path = sanitize_next_path(query.next.as_deref());
+    let state_id = uuid::Uuid::new_v4().simple().to_string();
+
+    state.pending_oauth_states.lock().await.insert(
+        state_id.clone(),
+        PendingOauthState {
+            next_path,
+            expires_at: Instant::now() + OAUTH_STATE_TTL,
+        },
+    );
+
+    let mut url = reqwest::Url::parse("https://github.com/login/oauth/authorize").unwrap();
+    url.query_pairs_mut()
+        .append_pair("client_id", &oauth.client_id)
+        .append_pair("redirect_uri", &oauth.callback_url)
+        .append_pair("scope", "read:user read:org")
+        .append_pair("state", &state_id);
+    Ok(Redirect::to(url.as_str()))
+}
+
+async fn github_auth_callback(
+    State(state): State<AgentState>,
+    query: axum::extract::Query<GithubCallbackQuery>,
+) -> Result<Response, AppError> {
+    if let Some(error) = query.error.as_deref() {
+        let description = query.error_description.as_deref().unwrap_or(error);
+        return Err(AppError::External(description.into()));
+    }
+
+    let oauth = state
+        .oauth
+        .as_ref()
+        .ok_or_else(|| AppError::Config("GitHub OAuth is not configured".into()))?;
+    let code = query
+        .code
+        .as_deref()
+        .ok_or_else(|| AppError::InvalidInput("missing GitHub OAuth code".into()))?;
+    let state_id = query
+        .state
+        .as_deref()
+        .ok_or_else(|| AppError::InvalidInput("missing GitHub OAuth state".into()))?;
+
+    let next_path = {
+        let mut states = state.pending_oauth_states.lock().await;
+        let now = Instant::now();
+        states.retain(|_, pending| pending.expires_at > now);
+        states
+            .remove(state_id)
+            .map(|pending| pending.next_path)
+            .ok_or(AppError::Unauthorized)?
+    };
+
+    let http = reqwest::Client::new();
+    let token_resp = http
+        .post("https://github.com/login/oauth/access_token")
+        .header("Accept", "application/json")
+        .header("User-Agent", "dd-agent")
+        .form(&[
+            ("client_id", oauth.client_id.as_str()),
+            ("client_secret", oauth.client_secret.as_str()),
+            ("code", code),
+            ("redirect_uri", oauth.callback_url.as_str()),
+            ("state", state_id),
+        ])
+        .send()
+        .await
+        .map_err(|e| AppError::External(format!("GitHub OAuth exchange failed: {e}")))?;
+
+    if !token_resp.status().is_success() {
+        return Err(AppError::Unauthorized);
+    }
+
+    let token_body: GithubTokenResponse = token_resp
+        .json()
+        .await
+        .map_err(|e| AppError::External(format!("invalid GitHub OAuth response: {e}")))?;
+    let token = token_body.access_token.ok_or(AppError::Unauthorized)?;
+
+    if !state.owner.is_empty() {
+        verify_github_token(&token, &state.owner).await?;
+    }
+
+    let session_id = uuid::Uuid::new_v4().simple().to_string();
+    state.browser_sessions.lock().await.insert(
+        session_id.clone(),
+        BrowserSession {
+            token,
+            expires_at: Instant::now() + SESSION_TTL,
+        },
+    );
+
+    Ok(response_with_cookie(
+        Redirect::to(&next_path),
+        build_session_cookie(&state, &session_id, SESSION_TTL.as_secs()),
+    ))
+}
+
+async fn github_auth_logout(State(state): State<AgentState>, headers: HeaderMap) -> Response {
+    if let Some(session_id) = extract_cookie(&headers, SESSION_COOKIE) {
+        state.browser_sessions.lock().await.remove(&session_id);
+    }
+
+    response_with_cookie(
+        Redirect::to("/logged-out"),
+        build_session_cookie(&state, "", 0),
+    )
 }
 
 async fn verify_github_token(token: &str, owner: &str) -> Result<(), AppError> {
@@ -679,10 +996,14 @@ struct DashQuery {
 async fn dashboard(
     State(state): State<AgentState>,
     query: axum::extract::Query<DashQuery>,
-) -> Result<Html<String>, AppError> {
+    headers: HeaderMap,
+    OriginalUri(uri): OriginalUri,
+) -> Result<Response, AppError> {
     if !state.owner.is_empty() {
-        let token = query.token.as_deref().ok_or(AppError::Unauthorized)?;
-        verify_github_token(token, &state.owner).await?;
+        match require_browser_token(&state, &headers, query.token.as_deref(), &uri).await {
+            Ok(_) => {}
+            Err(response) => return Ok(response),
+        }
     }
 
     let metrics = collect_metrics().await;
@@ -892,6 +1213,7 @@ async fn dashboard(
   <header>
     <h1>DevOps Defender</h1>
     <p class="muted">{agent_id}</p>
+    <p><a href="/auth/logout">Log out</a></p>
     <ul>
       <li>vm: <strong>{vm_name}</strong></li>
       <li>health: <strong>healthy</strong></li>
@@ -954,7 +1276,8 @@ async fn dashboard(
 </table></div>"#
             )
         },
-    )))
+    ))
+    .into_response())
 }
 
 // ── System Metrics ───────────────────────────────────────────────────────
@@ -1086,6 +1409,10 @@ async fn num_cpus() -> usize {
 pub fn build_router(state: AgentState) -> Router {
     Router::new()
         .route("/", get(dashboard))
+        .route("/logged-out", get(logged_out_page))
+        .route("/auth/github/start", get(github_auth_start))
+        .route("/auth/github/callback", get(github_auth_callback))
+        .route("/auth/logout", get(github_auth_logout))
         .route("/health", get(health))
         .route("/deployments", get(list_deployments))
         .route("/deployments/{id}", get(get_deployment))

--- a/agent/src/server.rs
+++ b/agent/src/server.rs
@@ -671,8 +671,277 @@ async fn handle_ws_noise_cmd(socket: WebSocket, state: AgentState) {
 
 // ── HTTP Router ──────────────────────────────────────────────────────────
 
+#[derive(Debug, serde::Deserialize)]
+struct DashQuery {
+    token: Option<String>,
+}
+
+async fn dashboard(
+    State(state): State<AgentState>,
+    query: axum::extract::Query<DashQuery>,
+) -> Result<Html<String>, AppError> {
+    if !state.owner.is_empty() {
+        let token = query.token.as_deref().ok_or(AppError::Unauthorized)?;
+        verify_github_token(token, &state.owner).await?;
+    }
+
+    let metrics = collect_metrics().await;
+    let deps = state.deployments.lock().await;
+    let mut rows = String::new();
+    for d in deps.values() {
+        let status_color = match d.status.as_str() {
+            "running" => "#a6e3a1",
+            "deploying" => "#f9e2af",
+            "failed" | "exited" => "#f38ba8",
+            _ => "#a6adc8",
+        };
+        let terminal_link = if d.status == "running" {
+            format!(r#"<a href="/session/{}">terminal</a>"#, d.app_name)
+        } else {
+            String::new()
+        };
+        rows.push_str(&format!(
+            r#"<tr>
+                <td>{}</td>
+                <td><span style="color:{status_color}">{}</span></td>
+                <td>{}</td>
+                <td>{}</td>
+                <td>{terminal_link}</td>
+            </tr>"#,
+            d.app_name,
+            d.status,
+            d.image,
+            d.started_at.split('T').next().unwrap_or(&d.started_at),
+        ));
+    }
+
+    let uptime = state.started_at.elapsed().as_secs();
+    let uptime_str = if uptime > 3600 {
+        format!("{}h {}m", uptime / 3600, (uptime % 3600) / 60)
+    } else if uptime > 60 {
+        format!("{}m {}s", uptime / 60, uptime % 60)
+    } else {
+        format!("{uptime}s")
+    };
+
+    Ok(Html(format!(
+        r#"<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>DD — {vm_name}</title>
+<style>
+  body {{ margin: 0; background: #1e1e2e; color: #cdd6f4; font-family: 'JetBrains Mono', monospace; padding: 24px; }}
+  h1 {{ color: #89b4fa; margin: 0 0 4px; font-size: 20px; }}
+  .subtitle {{ color: #585b70; font-size: 12px; margin-bottom: 16px; }}
+  .meta {{ color: #a6adc8; font-size: 13px; margin-bottom: 20px; }}
+  .meta .ok {{ color: #a6e3a1; }}
+  .metrics {{ display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 12px; margin-bottom: 24px; }}
+  .metric {{ background: #313244; border-radius: 8px; padding: 12px 16px; }}
+  .metric .label {{ color: #a6adc8; font-size: 11px; text-transform: uppercase; }}
+  .metric .value {{ color: #cdd6f4; font-size: 18px; font-weight: bold; margin-top: 4px; }}
+  .metric .bar {{ background: #45475a; border-radius: 4px; height: 4px; margin-top: 8px; }}
+  .metric .bar-fill {{ background: #89b4fa; border-radius: 4px; height: 4px; }}
+  .section {{ color: #a6adc8; font-size: 12px; text-transform: uppercase; margin: 20px 0 8px; }}
+  table {{ border-collapse: collapse; width: 100%; }}
+  th {{ text-align: left; color: #a6adc8; font-weight: normal; font-size: 12px; text-transform: uppercase; padding: 8px 12px; border-bottom: 1px solid #313244; }}
+  td {{ padding: 8px 12px; border-bottom: 1px solid #313244; font-size: 14px; }}
+  a {{ color: #89b4fa; text-decoration: none; }}
+  a:hover {{ text-decoration: underline; }}
+  .empty {{ color: #585b70; padding: 24px; text-align: center; }}
+</style>
+</head>
+<body>
+<h1>DevOps Defender</h1>
+<div class="subtitle">{agent_id}</div>
+<div class="meta">
+  {vm_name} &middot; <span class="ok">healthy</span> &middot; {att} &middot; owner: {owner} &middot; uptime {uptime}
+</div>
+
+<div class="metrics">
+  <div class="metric">
+    <div class="label">CPU</div>
+    <div class="value">{cpu_pct}%</div>
+    <div class="bar"><div class="bar-fill" style="width:{cpu_pct}%"></div></div>
+  </div>
+  <div class="metric">
+    <div class="label">Memory</div>
+    <div class="value">{mem_used} / {mem_total}</div>
+    <div class="bar"><div class="bar-fill" style="width:{mem_pct}%"></div></div>
+  </div>
+  <div class="metric">
+    <div class="label">Disk</div>
+    <div class="value">{disk_used} / {disk_total}</div>
+    <div class="bar"><div class="bar-fill" style="width:{disk_pct}%"></div></div>
+  </div>
+  <div class="metric">
+    <div class="label">Load</div>
+    <div class="value">{load_1m}</div>
+    <div class="bar"><div class="bar-fill" style="width:{load_pct}%"></div></div>
+  </div>
+</div>
+
+<div class="section">Jobs ({count})</div>
+{table}
+</body>
+</html>"#,
+        vm_name = state.vm_name,
+        agent_id = state.agent_id,
+        att = state.attestation_type,
+        owner = state.owner,
+        uptime = uptime_str,
+        count = deps.len(),
+        cpu_pct = metrics.cpu_pct,
+        mem_used = metrics.mem_used,
+        mem_total = metrics.mem_total,
+        mem_pct = metrics.mem_pct,
+        disk_used = metrics.disk_used,
+        disk_total = metrics.disk_total,
+        disk_pct = metrics.disk_pct,
+        load_1m = metrics.load_1m,
+        load_pct = metrics.load_pct,
+        table = if deps.is_empty() {
+            r#"<div class="empty">no jobs running &mdash; deploy something with <code>dd deploy</code></div>"#.to_string()
+        } else {
+            format!(
+                r#"<table>
+<tr><th>app</th><th>status</th><th>image</th><th>started</th><th></th></tr>
+{rows}
+</table>"#
+            )
+        },
+    )))
+}
+
+// ── System Metrics ───────────────────────────────────────────────────────
+
+struct SystemMetrics {
+    cpu_pct: u64,
+    mem_used: String,
+    mem_total: String,
+    mem_pct: u64,
+    disk_used: String,
+    disk_total: String,
+    disk_pct: u64,
+    load_1m: String,
+    load_pct: u64,
+}
+
+fn format_bytes(bytes: u64) -> String {
+    if bytes >= 1_073_741_824 {
+        format!("{:.1}G", bytes as f64 / 1_073_741_824.0)
+    } else if bytes >= 1_048_576 {
+        format!("{:.0}M", bytes as f64 / 1_048_576.0)
+    } else {
+        format!("{:.0}K", bytes as f64 / 1024.0)
+    }
+}
+
+async fn collect_metrics() -> SystemMetrics {
+    let mut metrics = SystemMetrics {
+        cpu_pct: 0,
+        mem_used: "?".into(),
+        mem_total: "?".into(),
+        mem_pct: 0,
+        disk_used: "?".into(),
+        disk_total: "?".into(),
+        disk_pct: 0,
+        load_1m: "?".into(),
+        load_pct: 0,
+    };
+
+    // Memory from /proc/meminfo
+    if let Ok(meminfo) = tokio::fs::read_to_string("/proc/meminfo").await {
+        let mut total_kb = 0u64;
+        let mut available_kb = 0u64;
+        for line in meminfo.lines() {
+            if let Some(val) = line.strip_prefix("MemTotal:") {
+                total_kb = val
+                    .split_whitespace()
+                    .next()
+                    .and_then(|v| v.parse().ok())
+                    .unwrap_or(0);
+            }
+            if let Some(val) = line.strip_prefix("MemAvailable:") {
+                available_kb = val
+                    .split_whitespace()
+                    .next()
+                    .and_then(|v| v.parse().ok())
+                    .unwrap_or(0);
+            }
+        }
+        if total_kb > 0 {
+            let used_kb = total_kb.saturating_sub(available_kb);
+            metrics.mem_total = format_bytes(total_kb * 1024);
+            metrics.mem_used = format_bytes(used_kb * 1024);
+            metrics.mem_pct = (used_kb * 100) / total_kb;
+        }
+    }
+
+    // Load average from /proc/loadavg
+    if let Ok(loadavg) = tokio::fs::read_to_string("/proc/loadavg").await {
+        if let Some(load_1m) = loadavg.split_whitespace().next() {
+            metrics.load_1m = load_1m.to_string();
+            let load: f64 = load_1m.parse().unwrap_or(0.0);
+            // Normalize to percentage of CPU count
+            let cpus = num_cpus().await;
+            metrics.load_pct = ((load / cpus as f64) * 100.0).min(100.0) as u64;
+        }
+    }
+
+    // CPU usage from /proc/stat (simple: 100 - idle%)
+    if let Ok(stat) = tokio::fs::read_to_string("/proc/stat").await {
+        if let Some(cpu_line) = stat.lines().next() {
+            let vals: Vec<u64> = cpu_line
+                .split_whitespace()
+                .skip(1)
+                .filter_map(|v| v.parse().ok())
+                .collect();
+            if vals.len() >= 4 {
+                let total: u64 = vals.iter().sum();
+                let idle = vals[3];
+                if total > 0 {
+                    metrics.cpu_pct = 100u64.saturating_sub((idle * 100) / total);
+                }
+            }
+        }
+    }
+
+    // Disk from /proc/mounts + statvfs equivalent
+    if let Ok(output) = tokio::process::Command::new("df")
+        .arg("-B1")
+        .arg("/")
+        .output()
+        .await
+    {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        if let Some(line) = stdout.lines().nth(1) {
+            let parts: Vec<&str> = line.split_whitespace().collect();
+            if parts.len() >= 4 {
+                let total: u64 = parts[1].parse().unwrap_or(0);
+                let used: u64 = parts[2].parse().unwrap_or(0);
+                if total > 0 {
+                    metrics.disk_total = format_bytes(total);
+                    metrics.disk_used = format_bytes(used);
+                    metrics.disk_pct = (used * 100) / total;
+                }
+            }
+        }
+    }
+
+    metrics
+}
+
+async fn num_cpus() -> usize {
+    tokio::fs::read_to_string("/proc/cpuinfo")
+        .await
+        .map(|s| s.matches("processor").count())
+        .unwrap_or(1)
+}
+
 pub fn build_router(state: AgentState) -> Router {
     Router::new()
+        .route("/", get(dashboard))
         .route("/health", get(health))
         .route("/deployments", get(list_deployments))
         .route("/deployments/{id}", get(get_deployment))

--- a/agent/src/server.rs
+++ b/agent/src/server.rs
@@ -688,25 +688,33 @@ async fn dashboard(
     let metrics = collect_metrics().await;
     let deps = state.deployments.lock().await;
     let mut rows = String::new();
+    let session_query = query
+        .token
+        .as_deref()
+        .map(|token| format!("?token={token}"))
+        .unwrap_or_default();
     for d in deps.values() {
-        let status_color = match d.status.as_str() {
-            "running" => "#a6e3a1",
-            "deploying" => "#f9e2af",
-            "failed" | "exited" => "#f38ba8",
-            _ => "#a6adc8",
+        let status_class = match d.status.as_str() {
+            "running" => "running",
+            "deploying" => "deploying",
+            "failed" | "exited" => "failed",
+            _ => "idle",
         };
         let terminal_link = if d.status == "running" {
-            format!(r#"<a href="/session/{}">terminal</a>"#, d.app_name)
+            format!(
+                r#"<a class="action-link" href="/session/{}{}">open session</a>"#,
+                d.app_name, session_query
+            )
         } else {
-            String::new()
+            r#"<span class="muted">unavailable</span>"#.to_string()
         };
         rows.push_str(&format!(
             r#"<tr>
-                <td>{}</td>
-                <td><span style="color:{status_color}">{}</span></td>
-                <td>{}</td>
-                <td>{}</td>
-                <td>{terminal_link}</td>
+                <td data-label="App"><span class="app-name">{}</span></td>
+                <td data-label="Status"><span class="status-pill {status_class}">{}</span></td>
+                <td data-label="Image"><span class="image-name">{}</span></td>
+                <td data-label="Started">{}</td>
+                <td data-label="Session" class="actions">{terminal_link}</td>
             </tr>"#,
             d.app_name,
             d.status,
@@ -729,60 +737,197 @@ async fn dashboard(
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <title>DD — {vm_name}</title>
 <style>
-  body {{ margin: 0; background: #1e1e2e; color: #cdd6f4; font-family: 'JetBrains Mono', monospace; padding: 24px; }}
-  h1 {{ color: #89b4fa; margin: 0 0 4px; font-size: 20px; }}
-  .subtitle {{ color: #585b70; font-size: 12px; margin-bottom: 16px; }}
-  .meta {{ color: #a6adc8; font-size: 13px; margin-bottom: 20px; }}
-  .meta .ok {{ color: #a6e3a1; }}
-  .metrics {{ display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 12px; margin-bottom: 24px; }}
-  .metric {{ background: #313244; border-radius: 8px; padding: 12px 16px; }}
-  .metric .label {{ color: #a6adc8; font-size: 11px; text-transform: uppercase; }}
-  .metric .value {{ color: #cdd6f4; font-size: 18px; font-weight: bold; margin-top: 4px; }}
-  .metric .bar {{ background: #45475a; border-radius: 4px; height: 4px; margin-top: 8px; }}
-  .metric .bar-fill {{ background: #89b4fa; border-radius: 4px; height: 4px; }}
-  .section {{ color: #a6adc8; font-size: 12px; text-transform: uppercase; margin: 20px 0 8px; }}
-  table {{ border-collapse: collapse; width: 100%; }}
-  th {{ text-align: left; color: #a6adc8; font-weight: normal; font-size: 12px; text-transform: uppercase; padding: 8px 12px; border-bottom: 1px solid #313244; }}
-  td {{ padding: 8px 12px; border-bottom: 1px solid #313244; font-size: 14px; }}
-  a {{ color: #89b4fa; text-decoration: none; }}
-  a:hover {{ text-decoration: underline; }}
-  .empty {{ color: #585b70; padding: 24px; text-align: center; }}
+  * {{ box-sizing: border-box; }}
+  body {{
+    margin: 0;
+    color: #111827;
+    font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    background: #fff;
+  }}
+  main {{
+    width: min(960px, 100%);
+    margin: 0 auto;
+    padding: 16px;
+  }}
+  header, section {{
+    margin-top: 18px;
+  }}
+  header {{
+    margin-top: 0;
+  }}
+  h1, h2, p {{
+    margin: 0;
+  }}
+  h1 {{
+    font-size: clamp(2rem, 6vw, 2.5rem);
+    line-height: 1.1;
+  }}
+  h2 {{
+    font-size: 1rem;
+  }}
+  p, li, td, th, a, code {{
+    font-size: 0.95rem;
+    line-height: 1.45;
+  }}
+  ul {{
+    margin: 12px 0 0;
+    padding-left: 1.2rem;
+  }}
+  .muted {{
+    color: #4b5563;
+  }}
+  .metrics {{
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 12px;
+    margin-top: 14px;
+  }}
+  .metric {{
+    border: 1px solid #d1d5db;
+    padding: 12px;
+  }}
+  .metric strong {{
+    display: block;
+    font-size: 1.25rem;
+    margin-top: 4px;
+  }}
+  .status {{
+    font-weight: 700;
+  }}
+  .status.running {{ color: #166534; }}
+  .status.deploying {{ color: #92400e; }}
+  .status.failed {{ color: #991b1b; }}
+  .status.idle {{ color: #4b5563; }}
+  .table-wrap {{ overflow-x: auto; }}
+  table {{
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 12px;
+  }}
+  thead {{
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }}
+  tbody, tr {{ display: block; }}
+  tr {{
+    border-top: 1px solid #e5e7eb;
+    padding: 10px 0;
+  }}
+  td {{
+    display: grid;
+    grid-template-columns: minmax(76px, 90px) minmax(0, 1fr);
+    gap: 12px;
+    align-items: center;
+    padding: 6px 0;
+  }}
+  td::before {{
+    content: attr(data-label);
+    color: #4b5563;
+    font-size: 0.75rem;
+    font-weight: 700;
+    text-transform: uppercase;
+  }}
+  .actions {{ align-items: start; }}
+  a {{
+    color: #1d4ed8;
+    text-decoration-thickness: 1px;
+  }}
+  .empty {{
+    margin-top: 12px;
+    padding-top: 12px;
+    border-top: 1px solid #e5e7eb;
+  }}
+  code {{ font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }}
+  @media (min-width: 720px) {{
+    main {{ padding: 24px; }}
+    .metrics {{ grid-template-columns: repeat(4, minmax(0, 1fr)); }}
+  }}
+  @media (min-width: 840px) {{
+    thead {{
+      position: static;
+      width: auto;
+      height: auto;
+      margin: 0;
+      overflow: visible;
+      clip: auto;
+      white-space: normal;
+    }}
+    tbody {{ display: table-row-group; }}
+    tr {{
+      display: table-row;
+      padding: 0;
+    }}
+    th {{
+      padding: 0 0 10px;
+      text-align: left;
+      color: #4b5563;
+      font-size: 0.75rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      border-bottom: 1px solid #d1d5db;
+    }}
+    td {{
+      display: table-cell;
+      padding: 12px 0;
+      border-bottom: 1px solid #e5e7eb;
+      vertical-align: middle;
+    }}
+    td::before {{ display: none; }}
+    .actions {{ text-align: right; }}
+  }}
 </style>
 </head>
 <body>
-<h1>DevOps Defender</h1>
-<div class="subtitle">{agent_id}</div>
-<div class="meta">
-  {vm_name} &middot; <span class="ok">healthy</span> &middot; {att} &middot; owner: {owner} &middot; uptime {uptime}
-</div>
+<main>
+  <header>
+    <h1>DevOps Defender</h1>
+    <p class="muted">{agent_id}</p>
+    <ul>
+      <li>vm: <strong>{vm_name}</strong></li>
+      <li>health: <strong>healthy</strong></li>
+      <li>attestation: <strong>{att}</strong></li>
+      <li>owner: <strong>{owner}</strong></li>
+      <li>uptime: <strong>{uptime}</strong></li>
+    </ul>
+    <div class="metrics">
+      <div class="metric">
+        <div>CPU</div>
+        <strong>{cpu_pct}%</strong>
+        <div class="muted">live host utilization</div>
+      </div>
+      <div class="metric">
+        <div>Memory</div>
+        <strong>{mem_used}</strong>
+        <div class="muted">{mem_used} of {mem_total}</div>
+      </div>
+      <div class="metric">
+        <div>Disk</div>
+        <strong>{disk_used}</strong>
+        <div class="muted">{disk_used} of {disk_total}</div>
+      </div>
+      <div class="metric">
+        <div>Load</div>
+        <strong>{load_1m}</strong>
+        <div class="muted">normalized over CPUs</div>
+      </div>
+    </div>
+  </header>
 
-<div class="metrics">
-  <div class="metric">
-    <div class="label">CPU</div>
-    <div class="value">{cpu_pct}%</div>
-    <div class="bar"><div class="bar-fill" style="width:{cpu_pct}%"></div></div>
-  </div>
-  <div class="metric">
-    <div class="label">Memory</div>
-    <div class="value">{mem_used} / {mem_total}</div>
-    <div class="bar"><div class="bar-fill" style="width:{mem_pct}%"></div></div>
-  </div>
-  <div class="metric">
-    <div class="label">Disk</div>
-    <div class="value">{disk_used} / {disk_total}</div>
-    <div class="bar"><div class="bar-fill" style="width:{disk_pct}%"></div></div>
-  </div>
-  <div class="metric">
-    <div class="label">Load</div>
-    <div class="value">{load_1m}</div>
-    <div class="bar"><div class="bar-fill" style="width:{load_pct}%"></div></div>
-  </div>
-</div>
-
-<div class="section">Jobs ({count})</div>
-{table}
+  <section>
+    <h2>Jobs ({count})</h2>
+    {table}
+  </section>
+</main>
 </body>
 </html>"#,
         vm_name = state.vm_name,
@@ -794,20 +939,19 @@ async fn dashboard(
         cpu_pct = metrics.cpu_pct,
         mem_used = metrics.mem_used,
         mem_total = metrics.mem_total,
-        mem_pct = metrics.mem_pct,
         disk_used = metrics.disk_used,
         disk_total = metrics.disk_total,
-        disk_pct = metrics.disk_pct,
         load_1m = metrics.load_1m,
-        load_pct = metrics.load_pct,
         table = if deps.is_empty() {
             r#"<div class="empty">no jobs running &mdash; deploy something with <code>dd deploy</code></div>"#.to_string()
         } else {
             format!(
-                r#"<table>
-<tr><th>app</th><th>status</th><th>image</th><th>started</th><th></th></tr>
+                r#"<div class="table-wrap"><table>
+<thead><tr><th>app</th><th>status</th><th>image</th><th>started</th><th>session</th></tr></thead>
+<tbody>
 {rows}
-</table>"#
+</tbody>
+</table></div>"#
             )
         },
     )))

--- a/agent/web/terminal.html
+++ b/agent/web/terminal.html
@@ -135,6 +135,7 @@
       <span class="muted" id="detail">Enter a GitHub token to attach to this container.</span>
     </div>
     <p class="muted" id="attestation"></p>
+    <p><a href="/auth/logout">Log out</a></p>
   </header>
 
   <section>
@@ -236,12 +237,11 @@ function focusTerminal() {
   fitTerminal();
 }
 
-let token = params.get('token') || localStorage.getItem('dd_token') || '';
+let token = params.get('token') || '';
 let ws = null;
 
 if (token) {
   tokenInput.value = token;
-  localStorage.setItem('dd_token', token);
 }
 
 updateHomeLink(token);
@@ -256,14 +256,7 @@ function sendInput(data) {
 }
 
 function connect(nextToken) {
-  if (!nextToken) {
-    setStatus('err', 'Token required', 'Enter a GitHub token to attach to this container.');
-    tokenInput.focus();
-    return;
-  }
-
-  token = nextToken;
-  localStorage.setItem('dd_token', token);
+  token = nextToken || '';
   updateHomeLink(token);
 
   if (ws && (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING)) {
@@ -274,7 +267,8 @@ function connect(nextToken) {
   setAttestation('');
 
   const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-  const wsUrl = `${proto}//${window.location.host}/ws/session/${encodeURIComponent(appName)}?token=${encodeURIComponent(token)}`;
+  let wsUrl = `${proto}//${window.location.host}/ws/session/${encodeURIComponent(appName)}`;
+  if (token) wsUrl += `?token=${encodeURIComponent(token)}`;
   ws = new WebSocket(wsUrl);
 
   ws.onopen = () => {
@@ -326,7 +320,13 @@ function connect(nextToken) {
   };
 
   ws.onerror = () => {
-    setStatus('err', 'Connection error', 'Check the token and whether the container is still running.');
+    setStatus(
+      'err',
+      'Connection error',
+      token
+        ? 'Check the token and whether the container is still running.'
+        : 'Log in again or enter a GitHub token if cookie auth is unavailable.'
+    );
   };
 }
 
@@ -361,11 +361,11 @@ clearButton.addEventListener('click', () => {
 });
 
 if (token) {
-  setStatus('warn', 'Connecting', `Opening ${appName || 'shell'} session...`);
-  connect(token);
+  tokenInput.value = token;
 } else {
-  setStatus('idle', 'Waiting', 'Enter a GitHub token to attach to this container.');
+  setStatus('warn', 'Connecting', `Opening ${appName || 'shell'} session...`);
 }
+connect(tokenInput.value.trim());
 </script>
 </body>
 </html>

--- a/agent/web/terminal.html
+++ b/agent/web/terminal.html
@@ -2,150 +2,370 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <title>DD Terminal</title>
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/xterm@5.3.0/css/xterm.min.css">
 <style>
-  body { margin: 0; background: #1e1e2e; display: flex; flex-direction: column; height: 100vh; }
-  #status { color: #a6adc8; font-family: monospace; padding: 8px 12px; font-size: 13px; }
-  #status .ok { color: #a6e3a1; }
-  #status .err { color: #f38ba8; }
-  #status .warn { color: #f9e2af; }
-  #attestation { color: #89b4fa; font-family: monospace; padding: 0 12px 8px; font-size: 12px; display: none; }
-  #terminal { flex: 1; }
+  * { box-sizing: border-box; }
+
+  body {
+    margin: 0;
+    background: #fff;
+    color: #111827;
+    font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  }
+
+  main {
+    min-height: 100dvh;
+    width: min(960px, 100%);
+    margin: 0 auto;
+    padding: 12px;
+    display: grid;
+    grid-template-rows: auto auto 1fr auto;
+    gap: 12px;
+  }
+
+  header {
+    display: grid;
+    gap: 6px;
+  }
+
+  h1 {
+    margin: 0;
+    font-size: 24px;
+    line-height: 1.05;
+    word-break: break-word;
+  }
+
+  p, a, input, button {
+    font-size: 0.95rem;
+  }
+
+  .row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+
+  a {
+    color: #1d4ed8;
+    text-decoration-thickness: 1px;
+  }
+
+  .muted {
+    color: #4b5563;
+  }
+
+  form {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 8px;
+  }
+
+  input,
+  button {
+    font: inherit;
+  }
+
+  input {
+    width: 100%;
+    min-width: 0;
+    height: 42px;
+    padding: 0 12px;
+    border: 1px solid #d1d5db;
+    background: #fff;
+    color: inherit;
+  }
+
+  button {
+    height: 42px;
+    padding: 0 14px;
+    border: 1px solid #d1d5db;
+    background: #fff;
+    color: inherit;
+  }
+
+  button.primary,
+  button:focus-visible {
+    background: #1d4ed8;
+    border-color: #1d4ed8;
+    color: #fff;
+  }
+
+  .terminal {
+    border: 1px solid #d1d5db;
+    overflow: hidden;
+  }
+
+  .terminal-frame {
+    min-height: min(68dvh, 720px);
+    padding: 10px;
+    background: #111827;
+  }
+
+  #terminal {
+    height: min(68dvh, 700px);
+  }
+
+  .controls {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+
+  .controls button {
+    min-width: 72px;
+  }
+
+  @media (min-width: 720px) {
+    main { padding: 20px; }
+    .terminal-frame { min-height: 72dvh; }
+    #terminal { height: 72dvh; }
+  }
 </style>
 </head>
 <body>
-<div id="status">connecting...</div>
-<div id="attestation"></div>
-<div id="terminal"></div>
+<main>
+  <header>
+    <a id="homeLink" href="/">Back to admin</a>
+    <h1 id="appName">Session</h1>
+    <div class="row">
+      <strong id="status">Waiting</strong>
+      <span class="muted" id="detail">Enter a GitHub token to attach to this container.</span>
+    </div>
+    <p class="muted" id="attestation"></p>
+  </header>
+
+  <section>
+    <form id="tokenForm">
+      <input id="tokenInput" type="password" placeholder="GitHub token" autocomplete="off" autocapitalize="none" spellcheck="false">
+      <button type="submit" class="primary" id="connectButton">Connect</button>
+    </form>
+  </section>
+
+  <section class="terminal">
+    <div class="terminal-frame" id="terminalFrame">
+      <div id="terminal"></div>
+    </div>
+  </section>
+
+  <nav class="controls">
+    <button type="button" class="primary" id="keyboardButton">Keyboard</button>
+    <button type="button" data-send="\u0003">Ctrl+C</button>
+    <button type="button" data-send="\t">Tab</button>
+    <button type="button" data-send="\u001b">Esc</button>
+    <button type="button" id="clearButton">Clear</button>
+  </nav>
+</main>
 
 <script src="https://cdn.jsdelivr.net/npm/xterm@5.3.0/lib/xterm.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/xterm-addon-fit@0.8.0/lib/xterm-addon-fit.min.js"></script>
 <script>
-// DD Terminal — End-to-end encrypted session via Noise protocol over WebSocket.
-//
-// Flow:
-// 1. WebSocket connects to agent
-// 2. Noise_XX handshake over WebSocket binary frames
-//    - Browser is initiator, agent is responder
-//    - Agent sends attestation (TDX quote etc.) as handshake payload
-// 3. After handshake: all terminal I/O is Noise-encrypted
-//    - Keystrokes → encrypt → WebSocket → agent decrypts → container stdin
-//    - Container stdout → agent encrypts → WebSocket → browser decrypts → xterm.js
-//
-// Currently uses plaintext JSON while noise-c.wasm integration is pending.
-// The WebSocket handler on the agent side supports both modes:
-// - Binary frames = Noise-encrypted (future)
-// - Text frames = plaintext JSON (current, TLS via CF tunnel provides transport security)
+const path = window.location.pathname;
+const appName = decodeURIComponent(path.split('/session/')[1] || '');
+const params = new URLSearchParams(window.location.search);
+
+const homeLink = document.getElementById('homeLink');
+const appNameEl = document.getElementById('appName');
+const statusEl = document.getElementById('status');
+const detailEl = document.getElementById('detail');
+const attestationEl = document.getElementById('attestation');
+const tokenForm = document.getElementById('tokenForm');
+const tokenInput = document.getElementById('tokenInput');
+const keyboardButton = document.getElementById('keyboardButton');
+const clearButton = document.getElementById('clearButton');
+const terminalFrame = document.getElementById('terminalFrame');
+
+appNameEl.textContent = appName || 'Shell';
 
 const term = new Terminal({
   cursorBlink: true,
-  theme: { background: '#1e1e2e', foreground: '#cdd6f4', cursor: '#f5e0dc' },
-  fontFamily: 'JetBrains Mono, Menlo, monospace',
-  fontSize: 14,
+  fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+  fontSize: 15,
+  scrollback: 3000,
+  theme: {
+    background: '#101828',
+    foreground: '#f8fafc',
+    cursor: '#f8fafc',
+  },
 });
+
 const fitAddon = new FitAddon.FitAddon();
 term.loadAddon(fitAddon);
 term.open(document.getElementById('terminal'));
-fitAddon.fit();
-window.addEventListener('resize', () => fitAddon.fit());
 
-const status = document.getElementById('status');
-const attestationEl = document.getElementById('attestation');
-
-// Parse app name and token from URL
-const path = window.location.pathname;
-const appName = path.split('/session/')[1] || '';
-const params = new URLSearchParams(window.location.search);
-let token = params.get('token') || localStorage.getItem('dd_token');
-
-if (!token) {
-  token = prompt('GitHub token (from: gh auth token)');
-  if (token) localStorage.setItem('dd_token', token);
-}
-
-if (!token) {
-  status.innerHTML = '<span class="err">no token provided</span>';
-  throw new Error('no token');
-}
-
-// Connect WebSocket with token
-const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-const wsUrl = `${proto}//${window.location.host}/ws/session/${appName}?token=${encodeURIComponent(token)}`;
-
-status.innerHTML = `connecting to <span class="ok">${appName || 'shell'}</span>...`;
-
-const ws = new WebSocket(wsUrl);
-
-ws.onopen = () => {
-  status.innerHTML = `handshake with <span class="ok">${appName}</span>...`;
-  // Future: initiate Noise_XX handshake here
-  // For now, the agent auto-attaches on WebSocket connect
-};
-
-ws.onmessage = (event) => {
-  try {
-    const text = typeof event.data === 'string' ? event.data : new TextDecoder().decode(event.data);
-    const msg = JSON.parse(text);
-
-    switch (msg.type) {
-      case 'stdout':
-      case 'stderr': {
-        const output = typeof msg.data === 'string'
-          ? msg.data
-          : String.fromCharCode(...msg.data);
-        term.write(output);
-        break;
-      }
-      case 'ok':
-        if (msg.status) {
-          status.innerHTML = `<span class="ok">${msg.status}</span>`;
-        }
-        // Show attestation info if present
-        if (msg.attestation_type) {
-          attestationEl.style.display = 'block';
-          attestationEl.textContent = `attestation: ${msg.attestation_type}`;
-          if (msg.attestation_type === 'tdx') {
-            attestationEl.textContent += ' (hardware-verified enclave)';
-          }
-        }
-        term.focus();
-        break;
-      case 'error':
-        status.innerHTML = `<span class="err">${msg.message}</span>`;
-        break;
-      case 'attestation':
-        // Future: verify TDX quote client-side
-        attestationEl.style.display = 'block';
-        attestationEl.textContent = `attestation: ${msg.attestation_type || 'unknown'}`;
-        if (msg.vm_name) attestationEl.textContent += ` (${msg.vm_name})`;
-        break;
+function fitTerminal() {
+  requestAnimationFrame(() => {
+    try {
+      fitAddon.fit();
+    } catch (_) {
+      // xterm throws if the container is temporarily hidden or not yet measurable.
     }
-  } catch {
-    // Raw text fallback
-    const text = typeof event.data === 'string' ? event.data : new TextDecoder().decode(event.data);
-    term.write(text);
-  }
-};
+  });
+}
 
-ws.onclose = () => {
-  status.innerHTML = '<span class="err">disconnected</span>';
-  term.write('\r\n[session ended]\r\n');
-};
+fitTerminal();
+window.addEventListener('resize', fitTerminal);
+if (window.visualViewport) {
+  window.visualViewport.addEventListener('resize', fitTerminal);
+}
 
-ws.onerror = () => {
-  status.innerHTML = '<span class="err">connection error</span>';
-};
+function setStatus(tone, text, detail) {
+  statusEl.textContent = text;
+  statusEl.style.color =
+    tone === 'ok' ? '#166534' :
+    tone === 'warn' ? '#92400e' :
+    tone === 'err' ? '#991b1b' :
+    '#111827';
+  detailEl.textContent = detail || '';
+}
 
-// Terminal input → agent (will be Noise-encrypted in future)
-term.onData((data) => {
-  if (ws.readyState === WebSocket.OPEN) {
+function setAttestation(text) {
+  attestationEl.textContent = text || '';
+}
+
+function updateHomeLink(token) {
+  const url = new URL('/', window.location.origin);
+  if (token) url.searchParams.set('token', token);
+  homeLink.href = url.pathname + url.search;
+}
+
+function focusTerminal() {
+  term.focus();
+  fitTerminal();
+}
+
+let token = params.get('token') || localStorage.getItem('dd_token') || '';
+let ws = null;
+
+if (token) {
+  tokenInput.value = token;
+  localStorage.setItem('dd_token', token);
+}
+
+updateHomeLink(token);
+
+function sendInput(data) {
+  if (ws && ws.readyState === WebSocket.OPEN) {
     ws.send(JSON.stringify({
       type: 'stdin',
-      data: Array.from(new TextEncoder().encode(data))
+      data: Array.from(new TextEncoder().encode(data)),
     }));
   }
+}
+
+function connect(nextToken) {
+  if (!nextToken) {
+    setStatus('err', 'Token required', 'Enter a GitHub token to attach to this container.');
+    tokenInput.focus();
+    return;
+  }
+
+  token = nextToken;
+  localStorage.setItem('dd_token', token);
+  updateHomeLink(token);
+
+  if (ws && (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING)) {
+    ws.close();
+  }
+
+  setStatus('warn', 'Connecting', `Opening ${appName || 'shell'} session...`);
+  setAttestation('');
+
+  const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+  const wsUrl = `${proto}//${window.location.host}/ws/session/${encodeURIComponent(appName)}?token=${encodeURIComponent(token)}`;
+  ws = new WebSocket(wsUrl);
+
+  ws.onopen = () => {
+    setStatus('warn', 'Handshake', 'Waiting for the shell to become ready...');
+  };
+
+  ws.onmessage = (event) => {
+    try {
+      const text = typeof event.data === 'string' ? event.data : new TextDecoder().decode(event.data);
+      const msg = JSON.parse(text);
+
+      switch (msg.type) {
+        case 'stdout':
+        case 'stderr': {
+          const output = typeof msg.data === 'string'
+            ? msg.data
+            : String.fromCharCode(...msg.data);
+          term.write(output);
+          break;
+        }
+        case 'ok':
+          setStatus('ok', msg.status || 'Connected', 'Session ready.');
+          if (msg.attestation_type) {
+            let label = `attestation: ${msg.attestation_type}`;
+            if (msg.attestation_type === 'tdx') label += ' (hardware-verified enclave)';
+            setAttestation(label);
+          }
+          focusTerminal();
+          break;
+        case 'error':
+          setStatus('err', 'Error', msg.message || 'Session error.');
+          break;
+        case 'attestation': {
+          let label = `attestation: ${msg.attestation_type || 'unknown'}`;
+          if (msg.vm_name) label += ` (${msg.vm_name})`;
+          setAttestation(label);
+          break;
+        }
+      }
+    } catch (_) {
+      const text = typeof event.data === 'string' ? event.data : new TextDecoder().decode(event.data);
+      term.write(text);
+    }
+  };
+
+  ws.onclose = () => {
+    setStatus('err', 'Disconnected', 'Session ended.');
+    term.write('\r\n[session ended]\r\n');
+  };
+
+  ws.onerror = () => {
+    setStatus('err', 'Connection error', 'Check the token and whether the container is still running.');
+  };
+}
+
+tokenForm.addEventListener('submit', (event) => {
+  event.preventDefault();
+  connect(tokenInput.value.trim());
 });
+
+term.onData((data) => {
+  sendInput(data);
+});
+
+terminalFrame.addEventListener('click', focusTerminal);
+keyboardButton.addEventListener('click', () => {
+  if (!tokenInput.value.trim()) {
+    tokenInput.focus();
+    return;
+  }
+  focusTerminal();
+});
+
+for (const button of document.querySelectorAll('[data-send]')) {
+  button.addEventListener('click', () => {
+    focusTerminal();
+    sendInput(button.dataset.send);
+  });
+}
+
+clearButton.addEventListener('click', () => {
+  term.clear();
+  focusTerminal();
+});
+
+if (token) {
+  setStatus('warn', 'Connecting', `Opening ${appName || 'shell'} session...`);
+  connect(token);
+} else {
+  setStatus('idle', 'Waiting', 'Enter a GitHub token to attach to this container.');
+}
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- make the admin dashboard and session page mobile-friendly with a simpler document-style layout
- add GitHub OAuth browser login with cookie-backed sessions for the protected web pages
- wire staging and production deploy workflows to inject GitHub OAuth settings into dd-agent
- update the staging integration check to validate the auth redirect instead of anonymous session access

## GitHub environment config
Already set:
- `staging` var `DD_GITHUB_CALLBACK_URL=https://app-staging.devopsdefender.com/auth/github/callback`
- `production` var `DD_GITHUB_CALLBACK_URL=https://app.devopsdefender.com/auth/github/callback`

Still needed:
- `staging` var `DD_GITHUB_CLIENT_ID`
- `production` var `DD_GITHUB_CLIENT_ID`
- `staging` secret `DD_GITHUB_CLIENT_SECRET`
- `production` secret `DD_GITHUB_CLIENT_SECRET`

## Testing
- cargo fmt --all
- cargo check