### PR TITLE
dd-register as fleet entry point with dashboard

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -142,6 +142,9 @@ jobs:
           export DD_CF_ZONE_ID=${CLOUDFLARE_ZONE_ID}
           export DD_CF_DOMAIN=${DD_DOMAIN}
           export DD_HOSTNAME=${HOSTNAME}
+          export DD_GITHUB_CLIENT_ID=${DD_GITHUB_CLIENT_ID}
+          export DD_GITHUB_CLIENT_SECRET=${DD_GITHUB_CLIENT_SECRET}
+          export DD_GITHUB_CALLBACK_URL=${DD_GITHUB_CALLBACK_URL}
 
           # Boot a demo shell workload
           export DD_BOOT_CMD=bash

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -54,7 +54,6 @@ jobs:
             --prerelease \
             target/release/dd-agent
 
-          # Get the download URL
           url=$(gh release view "$tag" --json assets --jq '.assets[] | select(.name=="dd-agent") | .url')
           echo "url=${url}" >> "$GITHUB_OUTPUT"
           echo "Binary URL: ${url}"
@@ -131,22 +130,20 @@ jobs:
           curl -fsSL -o /usr/local/bin/cloudflared https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64
           chmod +x /usr/local/bin/cloudflared
 
-          # Download dd-agent from GitHub release
+          # Download dd-agent
           curl -fsSL -o /usr/local/bin/dd-agent "${BINARY_URL}" -H "Accept: application/octet-stream"
           chmod +x /usr/local/bin/dd-agent
 
           export DD_OWNER=devopsdefender
+          export DD_AGENT_MODE=register
           export DD_ENV=staging
           export DD_CF_API_TOKEN=${CLOUDFLARE_API_TOKEN}
           export DD_CF_ACCOUNT_ID=${CLOUDFLARE_ACCOUNT_ID}
           export DD_CF_ZONE_ID=${CLOUDFLARE_ZONE_ID}
           export DD_CF_DOMAIN=${DD_DOMAIN}
           export DD_HOSTNAME=${HOSTNAME}
-          export DD_GITHUB_CLIENT_ID=${DD_GITHUB_CLIENT_ID}
-          export DD_GITHUB_CLIENT_SECRET=${DD_GITHUB_CLIENT_SECRET}
-          export DD_GITHUB_CALLBACK_URL=${DD_GITHUB_CALLBACK_URL}
 
-          # Boot a shell as the demo workload
+          # Boot a demo shell workload
           export DD_BOOT_CMD=bash
           export DD_BOOT_APP=demo
 

--- a/agent/src/bin/dd-agent/config.rs
+++ b/agent/src/bin/dd-agent/config.rs
@@ -7,6 +7,7 @@ use std::path::PathBuf;
 #[serde(rename_all = "kebab-case")]
 pub enum AgentMode {
     Agent,
+    Register,
     ControlPlane,
     Measure,
 }
@@ -15,6 +16,7 @@ impl AgentMode {
     fn from_str_loose(s: &str) -> Option<Self> {
         match s.to_lowercase().replace('_', "-").as_str() {
             "agent" => Some(Self::Agent),
+            "register" => Some(Self::Register),
             "control-plane" | "controlplane" | "cp" => Some(Self::ControlPlane),
             "measure" => Some(Self::Measure),
             _ => None,

--- a/agent/src/bin/dd-agent/main.rs
+++ b/agent/src/bin/dd-agent/main.rs
@@ -23,7 +23,7 @@ async fn main() {
     eprintln!("dd-agent: starting in {:?} mode", cfg.mode);
 
     match cfg.mode {
-        AgentMode::Agent => run_agent_mode(cfg).await,
+        AgentMode::Agent | AgentMode::Register => run_agent_mode(cfg).await,
         AgentMode::ControlPlane => run_control_plane_mode(cfg),
         AgentMode::Measure => measure::run_measure_mode(),
     }
@@ -184,6 +184,13 @@ async fn run_agent_mode(cfg: AgentRuntimeConfig) {
         eprintln!("dd-agent: boot workload {id} {status}");
     }
 
+    let register_mode = cfg.mode == config::AgentMode::Register;
+    let cf_config = if register_mode {
+        dd_agent::tunnel::CfConfig::from_env().ok()
+    } else {
+        None
+    };
+
     let state = AgentState {
         owner,
         vm_name,
@@ -195,9 +202,28 @@ async fn run_agent_mode(cfg: AgentRuntimeConfig) {
         oauth,
         browser_sessions,
         pending_oauth_states,
+        register_mode,
+        agent_registry: Arc::new(Mutex::new(HashMap::new())),
+        cf_config,
     };
 
-    // HTTP server (read-only: health, list deployments, logs)
+    // In register mode, add ourselves to the registry
+    if register_mode {
+        let hostname = std::env::var("DD_HOSTNAME").unwrap_or_else(|_| "localhost".into());
+        state.agent_registry.lock().await.insert(
+            state.agent_id.clone(),
+            dd_agent::server::RegisteredAgent {
+                agent_id: state.agent_id.clone(),
+                hostname,
+                vm_name: state.vm_name.clone(),
+                attestation_type: state.attestation_type.clone(),
+                registered_at: chrono::Utc::now().to_rfc3339(),
+            },
+        );
+        eprintln!("dd-agent: registered self in fleet registry");
+    }
+
+    // HTTP server
     let http_port = port;
     let app = dd_agent::server::build_router(state.clone());
     let bind_addr = format!("0.0.0.0:{http_port}");

--- a/agent/src/bin/dd-register/main.rs
+++ b/agent/src/bin/dd-register/main.rs
@@ -1,16 +1,32 @@
-//! Registration service — accepts Noise-over-WebSocket connections from agents,
-//! verifies attestation, provisions CF tunnels, delivers tokens.
+//! DD Register — fleet entry point.
 //!
-//! Single HTTP server with one WebSocket endpoint. No database, no state.
+//! Runs on the bootstrap VM. Self-registers a CF tunnel, serves the fleet
+//! dashboard, and handles agent registrations. Agents connect via Noise
+//! WebSocket to get their own tunnel tokens.
 
 use axum::extract::ws::{Message, WebSocket};
 use axum::extract::WebSocketUpgrade;
+use axum::response::Html;
 use axum::routing::get;
 use axum::Router;
 use futures_util::{SinkExt, StreamExt};
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::Mutex;
 
 use dd_agent::noise::{self, AttestationPayload, BootstrapConfig};
 use dd_agent::tunnel::{self, CfConfig};
+
+#[derive(Debug, Clone, serde::Serialize)]
+struct AgentRecord {
+    agent_id: String,
+    hostname: String,
+    vm_name: String,
+    attestation_type: String,
+    registered_at: String,
+}
+
+type AgentRegistry = Arc<Mutex<HashMap<String, AgentRecord>>>;
 
 #[derive(Debug, serde::Deserialize)]
 struct RegisterRequest {
@@ -23,7 +39,7 @@ async fn main() {
     let port: u16 = std::env::var("DD_REGISTER_PORT")
         .ok()
         .and_then(|s| s.parse().ok())
-        .unwrap_or(9090);
+        .unwrap_or(8080);
 
     let cf = match CfConfig::from_env() {
         Ok(c) => c,
@@ -34,19 +50,78 @@ async fn main() {
         }
     };
 
+    // Self-register: create our own CF tunnel
+    let hostname = std::env::var("DD_HOSTNAME").unwrap_or_else(|_| {
+        eprintln!("dd-register: DD_HOSTNAME not set");
+        std::process::exit(1);
+    });
+
+    let register_id = uuid::Uuid::new_v4().to_string();
+    eprintln!("dd-register: self-registering tunnel for {hostname}");
+
+    let http_client = reqwest::Client::new();
+    let tunnel_info =
+        match tunnel::create_agent_tunnel(&http_client, &cf, &register_id, "register").await {
+            Ok(info) => info,
+            Err(e) => {
+                eprintln!("dd-register: self-registration failed: {e}");
+                std::process::exit(1);
+            }
+        };
+
+    eprintln!("dd-register: tunnel created — {}", tunnel_info.hostname);
+
+    // Spawn cloudflared
+    let token = tunnel_info.tunnel_token.clone();
+    tokio::spawn(async move {
+        eprintln!("dd-register: starting cloudflared");
+        let mut child = tokio::process::Command::new("cloudflared")
+            .args(["tunnel", "--no-autoupdate", "run", "--token", &token])
+            .spawn()
+            .expect("failed to spawn cloudflared");
+        let _ = child.wait().await;
+        eprintln!("dd-register: cloudflared exited");
+    });
+
+    let registry: AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
+    let env_label = std::env::var("DD_ENV").unwrap_or_else(|_| "dev".into());
+
+    let dashboard_registry = registry.clone();
+    let dashboard_cf = cf.clone();
+    let dashboard_env = env_label.clone();
+    let dashboard_hostname = hostname.clone();
+
+    let register_cf = cf.clone();
+    let register_registry = registry.clone();
+
     let app = Router::new()
-        .route("/health", get(|| async { "ok" }))
+        .route(
+            "/",
+            get(move || {
+                let reg = dashboard_registry.clone();
+                let cf = dashboard_cf.clone();
+                let env = dashboard_env.clone();
+                let host = dashboard_hostname.clone();
+                async move { fleet_dashboard(reg, cf, env, host).await }
+            }),
+        )
+        .route(
+            "/health",
+            get(|| async { axum::Json(serde_json::json!({"ok": true, "service": "dd-register"})) }),
+        )
         .route(
             "/register",
             get(move |ws: WebSocketUpgrade| {
-                let cf = cf.clone();
-                async move { ws.on_upgrade(move |socket| handle_registration(socket, cf)) }
+                let cf = register_cf.clone();
+                let reg = register_registry.clone();
+                async move { ws.on_upgrade(move |socket| handle_registration(socket, cf, reg)) }
             }),
         );
 
     let addr = format!("0.0.0.0:{port}");
     eprintln!("dd-register: listening on {addr}");
-    eprintln!("dd-register: agents connect to ws://host:{port}/register");
+    eprintln!("dd-register: dashboard at https://{hostname}/");
+    eprintln!("dd-register: agents register at wss://{hostname}/register");
 
     let listener = tokio::net::TcpListener::bind(&addr)
         .await
@@ -54,7 +129,88 @@ async fn main() {
     axum::serve(listener, app).await.expect("server error");
 }
 
-async fn handle_registration(socket: WebSocket, cf: CfConfig) {
+// ── Fleet Dashboard ──────────────────────────────────────────────────────
+
+async fn fleet_dashboard(
+    registry: AgentRegistry,
+    _cf: CfConfig,
+    env: String,
+    hostname: String,
+) -> Html<String> {
+    let agents = registry.lock().await;
+
+    let mut rows = String::new();
+    for agent in agents.values() {
+        rows.push_str(&format!(
+            r#"<tr>
+                <td><a href="https://{hostname}">{hostname}</a></td>
+                <td>{vm_name}</td>
+                <td><span style="color:#a6e3a1">registered</span></td>
+                <td>{att}</td>
+                <td>{registered}</td>
+            </tr>"#,
+            hostname = agent.hostname,
+            vm_name = agent.vm_name,
+            att = agent.attestation_type,
+            registered = agent
+                .registered_at
+                .split('T')
+                .next()
+                .unwrap_or(&agent.registered_at),
+        ));
+    }
+
+    Html(format!(
+        r#"<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>DD Fleet — {env}</title>
+<style>
+  body {{ margin: 0; background: #1e1e2e; color: #cdd6f4; font-family: 'JetBrains Mono', monospace; padding: 24px; }}
+  h1 {{ color: #89b4fa; margin: 0 0 4px; font-size: 20px; }}
+  .subtitle {{ color: #585b70; font-size: 12px; margin-bottom: 16px; }}
+  .meta {{ color: #a6adc8; font-size: 13px; margin-bottom: 24px; }}
+  .meta .ok {{ color: #a6e3a1; }}
+  .section {{ color: #a6adc8; font-size: 12px; text-transform: uppercase; margin: 20px 0 8px; }}
+  table {{ border-collapse: collapse; width: 100%; }}
+  th {{ text-align: left; color: #a6adc8; font-weight: normal; font-size: 12px; text-transform: uppercase; padding: 8px 12px; border-bottom: 1px solid #313244; }}
+  td {{ padding: 8px 12px; border-bottom: 1px solid #313244; font-size: 14px; }}
+  a {{ color: #89b4fa; text-decoration: none; }}
+  a:hover {{ text-decoration: underline; }}
+  .empty {{ color: #585b70; padding: 24px; text-align: center; }}
+</style>
+</head>
+<body>
+<h1>DevOps Defender</h1>
+<div class="subtitle">{env} fleet</div>
+<div class="meta">
+  <span class="ok">healthy</span> &middot; {hostname} &middot; {count} agent(s) registered
+</div>
+
+<div class="section">Agents ({count})</div>
+{table}
+</body>
+</html>"#,
+        env = env,
+        hostname = hostname,
+        count = agents.len(),
+        table = if agents.is_empty() {
+            r#"<div class="empty">no agents registered &mdash; start a dd-agent with DD_REGISTER_URL pointing here</div>"#.to_string()
+        } else {
+            format!(
+                r#"<table>
+<tr><th>hostname</th><th>vm</th><th>status</th><th>attestation</th><th>registered</th></tr>
+{rows}
+</table>"#
+            )
+        },
+    ))
+}
+
+// ── Agent Registration ───────────────────────────────────────────────────
+
+async fn handle_registration(socket: WebSocket, cf: CfConfig, registry: AgentRegistry) {
     let (mut ws_tx, mut ws_rx) = socket.split();
 
     let keypair = match noise::generate_keypair() {
@@ -78,19 +234,15 @@ async fn handle_registration(socket: WebSocket, cf: CfConfig) {
 
     let mut buf = vec![0u8; 65535];
 
-    // XX handshake over WebSocket binary frames
-
-    // msg1 from agent
+    // XX handshake
     let msg1 = match ws_rx.next().await {
         Some(Ok(Message::Binary(data))) => data.to_vec(),
         _ => return,
     };
     if noise.read_message(&msg1, &mut buf).is_err() {
-        eprintln!("dd-register: handshake msg1 failed");
         return;
     }
 
-    // msg2 (no payload from register side)
     let mut msg2_buf = vec![0u8; 65535];
     let msg2_len = match noise.write_message(&[], &mut msg2_buf) {
         Ok(n) => n,
@@ -104,29 +256,22 @@ async fn handle_registration(socket: WebSocket, cf: CfConfig) {
         return;
     }
 
-    // msg3 from agent (with attestation payload)
     let msg3 = match ws_rx.next().await {
         Some(Ok(Message::Binary(data))) => data.to_vec(),
         _ => return,
     };
     let payload_len = match noise.read_message(&msg3, &mut buf) {
         Ok(n) => n,
-        Err(_) => {
-            eprintln!("dd-register: handshake msg3 failed");
-            return;
-        }
+        Err(_) => return,
     };
 
     let attestation: AttestationPayload = match serde_json::from_slice(&buf[..payload_len]) {
         Ok(a) => a,
-        Err(_) => {
-            eprintln!("dd-register: parse attestation failed");
-            return;
-        }
+        Err(_) => return,
     };
 
     eprintln!(
-        "dd-register: agent {} attestation: {}",
+        "dd-register: agent {} ({})",
         attestation.vm_name, attestation.attestation_type
     );
 
@@ -135,7 +280,7 @@ async fn handle_registration(socket: WebSocket, cf: CfConfig) {
         Err(_) => return,
     };
 
-    // Read encrypted registration request
+    // Read registration request
     let enc_req = match ws_rx.next().await {
         Some(Ok(Message::Binary(data))) => data.to_vec(),
         _ => return,
@@ -144,42 +289,45 @@ async fn handle_registration(socket: WebSocket, cf: CfConfig) {
         Ok(n) => n,
         Err(_) => return,
     };
-
     let reg: RegisterRequest = match serde_json::from_slice(&buf[..req_len]) {
         Ok(r) => r,
-        Err(_) => {
-            eprintln!("dd-register: parse request failed");
-            return;
-        }
+        Err(_) => return,
     };
 
-    eprintln!(
-        "dd-register: creating tunnel for owner={} vm={}",
-        reg.owner, reg.vm_name
-    );
-
-    // Create CF tunnel
+    // Create tunnel for the agent
     let client = reqwest::Client::new();
     let agent_id = uuid::Uuid::new_v4().to_string();
     let tunnel_info = match tunnel::create_agent_tunnel(&client, &cf, &agent_id, &reg.vm_name).await
     {
         Ok(info) => info,
         Err(e) => {
-            eprintln!("dd-register: tunnel creation failed: {e}");
+            eprintln!("dd-register: tunnel failed: {e}");
             return;
         }
     };
 
     eprintln!(
-        "dd-register: tunnel created — hostname={}",
-        tunnel_info.hostname
+        "dd-register: {} registered at {}",
+        reg.vm_name, tunnel_info.hostname
     );
 
-    // Send encrypted bootstrap config
+    // Record in registry
+    registry.lock().await.insert(
+        agent_id.clone(),
+        AgentRecord {
+            agent_id,
+            hostname: tunnel_info.hostname.clone(),
+            vm_name: reg.vm_name.clone(),
+            attestation_type: attestation.attestation_type,
+            registered_at: chrono::Utc::now().to_rfc3339(),
+        },
+    );
+
+    // Send bootstrap config
     let config = BootstrapConfig {
         owner: reg.owner,
         tunnel_token: tunnel_info.tunnel_token,
-        hostname: tunnel_info.hostname.clone(),
+        hostname: tunnel_info.hostname,
     };
     let config_json = serde_json::to_vec(&config).unwrap();
     let mut enc_resp = vec![0u8; 65535];
@@ -188,9 +336,4 @@ async fn handle_registration(socket: WebSocket, cf: CfConfig) {
             .send(Message::Binary(enc_resp[..len].to_vec().into()))
             .await;
     }
-
-    eprintln!(
-        "dd-register: agent {} registered at {}",
-        attestation.vm_name, tunnel_info.hostname
-    );
 }

--- a/agent/src/process.rs
+++ b/agent/src/process.rs
@@ -98,23 +98,19 @@ pub async fn pull_image(image: &str, app_name: &str) -> Result<ImageConfig, Stri
     Ok(config)
 }
 
-/// Spawn a workload process from a pulled image using chroot.
-/// Mounts /proc, /sys, /dev into the rootfs for a functional environment.
+/// Spawn a workload process from a pulled OCI image.
+/// No chroot — the VM is the isolation boundary. Just run the binary directly.
 pub async fn spawn_workload(
     app_name: &str,
     config: &ImageConfig,
     extra_env: Vec<String>,
     tty: bool,
 ) -> Result<Child, String> {
-    // oci-unpack extracts layers directly into the target dir (no rootfs/ subdir)
-    let rootfs = PathBuf::from(WORKLOADS_DIR).join(app_name);
+    let workdir = PathBuf::from(WORKLOADS_DIR).join(app_name);
 
-    if !rootfs.join("bin").exists() && !rootfs.join("usr").exists() {
-        return Err(format!("rootfs not found at {}", rootfs.display()));
+    if !workdir.exists() {
+        return Err(format!("workload dir not found: {}", workdir.display()));
     }
-
-    // Mount essential filesystems into the chroot
-    setup_chroot_mounts(&rootfs).await?;
 
     // Entrypoint + cmd
     let mut args: Vec<String> = config.entrypoint.clone();
@@ -126,7 +122,20 @@ pub async fn spawn_workload(
 
     let program = args.remove(0);
 
-    // Environment
+    // Resolve the program path — look in the extracted image first, then system PATH
+    let resolved_program = if program.starts_with('/') {
+        // Absolute path — look inside extracted image
+        let in_image = workdir.join(program.trim_start_matches('/'));
+        if in_image.exists() {
+            in_image.to_string_lossy().to_string()
+        } else {
+            program.clone() // Fall back to system
+        }
+    } else {
+        program.clone()
+    };
+
+    // Environment from image config + extras
     let mut env_map: HashMap<String, String> = HashMap::new();
     for kv in &config.env {
         if let Some((k, v)) = kv.split_once('=') {
@@ -138,9 +147,14 @@ pub async fn spawn_workload(
             env_map.insert(k.to_string(), v.to_string());
         }
     }
-    env_map
-        .entry("PATH".into())
-        .or_insert_with(|| "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin".into());
+
+    // Prepend extracted image dirs to PATH so image binaries are found
+    let image_path = format!(
+        "{0}/usr/local/sbin:{0}/usr/local/bin:{0}/usr/sbin:{0}/usr/bin:{0}/sbin:{0}/bin",
+        workdir.display()
+    );
+    let system_path = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
+    env_map.insert("PATH".into(), format!("{image_path}:{system_path}"));
     env_map
         .entry("HOME".into())
         .or_insert_with(|| "/root".into());
@@ -148,24 +162,32 @@ pub async fn spawn_workload(
         .entry("TERM".into())
         .or_insert_with(|| "xterm-256color".into());
 
-    // Ensure log directory exists
     let _ = tokio::fs::create_dir_all("/var/lib/dd/workloads/logs").await;
-
-    // Build the chroot command
-    let chroot_cmd = format!("chroot {} {} {}", rootfs.display(), program, args.join(" "));
 
     let mut cmd = if tty {
         let mut c = Command::new("script");
         c.arg("-qfc");
-        c.arg(&chroot_cmd);
+        c.arg(format!("{} {}", resolved_program, args.join(" ")));
         c.arg("/dev/null");
         c
     } else {
-        let mut c = Command::new("sh");
-        c.arg("-c");
-        c.arg(&chroot_cmd);
+        let mut c = Command::new(&resolved_program);
+        c.args(&args);
         c
     };
+
+    // Set working directory to the image's configured workdir (inside extracted image)
+    let cwd = if !config.working_dir.is_empty() && config.working_dir != "/" {
+        let img_cwd = workdir.join(config.working_dir.trim_start_matches('/'));
+        if img_cwd.exists() {
+            img_cwd
+        } else {
+            workdir.clone()
+        }
+    } else {
+        workdir.clone()
+    };
+    cmd.current_dir(&cwd);
 
     cmd.env_clear();
     for (k, v) in &env_map {
@@ -226,66 +248,6 @@ pub async fn spawn_command(program: &str, args: &[&str], tty: bool) -> Result<Ch
         child.id().unwrap_or(0)
     );
     Ok(child)
-}
-
-/// Mount /proc, /sys, /dev into a chroot rootfs.
-async fn setup_chroot_mounts(rootfs: &Path) -> Result<(), String> {
-    let mounts = [
-        ("proc", "proc", "/proc"),
-        ("sysfs", "sysfs", "/sys"),
-        ("devtmpfs", "devtmpfs", "/dev"),
-        ("devpts", "devpts", "/dev/pts"),
-        ("tmpfs", "tmpfs", "/tmp"),
-        ("tmpfs", "tmpfs", "/run"),
-    ];
-
-    for (fstype, src, target) in &mounts {
-        let mount_point = rootfs.join(target.trim_start_matches('/'));
-        let _ = tokio::fs::create_dir_all(&mount_point).await;
-
-        // Skip if already mounted
-        let status = Command::new("mountpoint")
-            .arg("-q")
-            .arg(&mount_point)
-            .status()
-            .await;
-        if matches!(status, Ok(s) if s.success()) {
-            continue;
-        }
-
-        let result = Command::new("mount")
-            .arg("-t")
-            .arg(fstype)
-            .arg(src)
-            .arg(&mount_point)
-            .status()
-            .await
-            .map_err(|e| format!("mount {target}: {e}"))?;
-
-        if !result.success() {
-            eprintln!("dd-agent: warning: failed to mount {target} in chroot (non-fatal)");
-        }
-    }
-
-    // Bind mount /shared into the chroot
-    let shared_mount = rootfs.join("shared");
-    let _ = tokio::fs::create_dir_all(&shared_mount).await;
-    let _ = tokio::fs::create_dir_all("/var/lib/dd/shared").await;
-    let _ = Command::new("mount")
-        .arg("--bind")
-        .arg("/var/lib/dd/shared")
-        .arg(&shared_mount)
-        .status()
-        .await;
-
-    // Copy resolv.conf for DNS
-    let resolv_src = Path::new("/etc/resolv.conf");
-    let resolv_dst = rootfs.join("etc/resolv.conf");
-    if resolv_src.exists() {
-        let _ = tokio::fs::copy(resolv_src, resolv_dst).await;
-    }
-
-    Ok(())
 }
 
 /// Kill a process by PID.

--- a/agent/src/server.rs
+++ b/agent/src/server.rs
@@ -14,6 +14,7 @@ use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::sync::Mutex;
 
 use crate::common::error::AppError;
+use crate::tunnel::CfConfig;
 
 // ── Types ─────────────────────────────────────────────────────────────────
 
@@ -109,6 +110,18 @@ pub struct PendingOauthState {
     pub expires_at: Instant,
 }
 
+/// Agent record in the fleet registry (register mode only).
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct RegisteredAgent {
+    pub agent_id: String,
+    pub hostname: String,
+    pub vm_name: String,
+    pub attestation_type: String,
+    pub registered_at: String,
+}
+
+pub type AgentRegistry = Arc<Mutex<HashMap<String, RegisteredAgent>>>;
+
 #[derive(Clone)]
 pub struct AgentState {
     pub owner: String,
@@ -121,6 +134,10 @@ pub struct AgentState {
     pub oauth: Option<GithubOAuthConfig>,
     pub browser_sessions: BrowserSessions,
     pub pending_oauth_states: PendingOauthStates,
+    /// Register mode: fleet registry + CF config for creating agent tunnels.
+    pub register_mode: bool,
+    pub agent_registry: AgentRegistry,
+    pub cf_config: Option<CfConfig>,
 }
 
 // ── Auth ──────────────────────────────────────────────────────────────────
@@ -1406,9 +1423,241 @@ async fn num_cpus() -> usize {
         .unwrap_or(1)
 }
 
+// ── Fleet dashboard (register mode) ──────────────────────────────────────
+
+async fn fleet_dashboard(
+    State(state): State<AgentState>,
+    query: axum::extract::Query<DashQuery>,
+    headers: HeaderMap,
+    OriginalUri(uri): OriginalUri,
+) -> Result<Response, AppError> {
+    if !state.owner.is_empty() {
+        match require_browser_token(&state, &headers, query.token.as_deref(), &uri).await {
+            Ok(_) => {}
+            Err(response) => return Ok(response),
+        }
+    }
+
+    Ok(fleet_dashboard_html(&state).await.into_response())
+}
+
+async fn fleet_dashboard_html(state: &AgentState) -> Html<String> {
+    let agents = state.agent_registry.lock().await;
+    let env = std::env::var("DD_ENV").unwrap_or_else(|_| "dev".into());
+
+    let mut rows = String::new();
+    for a in agents.values() {
+        rows.push_str(&format!(
+            r#"<tr>
+                <td><a href="https://{}">{}</a></td>
+                <td>{}</td>
+                <td><span style="color:#a6e3a1">registered</span></td>
+                <td>{}</td>
+                <td>{}</td>
+            </tr>"#,
+            a.hostname,
+            a.hostname,
+            a.vm_name,
+            a.attestation_type,
+            a.registered_at
+                .split('T')
+                .next()
+                .unwrap_or(&a.registered_at),
+        ));
+    }
+
+    let uptime = state.started_at.elapsed().as_secs();
+    let uptime_str = if uptime > 3600 {
+        format!("{}h {}m", uptime / 3600, (uptime % 3600) / 60)
+    } else if uptime > 60 {
+        format!("{}m", uptime / 60)
+    } else {
+        format!("{uptime}s")
+    };
+
+    Html(format!(
+        r#"<!DOCTYPE html>
+<html><head><meta charset="utf-8"><title>DD Fleet — {env}</title>
+<style>
+  body {{ margin:0; background:#1e1e2e; color:#cdd6f4; font-family:'JetBrains Mono',monospace; padding:24px; }}
+  h1 {{ color:#89b4fa; margin:0 0 4px; font-size:20px; }}
+  .sub {{ color:#585b70; font-size:12px; margin-bottom:16px; }}
+  .meta {{ color:#a6adc8; font-size:13px; margin-bottom:24px; }}
+  .meta .ok {{ color:#a6e3a1; }}
+  .section {{ color:#a6adc8; font-size:12px; text-transform:uppercase; margin:20px 0 8px; }}
+  table {{ border-collapse:collapse; width:100%; }}
+  th {{ text-align:left; color:#a6adc8; font-weight:normal; font-size:12px; text-transform:uppercase; padding:8px 12px; border-bottom:1px solid #313244; }}
+  td {{ padding:8px 12px; border-bottom:1px solid #313244; font-size:14px; }}
+  a {{ color:#89b4fa; text-decoration:none; }} a:hover {{ text-decoration:underline; }}
+  .empty {{ color:#585b70; padding:24px; text-align:center; }}
+</style></head><body>
+<h1>DevOps Defender</h1>
+<div class="sub">{env} fleet &middot; {agent_id}</div>
+<div class="meta"><span class="ok">healthy</span> &middot; uptime {uptime} &middot; {count} agent(s)</div>
+<div class="section">Agents</div>
+{table}
+</body></html>"#,
+        env = env,
+        agent_id = &state.agent_id[..8],
+        uptime = uptime_str,
+        count = agents.len(),
+        table = if agents.is_empty() {
+            r#"<div class="empty">no agents registered</div>"#.to_string()
+        } else {
+            format!(
+                r#"<table><tr><th>hostname</th><th>vm</th><th>status</th><th>attestation</th><th>registered</th></tr>{rows}</table>"#
+            )
+        },
+    ))
+}
+
+async fn ws_register(State(state): State<AgentState>, ws: WebSocketUpgrade) -> impl IntoResponse {
+    ws.on_upgrade(move |socket| handle_ws_register(socket, state))
+}
+
+async fn handle_ws_register(socket: WebSocket, state: AgentState) {
+    let cf = match &state.cf_config {
+        Some(cf) => cf.clone(),
+        None => {
+            eprintln!("dd-register: no CF config, can't register agents");
+            return;
+        }
+    };
+
+    let (mut ws_tx, mut ws_rx) = socket.split();
+    let keypair = match crate::noise::generate_keypair() {
+        Ok(k) => k,
+        Err(_) => return,
+    };
+
+    let mut noise = match snow::Builder::new(crate::noise::NOISE_PATTERN.parse().unwrap())
+        .local_private_key(&keypair.private)
+        .and_then(|b| b.build_responder())
+    {
+        Ok(n) => n,
+        Err(_) => return,
+    };
+
+    let mut buf = vec![0u8; 65535];
+
+    // Noise XX handshake
+    let msg1 = match ws_rx.next().await {
+        Some(Ok(Message::Binary(d))) => d.to_vec(),
+        _ => return,
+    };
+    if noise.read_message(&msg1, &mut buf).is_err() {
+        return;
+    }
+
+    let mut msg2 = vec![0u8; 65535];
+    let len = match noise.write_message(&[], &mut msg2) {
+        Ok(n) => n,
+        Err(_) => return,
+    };
+    if ws_tx
+        .send(Message::Binary(msg2[..len].to_vec().into()))
+        .await
+        .is_err()
+    {
+        return;
+    }
+
+    let msg3 = match ws_rx.next().await {
+        Some(Ok(Message::Binary(d))) => d.to_vec(),
+        _ => return,
+    };
+    let payload_len = match noise.read_message(&msg3, &mut buf) {
+        Ok(n) => n,
+        Err(_) => return,
+    };
+
+    let attestation: crate::noise::AttestationPayload =
+        match serde_json::from_slice(&buf[..payload_len]) {
+            Ok(a) => a,
+            Err(_) => return,
+        };
+
+    let mut transport = match noise.into_transport_mode() {
+        Ok(t) => t,
+        Err(_) => return,
+    };
+
+    // Read registration request
+    let enc = match ws_rx.next().await {
+        Some(Ok(Message::Binary(d))) => d.to_vec(),
+        _ => return,
+    };
+    let req_len = match transport.read_message(&enc, &mut buf) {
+        Ok(n) => n,
+        Err(_) => return,
+    };
+
+    #[derive(serde::Deserialize)]
+    struct RegReq {
+        owner: String,
+        vm_name: String,
+    }
+    let reg: RegReq = match serde_json::from_slice(&buf[..req_len]) {
+        Ok(r) => r,
+        Err(_) => return,
+    };
+
+    // Create tunnel
+    let client = reqwest::Client::new();
+    let agent_id = uuid::Uuid::new_v4().to_string();
+    let tunnel_info =
+        match crate::tunnel::create_agent_tunnel(&client, &cf, &agent_id, &reg.vm_name).await {
+            Ok(info) => info,
+            Err(e) => {
+                eprintln!("dd-register: tunnel failed: {e}");
+                return;
+            }
+        };
+
+    eprintln!(
+        "dd-register: {} registered at {}",
+        reg.vm_name, tunnel_info.hostname
+    );
+
+    // Record
+    state.agent_registry.lock().await.insert(
+        agent_id.clone(),
+        RegisteredAgent {
+            agent_id,
+            hostname: tunnel_info.hostname.clone(),
+            vm_name: reg.vm_name,
+            attestation_type: attestation.attestation_type,
+            registered_at: chrono::Utc::now().to_rfc3339(),
+        },
+    );
+
+    // Send bootstrap config
+    let config = crate::noise::BootstrapConfig {
+        owner: reg.owner,
+        tunnel_token: tunnel_info.tunnel_token,
+        hostname: tunnel_info.hostname,
+    };
+    let json = serde_json::to_vec(&config).unwrap();
+    let mut enc_resp = vec![0u8; 65535];
+    if let Ok(len) = transport.write_message(&json, &mut enc_resp) {
+        let _ = ws_tx
+            .send(Message::Binary(enc_resp[..len].to_vec().into()))
+            .await;
+    }
+}
+
 pub fn build_router(state: AgentState) -> Router {
-    Router::new()
-        .route("/", get(dashboard))
+    let mut router = Router::new();
+
+    if state.register_mode {
+        router = router
+            .route("/", get(fleet_dashboard))
+            .route("/register", get(ws_register));
+    } else {
+        router = router.route("/", get(dashboard));
+    }
+
+    router
         .route("/logged-out", get(logged_out_page))
         .route("/auth/github/start", get(github_auth_start))
         .route("/auth/github/callback", get(github_auth_callback))


### PR DESCRIPTION
Bootstrap VM runs dd-register instead of dd-agent. Fleet dashboard at /, agent registration via Noise WebSocket at /register. Agents get their own tunnels and hostnames.