### PR TITLE
Fix double-wrapped register URL breaking agent registration

### DIFF
--- a/agent/src/bin/dd-agent/main.rs
+++ b/agent/src/bin/dd-agent/main.rs
@@ -646,8 +646,8 @@ async fn register_via_noise(
     let keypair = dd_agent::noise::generate_keypair()?;
     let attestation = build_attestation(vm_name, backend);
 
-    // Connect via WebSocket
-    let ws_url = format!("ws://{register_url}/register");
+    // Connect via WebSocket — DD_REGISTER_URL is already a full URL like wss://host/register
+    let ws_url = register_url.to_string();
     let (ws_stream, _) = tokio_tungstenite::connect_async(&ws_url)
         .await
         .map_err(|e| format!("ws connect to {ws_url}: {e}"))?;


### PR DESCRIPTION
## Summary

`register_via_noise()` was wrapping `DD_REGISTER_URL` with `ws://` prefix and `/register` suffix, but the URL is already complete (e.g. `wss://app-staging.devopsdefender.com/register`). This produced `ws://wss://host/register/register` which fails DNS lookup. Every marketplace agent silently crashed on startup.

Also includes the workload names fix from #41 (self-update metrics, show workload names in dashboard).

## Test plan

- [ ] `DD_REGISTER_URL=wss://app-staging.devopsdefender.com/register dd-agent` connects successfully
- [ ] Marketplace agent appears in fleet dashboard after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)