### PR TITLE
Fix: UUID tunnel names — staging and production can't collide

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -80,7 +80,7 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.DD_CP_CF_ACCOUNT_ID }}
         run: |
           tunnels=$(curl -sf "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/cfd_tunnel?is_deleted=false" \
-            -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" | jq -r '.result[] | select(.name | startswith("dd-devopsdefender-dd-prod-")) | .id') || true
+            -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" | jq -r '.result[] | select(.name | startswith("dd-production-")) | .id') || true
           for id in $tunnels; do
             echo "Deleting tunnel: $id"
             curl -sf -X DELETE "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/cfd_tunnel/${id}/connections" \
@@ -128,6 +128,7 @@ jobs:
           chmod +x /usr/local/bin/dd-agent
 
           export DD_OWNER=devopsdefender
+          export DD_ENV=production
           export DD_CF_API_TOKEN=${CLOUDFLARE_API_TOKEN}
           export DD_CF_ACCOUNT_ID=${CLOUDFLARE_ACCOUNT_ID}
           export DD_CF_ZONE_ID=${CLOUDFLARE_ZONE_ID}

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -87,7 +87,7 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.DD_CP_CF_ACCOUNT_ID }}
         run: |
           tunnels=$(curl -sf "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/cfd_tunnel?is_deleted=false" \
-            -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" | jq -r '.result[] | select(.name | startswith("dd-devopsdefender-dd-staging-")) | .id') || true
+            -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" | jq -r '.result[] | select(.name | startswith("dd-staging-")) | .id') || true
           for id in $tunnels; do
             echo "Deleting tunnel: $id"
             curl -sf -X DELETE "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/cfd_tunnel/${id}/connections" \
@@ -136,6 +136,7 @@ jobs:
           chmod +x /usr/local/bin/dd-agent
 
           export DD_OWNER=devopsdefender
+          export DD_ENV=staging
           export DD_CF_API_TOKEN=${CLOUDFLARE_API_TOKEN}
           export DD_CF_ACCOUNT_ID=${CLOUDFLARE_ACCOUNT_ID}
           export DD_CF_ZONE_ID=${CLOUDFLARE_ZONE_ID}

--- a/agent/src/bin/dd-agent/main.rs
+++ b/agent/src/bin/dd-agent/main.rs
@@ -75,7 +75,7 @@ async fn run_agent_mode(cfg: AgentRuntimeConfig) {
         let cf = dd_agent::tunnel::CfConfig::from_env().unwrap();
         eprintln!("dd-agent: self-registering via CF API");
         let http = reqwest::Client::new();
-        match dd_agent::tunnel::create_agent_tunnel(&http, &cf, &owner, &vm_name).await {
+        match dd_agent::tunnel::create_agent_tunnel(&http, &cf, &agent_id, &vm_name).await {
             Ok(info) => {
                 eprintln!("dd-agent: tunnel created — hostname={}", info.hostname);
                 if let Err(e) = start_cloudflared(&info.tunnel_token).await {

--- a/agent/src/bin/dd-register/main.rs
+++ b/agent/src/bin/dd-register/main.rs
@@ -160,14 +160,15 @@ async fn handle_registration(socket: WebSocket, cf: CfConfig) {
 
     // Create CF tunnel
     let client = reqwest::Client::new();
-    let tunnel_info =
-        match tunnel::create_agent_tunnel(&client, &cf, &reg.owner, &reg.vm_name).await {
-            Ok(info) => info,
-            Err(e) => {
-                eprintln!("dd-register: tunnel creation failed: {e}");
-                return;
-            }
-        };
+    let agent_id = uuid::Uuid::new_v4().to_string();
+    let tunnel_info = match tunnel::create_agent_tunnel(&client, &cf, &agent_id, &reg.vm_name).await
+    {
+        Ok(info) => info,
+        Err(e) => {
+            eprintln!("dd-register: tunnel creation failed: {e}");
+            return;
+        }
+    };
 
     eprintln!(
         "dd-register: tunnel created — hostname={}",

--- a/agent/src/tunnel.rs
+++ b/agent/src/tunnel.rs
@@ -41,15 +41,17 @@ pub struct TunnelInfo {
 const CF_API: &str = "https://api.cloudflare.com/client/v4";
 
 /// Create a CF tunnel for an agent, configure ingress, create DNS CNAME.
-/// If `hostname_override` is set, use it instead of `{vm_name}.{domain}`.
+/// Tunnel name uses agent_id (UUID) to guarantee uniqueness.
+/// DD_HOSTNAME controls the public DNS name users see.
 pub async fn create_agent_tunnel(
     client: &reqwest::Client,
     cf: &CfConfig,
-    owner: &str,
+    agent_id: &str,
     vm_name: &str,
 ) -> Result<TunnelInfo, String> {
     let hostname_override = std::env::var("DD_HOSTNAME").ok().filter(|s| !s.is_empty());
-    let tunnel_name = format!("dd-{owner}-{vm_name}");
+    let env_label = std::env::var("DD_ENV").unwrap_or_else(|_| "dev".into());
+    let tunnel_name = format!("dd-{env_label}-{agent_id}");
     let tunnel_secret = uuid::Uuid::new_v4().to_string().replace('-', "");
     let hostname = hostname_override.unwrap_or_else(|| format!("{vm_name}.{}", cf.domain));
 
@@ -175,13 +177,13 @@ pub async fn delete_dns_record(
 pub async fn remove_agent(
     client: &reqwest::Client,
     cf: &CfConfig,
-    owner: &str,
-    vm_name: &str,
+    agent_id: &str,
+    hostname: &str,
 ) -> Result<(), String> {
-    let tunnel_name = format!("dd-{owner}-{vm_name}");
-    let hostname = format!("{vm_name}.{}", cf.domain);
+    let env_label = std::env::var("DD_ENV").unwrap_or_else(|_| "dev".into());
+    let tunnel_name = format!("dd-{env_label}-{agent_id}");
     delete_tunnel_by_name(client, cf, &tunnel_name).await?;
-    delete_dns_record(client, cf, &hostname).await?;
+    delete_dns_record(client, cf, hostname).await?;
     Ok(())
 }
 


### PR DESCRIPTION
Both environments had hostname 'unknown', creating identical tunnel names. Now tunnel names are dd-{env}-{uuid}. Staging cleanup only touches dd-staging-*, production only touches dd-production-*.