### PR TITLE
Fix agent registration clobbering register's hostname

### DIFF
--- a/agent/src/bin/dd-agent/main.rs
+++ b/agent/src/bin/dd-agent/main.rs
@@ -76,7 +76,16 @@ async fn run_agent_mode(cfg: AgentRuntimeConfig) {
         let cf = dd_agent::tunnel::CfConfig::from_env().unwrap();
         eprintln!("dd-agent: self-registering via CF API");
         let http = reqwest::Client::new();
-        match dd_agent::tunnel::create_agent_tunnel(&http, &cf, &agent_id, &vm_name).await {
+        let hostname_override = std::env::var("DD_HOSTNAME").ok().filter(|s| !s.is_empty());
+        match dd_agent::tunnel::create_agent_tunnel(
+            &http,
+            &cf,
+            &agent_id,
+            &vm_name,
+            hostname_override.as_deref(),
+        )
+        .await
+        {
             Ok(info) => {
                 eprintln!("dd-agent: tunnel created — hostname={}", info.hostname);
                 if let Err(e) = start_cloudflared(&info.tunnel_token).await {

--- a/agent/src/bin/dd-register/main.rs
+++ b/agent/src/bin/dd-register/main.rs
@@ -60,14 +60,21 @@ async fn main() {
     eprintln!("dd-register: self-registering tunnel for {hostname}");
 
     let http_client = reqwest::Client::new();
-    let tunnel_info =
-        match tunnel::create_agent_tunnel(&http_client, &cf, &register_id, "register").await {
-            Ok(info) => info,
-            Err(e) => {
-                eprintln!("dd-register: self-registration failed: {e}");
-                std::process::exit(1);
-            }
-        };
+    let tunnel_info = match tunnel::create_agent_tunnel(
+        &http_client,
+        &cf,
+        &register_id,
+        "register",
+        Some(&hostname),
+    )
+    .await
+    {
+        Ok(info) => info,
+        Err(e) => {
+            eprintln!("dd-register: self-registration failed: {e}");
+            std::process::exit(1);
+        }
+    };
 
     eprintln!("dd-register: tunnel created — {}", tunnel_info.hostname);
 
@@ -297,14 +304,14 @@ async fn handle_registration(socket: WebSocket, cf: CfConfig, registry: AgentReg
     // Create tunnel for the agent
     let client = reqwest::Client::new();
     let agent_id = uuid::Uuid::new_v4().to_string();
-    let tunnel_info = match tunnel::create_agent_tunnel(&client, &cf, &agent_id, &reg.vm_name).await
-    {
-        Ok(info) => info,
-        Err(e) => {
-            eprintln!("dd-register: tunnel failed: {e}");
-            return;
-        }
-    };
+    let tunnel_info =
+        match tunnel::create_agent_tunnel(&client, &cf, &agent_id, &reg.vm_name, None).await {
+            Ok(info) => info,
+            Err(e) => {
+                eprintln!("dd-register: tunnel failed: {e}");
+                return;
+            }
+        };
 
     eprintln!(
         "dd-register: {} registered at {}",

--- a/agent/src/server.rs
+++ b/agent/src/server.rs
@@ -1985,7 +1985,8 @@ async fn handle_ws_register(socket: WebSocket, state: AgentState) {
     let client = reqwest::Client::new();
     let agent_id = uuid::Uuid::new_v4().to_string();
     let tunnel_info =
-        match crate::tunnel::create_agent_tunnel(&client, &cf, &agent_id, &reg.vm_name).await {
+        match crate::tunnel::create_agent_tunnel(&client, &cf, &agent_id, &reg.vm_name, None).await
+        {
             Ok(info) => info,
             Err(e) => {
                 eprintln!("dd-register: tunnel failed: {e}");

--- a/agent/src/tunnel.rs
+++ b/agent/src/tunnel.rs
@@ -42,18 +42,22 @@ const CF_API: &str = "https://api.cloudflare.com/client/v4";
 
 /// Create a CF tunnel for an agent, configure ingress, create DNS CNAME.
 /// Tunnel name uses agent_id (UUID) to guarantee uniqueness.
-/// DD_HOSTNAME controls the public DNS name users see.
+/// `hostname_override` sets the public DNS name — pass `None` for UUID-based.
+/// Callers must pass the override explicitly; this function never reads DD_HOSTNAME
+/// from the environment (to avoid the register's hostname leaking to remote agents).
 pub async fn create_agent_tunnel(
     client: &reqwest::Client,
     cf: &CfConfig,
     agent_id: &str,
-    vm_name: &str,
+    _vm_name: &str,
+    hostname_override: Option<&str>,
 ) -> Result<TunnelInfo, String> {
-    let hostname_override = std::env::var("DD_HOSTNAME").ok().filter(|s| !s.is_empty());
     let env_label = std::env::var("DD_ENV").unwrap_or_else(|_| "dev".into());
     let tunnel_name = format!("dd-{env_label}-{agent_id}");
     let tunnel_secret = uuid::Uuid::new_v4().to_string().replace('-', "");
-    let hostname = hostname_override.unwrap_or_else(|| format!("{vm_name}.{}", cf.domain));
+    let hostname = hostname_override
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| format!("{tunnel_name}.{}", cf.domain));
 
     // Delete existing tunnel with this name (idempotent redeploy)
     let _ = delete_tunnel_by_name(client, cf, &tunnel_name).await;


### PR DESCRIPTION
## Summary

`create_agent_tunnel()` read `DD_HOSTNAME` from the environment, which on the register VM is `app-staging.devopsdefender.com`. When creating a tunnel for a remote agent, it gave the agent the register's hostname — overwriting the register's DNS CNAME and taking staging offline (502).

Now `hostname_override` is an explicit parameter:
- **Self-registration** (agent creates own tunnel): passes `DD_HOSTNAME` from env
- **Register creating tunnel for remote agent**: passes `None` → UUID-based hostname (`dd-staging-{uuid}.devopsdefender.com`)

## Test plan

- [ ] Register keeps `app-staging.devopsdefender.com` after agent registers
- [ ] Agent gets `dd-staging-{uuid}.devopsdefender.com` hostname
- [ ] Staging doesn't go 502 after registration
- [ ] Fleet dashboard shows agent with unique hostname

🤖 Generated with [Claude Code](https://claude.com/claude-code)