### PR TITLE
feat: register-issued auth tokens for agents

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -74,20 +74,10 @@ jobs:
             gcloud compute instances delete "$name" --project="$GCP_PROJECT_ID" --zone="$zone" --quiet || true
           done
 
-      - name: Delete CF tunnels for production
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.DD_CP_CF_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.DD_CP_CF_ACCOUNT_ID }}
-        run: |
-          tunnels=$(curl -sf "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/cfd_tunnel?is_deleted=false" \
-            -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" | jq -r '.result[] | select(.name | startswith("dd-production-")) | .id') || true
-          for id in $tunnels; do
-            echo "Deleting tunnel: $id"
-            curl -sf -X DELETE "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/cfd_tunnel/${id}/connections" \
-              -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" || true
-            curl -sf -X DELETE "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/cfd_tunnel/${id}" \
-              -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" || true
-          done
+      # CF tunnel cleanup removed — create_agent_tunnel() in tunnel.rs
+      # already deletes any existing tunnel with the same name before
+      # creating a new one. Blanket deletion of dd-production-* tunnels
+      # was killing marketplace agent tunnels.
 
   deploy:
     needs: [build, cleanup]

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -80,20 +80,10 @@ jobs:
             gcloud compute instances delete "$name" --project="$GCP_PROJECT_ID" --zone="$zone" --quiet || true
           done
 
-      - name: Delete CF tunnels for staging
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.DD_CP_CF_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.DD_CP_CF_ACCOUNT_ID }}
-        run: |
-          tunnels=$(curl -sf "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/cfd_tunnel?is_deleted=false" \
-            -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" | jq -r '.result[] | select(.name | startswith("dd-staging-")) | .id') || true
-          for id in $tunnels; do
-            echo "Deleting tunnel: $id"
-            curl -sf -X DELETE "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/cfd_tunnel/${id}/connections" \
-              -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" || true
-            curl -sf -X DELETE "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/cfd_tunnel/${id}" \
-              -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" || true
-          done
+      # CF tunnel cleanup removed — create_agent_tunnel() in tunnel.rs
+      # already deletes any existing tunnel with the same name before
+      # creating a new one. Blanket deletion of dd-staging-* tunnels
+      # was killing marketplace agent tunnels.
 
   deploy:
     needs: [build, cleanup]

--- a/agent/src/bin/dd-agent/main.rs
+++ b/agent/src/bin/dd-agent/main.rs
@@ -303,6 +303,10 @@ async fn run_agent_mode(cfg: AgentRuntimeConfig) {
     // Ensure workloads directory exists
     let _ = tokio::fs::create_dir_all("/var/lib/dd/workloads/logs").await;
 
+    // Auth config from register bootstrap (populated if agent registers via Noise)
+    let mut bootstrap_auth_key: Option<jsonwebtoken::DecodingKey> = None;
+    let mut bootstrap_auth_issuer: Option<String> = None;
+
     // Bootstrap priority: pre-provisioned token > self-register via CF API > register via Noise > standalone
     if let Some(token) = std::env::var("DD_TUNNEL_TOKEN")
         .ok()
@@ -347,6 +351,14 @@ async fn run_agent_mode(cfg: AgentRuntimeConfig) {
         );
         if let Err(e) = start_cloudflared(&config.tunnel_token).await {
             eprintln!("dd-agent: cloudflared start failed: {e}");
+        }
+        // Store register-issued auth config for JWT verification
+        if let Some(ref key_b64) = config.auth_public_key {
+            if let Some((_, decoding)) = dd_agent::server::auth_keys_from_b64(key_b64) {
+                bootstrap_auth_key = Some(decoding);
+                bootstrap_auth_issuer = config.auth_issuer.clone();
+                eprintln!("dd-agent: register auth tokens enabled");
+            }
         }
     } else {
         eprintln!("dd-agent: no tunnel config set, running without tunnel");
@@ -481,6 +493,19 @@ async fn run_agent_mode(cfg: AgentRuntimeConfig) {
         None
     };
 
+    // In register mode, generate auth signing keypair for issuing JWTs to agents
+    let (auth_signing_key, auth_public_key_decoded, auth_public_key_b64, auth_issuer) =
+        if register_mode {
+            let (enc, dec, b64) = dd_agent::server::generate_auth_secret();
+            let hostname = std::env::var("DD_HOSTNAME").unwrap_or_else(|_| "localhost".into());
+            let issuer = format!("https://{hostname}");
+            eprintln!("dd-agent: register auth token signing enabled");
+            (Some(enc), Some(dec), Some(b64), Some(issuer))
+        } else {
+            // Agent mode: use bootstrap auth key if available
+            (None, bootstrap_auth_key, None, bootstrap_auth_issuer)
+        };
+
     let state = AgentState {
         owner,
         vm_name,
@@ -495,6 +520,10 @@ async fn run_agent_mode(cfg: AgentRuntimeConfig) {
         register_mode,
         agent_registry: Arc::new(Mutex::new(HashMap::new())),
         cf_config,
+        auth_signing_key,
+        auth_public_key_decoded,
+        auth_issuer,
+        auth_public_key_b64,
     };
 
     // In register mode, add ourselves to the registry
@@ -538,8 +567,16 @@ async fn run_agent_mode(cfg: AgentRuntimeConfig) {
     } else {
         None
     };
+    let monitor_reregister = std::env::var("DD_REGISTER_URL")
+        .ok()
+        .map(|url| ReregisterInfo {
+            vm_name: state.vm_name.clone(),
+            owner: state.owner.clone(),
+            register_url: url,
+            attestation: dd_agent::attestation::detect(),
+        });
     tokio::spawn(async move {
-        monitoring_loop(monitor_deps, monitor_registry).await;
+        monitoring_loop(monitor_deps, monitor_registry, monitor_reregister).await;
     });
 
     // Run HTTP server until shutdown
@@ -975,11 +1012,21 @@ async fn register_via_noise(
 
 // ── Monitoring loop — check process liveness by PID ─────────────────────
 
+struct ReregisterInfo {
+    vm_name: String,
+    owner: String,
+    register_url: String,
+    attestation: Box<dyn dd_agent::attestation::AttestationBackend>,
+}
+
 async fn monitoring_loop(
     deployments: Deployments,
     self_registry: Option<(dd_agent::server::AgentRegistry, String)>,
+    reregister: Option<ReregisterInfo>,
 ) {
     let mut interval = tokio::time::interval(std::time::Duration::from_secs(30));
+    let mut last_reregister: Option<std::time::Instant> = None;
+    let reregister_cooldown = std::time::Duration::from_secs(5 * 60);
     loop {
         interval.tick().await;
 
@@ -1025,7 +1072,38 @@ async fn monitoring_loop(
             }
         }
 
-        check_cloudflared().await;
+        // Check if cloudflared is alive; if dead and we have a register URL, re-register (with cooldown)
+        if !is_cloudflared_running().await {
+            let can_reregister = last_reregister
+                .map(|t: std::time::Instant| t.elapsed() > reregister_cooldown)
+                .unwrap_or(true);
+            if let Some(ref info) = reregister {
+                if !can_reregister {
+                    eprintln!(
+                        "dd-agent: cloudflared dead, waiting for cooldown before re-registering"
+                    );
+                    continue;
+                }
+                last_reregister = Some(std::time::Instant::now());
+                eprintln!(
+                    "dd-agent: cloudflared dead, re-registering with {}",
+                    info.register_url
+                );
+                let config = register(
+                    &info.vm_name,
+                    &info.owner,
+                    &info.register_url,
+                    info.attestation.as_ref(),
+                )
+                .await;
+                eprintln!("dd-agent: re-registered — hostname={}", config.hostname);
+                if let Err(e) = start_cloudflared(&config.tunnel_token).await {
+                    eprintln!("dd-agent: cloudflared restart failed: {e}");
+                }
+            } else {
+                eprintln!("dd-agent: cloudflared not running (no register URL to reconnect)");
+            }
+        }
     }
 }
 
@@ -1060,10 +1138,8 @@ async fn start_cloudflared(tunnel_token: &str) -> Result<(), String> {
     }
 }
 
-async fn check_cloudflared() {
-    if !is_process_running("cloudflared") {
-        eprintln!("dd-agent: cloudflared not running (may need restart)");
-    }
+async fn is_cloudflared_running() -> bool {
+    is_process_running("cloudflared")
 }
 
 /// Check if a process with the given name is running by scanning /proc.

--- a/agent/src/bin/dd-register/main.rs
+++ b/agent/src/bin/dd-register/main.rs
@@ -335,6 +335,8 @@ async fn handle_registration(socket: WebSocket, cf: CfConfig, registry: AgentReg
         owner: reg.owner,
         tunnel_token: tunnel_info.tunnel_token,
         hostname: tunnel_info.hostname,
+        auth_public_key: None,
+        auth_issuer: None,
     };
     let config_json = serde_json::to_vec(&config).unwrap();
     let mut enc_resp = vec![0u8; 65535];

--- a/agent/src/noise.rs
+++ b/agent/src/noise.rs
@@ -108,6 +108,12 @@ pub struct BootstrapConfig {
     pub owner: String,
     pub tunnel_token: String,
     pub hostname: String,
+    /// Ed25519 public key (base64) for verifying register-issued JWTs.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub auth_public_key: Option<String>,
+    /// Register hostname for auth redirects (e.g. "https://app-staging.devopsdefender.com").
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub auth_issuer: Option<String>,
 }
 
 // ── Wire helpers ─────────────────────────────────────────────────────────

--- a/agent/src/server.rs
+++ b/agent/src/server.rs
@@ -151,6 +151,13 @@ pub struct AgentState {
     pub register_mode: bool,
     pub agent_registry: AgentRegistry,
     pub cf_config: Option<CfConfig>,
+    /// Register-issued auth: Ed25519 keypair (register) or public key (agent).
+    pub auth_signing_key: Option<jsonwebtoken::EncodingKey>,
+    pub auth_public_key_decoded: Option<jsonwebtoken::DecodingKey>,
+    /// Register URL for auth redirects (agents redirect here when dd_auth cookie is missing).
+    pub auth_issuer: Option<String>,
+    /// Base64-encoded Ed25519 public key (to send to agents during bootstrap).
+    pub auth_public_key_b64: Option<String>,
 }
 
 // ── Auth ──────────────────────────────────────────────────────────────────
@@ -158,6 +165,43 @@ pub struct AgentState {
 const SESSION_COOKIE: &str = "dd_session";
 const SESSION_TTL: Duration = Duration::from_secs(8 * 60 * 60);
 const OAUTH_STATE_TTL: Duration = Duration::from_secs(10 * 60);
+
+/// Register-issued auth token cookie (domain-scoped to .devopsdefender.com).
+const AUTH_COOKIE: &str = "dd_auth";
+const AUTH_TOKEN_TTL: Duration = Duration::from_secs(24 * 60 * 60);
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct AuthClaims {
+    pub sub: String,
+    pub login: String,
+    pub iss: String,
+    pub iat: i64,
+    pub exp: i64,
+}
+
+/// Generate a random HMAC-SHA256 secret for register-issued auth tokens.
+/// Returns (EncodingKey, DecodingKey, base64-encoded secret for distribution to agents).
+pub fn generate_auth_secret() -> (jsonwebtoken::EncodingKey, jsonwebtoken::DecodingKey, String) {
+    // Use two UUIDv4s (128 bits each) for 256 bits of randomness
+    let mut secret = Vec::with_capacity(32);
+    secret.extend_from_slice(uuid::Uuid::new_v4().as_bytes());
+    secret.extend_from_slice(uuid::Uuid::new_v4().as_bytes());
+    let b64 = base64::Engine::encode(&base64::engine::general_purpose::STANDARD, &secret);
+    let encoding = jsonwebtoken::EncodingKey::from_secret(&secret);
+    let decoding = jsonwebtoken::DecodingKey::from_secret(&secret);
+    (encoding, decoding, b64)
+}
+
+/// Reconstruct auth keys from a base64-encoded secret (used by agents).
+pub fn auth_keys_from_b64(
+    b64: &str,
+) -> Option<(jsonwebtoken::EncodingKey, jsonwebtoken::DecodingKey)> {
+    let secret = base64::Engine::decode(&base64::engine::general_purpose::STANDARD, b64).ok()?;
+    Some((
+        jsonwebtoken::EncodingKey::from_secret(&secret),
+        jsonwebtoken::DecodingKey::from_secret(&secret),
+    ))
+}
 
 fn extract_auth(headers: &HeaderMap) -> Option<String> {
     let value = headers.get("authorization")?.to_str().ok()?;
@@ -239,6 +283,19 @@ async fn resolve_github_token(
         return Ok(None);
     }
 
+    // Check register-issued dd_auth JWT cookie first
+    if let Some(ref decoding_key) = state.auth_public_key_decoded {
+        if let Some(jwt) = extract_cookie(headers, AUTH_COOKIE) {
+            let mut validation = jsonwebtoken::Validation::new(jsonwebtoken::Algorithm::HS256);
+            validation.validate_exp = true;
+            if let Ok(data) = jsonwebtoken::decode::<AuthClaims>(&jwt, decoding_key, &validation) {
+                if !data.claims.login.is_empty() {
+                    return Ok(Some(data.claims.login));
+                }
+            }
+        }
+    }
+
     if let Some(token) = query_token.filter(|token| !token.is_empty()) {
         verify_github_token(token, &state.owner).await?;
         return Ok(Some(token.to_string()));
@@ -266,6 +323,14 @@ async fn require_browser_token(
         Ok(token) => Ok(token),
         Err(AppError::Unauthorized) if state.oauth.is_some() => {
             Err(github_oauth_redirect(current_uri).into_response())
+        }
+        Err(AppError::Unauthorized) if state.auth_issuer.is_some() => {
+            // Redirect to register for auth. After login, the dd_auth cookie
+            // (scoped to .devopsdefender.com) will be set, and the user
+            // can return to this agent. Redirect to register's root which
+            // will trigger GitHub login and then show the fleet dashboard.
+            let issuer = state.auth_issuer.as_deref().unwrap();
+            Err(Redirect::to(issuer).into_response())
         }
         Err(err) => Err(err.into_response()),
     }
@@ -542,15 +607,61 @@ async fn github_auth_callback(
     state.browser_sessions.lock().await.insert(
         session_id.clone(),
         BrowserSession {
-            token,
+            token: token.clone(),
             expires_at: Instant::now() + SESSION_TTL,
         },
     );
 
-    Ok(response_with_cookie(
+    let mut response = response_with_cookie(
         Redirect::to(&next_path),
         build_session_cookie(&state, &session_id, SESSION_TTL.as_secs()),
-    ))
+    );
+
+    // If register has an auth signing key, also issue a domain-scoped dd_auth JWT.
+    if let Some(ref signing_key) = state.auth_signing_key {
+        // Fetch GitHub user info for the JWT claims
+        let login = match http
+            .get("https://api.github.com/user")
+            .header("Authorization", format!("Bearer {token}"))
+            .header("User-Agent", "dd-agent")
+            .send()
+            .await
+        {
+            Ok(resp) => resp
+                .json::<serde_json::Value>()
+                .await
+                .ok()
+                .and_then(|v| v["login"].as_str().map(String::from))
+                .unwrap_or_default(),
+            Err(_) => String::new(),
+        };
+
+        let now = chrono::Utc::now().timestamp();
+        let claims = AuthClaims {
+            sub: login.clone(),
+            login,
+            iss: state.auth_issuer.clone().unwrap_or_default(),
+            iat: now,
+            exp: now + AUTH_TOKEN_TTL.as_secs() as i64,
+        };
+        let header = jsonwebtoken::Header::new(jsonwebtoken::Algorithm::HS256);
+        if let Ok(jwt) = jsonwebtoken::encode(&header, &claims, signing_key) {
+            let domain = state
+                .cf_config
+                .as_ref()
+                .map(|c| c.domain.as_str())
+                .unwrap_or("devopsdefender.com");
+            let cookie = format!(
+                "{AUTH_COOKIE}={jwt}; Path=/; Domain=.{domain}; HttpOnly; Secure; SameSite=Lax; Max-Age={}",
+                AUTH_TOKEN_TTL.as_secs()
+            );
+            if let Ok(value) = HeaderValue::from_str(&cookie) {
+                response.headers_mut().append(SET_COOKIE, value);
+            }
+        }
+    }
+
+    Ok(response)
 }
 
 async fn github_auth_logout(State(state): State<AgentState>, headers: HeaderMap) -> Response {
@@ -2024,6 +2135,8 @@ async fn handle_ws_register(socket: WebSocket, state: AgentState) {
         owner: reg.owner,
         tunnel_token: tunnel_info.tunnel_token,
         hostname: tunnel_info.hostname,
+        auth_public_key: state.auth_public_key_b64.clone(),
+        auth_issuer: state.auth_issuer.clone(),
     };
     let json = serde_json::to_vec(&config).unwrap();
     let mut enc_resp = vec![0u8; 65535];


### PR DESCRIPTION
## Summary

Three changes to support marketplace agents that register with the fleet:

1. **Register-issued JWT auth tokens** — Register generates HMAC-SHA256 secret at startup, passes to agents during Noise bootstrap. After GitHub OAuth, register signs a `dd_auth` cookie scoped to `.devopsdefender.com`. Agents verify the JWT — no per-agent GitHub OAuth app needed.

2. **Remove blanket CF tunnel cleanup** — Deploy workflows no longer delete all `dd-{env}-*` tunnels. `create_agent_tunnel()` already cleans up by name. The blanket delete was killing marketplace agent tunnels on every register redeploy.

3. **Agent auto re-register** — Monitoring loop detects cloudflared death. If agent has `DD_REGISTER_URL`, it re-registers for a fresh tunnel and restarts cloudflared. 5-minute cooldown between attempts.

## Test plan
- [ ] Deploy register → verify dd_auth cookie set after GitHub login
- [ ] Deploy marketplace agent via register → verify JWT auth works across agent hostnames
- [ ] Kill marketplace agent's cloudflared → verify it re-registers within 5 minutes
- [ ] Redeploy register → verify marketplace agent tunnels survive

🤖 Generated with [Claude Code](https://claude.com/claude-code)