### PR TITLE
Chroot OCI workloads, auth tokens, and fleet agent detail page

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,26 +259,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -361,6 +341,7 @@ dependencies = [
  "chrono",
  "futures-util",
  "jsonwebtoken",
+ "libc",
  "oci-unpack",
  "reqwest",
  "serde",
@@ -404,15 +385,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "encoding_rs"
-version = "0.8.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "enumflags2"
 version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -449,12 +421,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fastrand"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
-
-[[package]]
 name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -488,31 +454,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -645,25 +590,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "h2"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
-dependencies = [
- "atomic-waker",
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "http",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -739,7 +665,6 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2",
  "http",
  "http-body",
  "httparse",
@@ -770,22 +695,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
-]
-
-[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -803,11 +712,9 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
- "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry",
 ]
 
 [[package]]
@@ -1131,23 +1038,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1214,50 +1104,6 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
-
-[[package]]
-name = "openssl"
-version = "0.10.76"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
-dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "openssl-probe"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.112"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "pem"
@@ -1517,22 +1363,17 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
- "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
- "mime",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -1543,7 +1384,6 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls",
  "tower",
  "tower-http",
@@ -1657,38 +1497,6 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
-
-[[package]]
-name = "schannel"
-version = "0.1.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "security-framework"
-version = "3.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
-dependencies = [
- "bitflags",
- "core-foundation 0.10.1",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
 
 [[package]]
 name = "semver"
@@ -1901,27 +1709,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "system-configuration"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
-dependencies = [
- "bitflags",
- "core-foundation 0.9.4",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "tar"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1930,19 +1717,6 @@ dependencies = [
  "filetime",
  "libc",
  "xattr",
-]
-
-[[package]]
-name = "tempfile"
-version = "3.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
-dependencies = [
- "fastrand",
- "getrandom 0.4.2",
- "once_cell",
- "rustix 1.1.4",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2081,16 +1855,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2108,10 +1872,12 @@ checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
 dependencies = [
  "futures-util",
  "log",
- "native-tls",
+ "rustls",
+ "rustls-pki-types",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls",
  "tungstenite 0.24.0",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -2124,19 +1890,6 @@ dependencies = [
  "log",
  "tokio",
  "tungstenite 0.28.0",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.7.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "pin-project-lite",
- "tokio",
 ]
 
 [[package]]
@@ -2223,8 +1976,9 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "native-tls",
  "rand 0.8.5",
+ "rustls",
+ "rustls-pki-types",
  "sha1",
  "thiserror 1.0.69",
  "utf-8",
@@ -2332,12 +2086,6 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -2549,17 +2297,6 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-registry"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
-dependencies = [
- "windows-link",
- "windows-result",
- "windows-strings",
-]
 
 [[package]]
 name = "windows-result"

--- a/agent/src/process.rs
+++ b/agent/src/process.rs
@@ -99,7 +99,8 @@ pub async fn pull_image(image: &str, app_name: &str) -> Result<ImageConfig, Stri
 }
 
 /// Spawn a workload process from a pulled OCI image.
-/// No chroot — the VM is the isolation boundary. Just run the binary directly.
+/// Uses chroot into the extracted rootfs — the VM is the security boundary,
+/// chroot provides filesystem isolation so images work as expected.
 pub async fn spawn_workload(
     app_name: &str,
     config: &ImageConfig,
@@ -122,19 +123,6 @@ pub async fn spawn_workload(
 
     let program = args.remove(0);
 
-    // Resolve the program path — look in the extracted image first, then system PATH
-    let resolved_program = if program.starts_with('/') {
-        // Absolute path — look inside extracted image
-        let in_image = workdir.join(program.trim_start_matches('/'));
-        if in_image.exists() {
-            in_image.to_string_lossy().to_string()
-        } else {
-            program.clone() // Fall back to system
-        }
-    } else {
-        program.clone()
-    };
-
     // Environment from image config + extras
     let mut env_map: HashMap<String, String> = HashMap::new();
     for kv in &config.env {
@@ -148,13 +136,11 @@ pub async fn spawn_workload(
         }
     }
 
-    // Prepend extracted image dirs to PATH so image binaries are found
-    let image_path = format!(
-        "{0}/usr/local/sbin:{0}/usr/local/bin:{0}/usr/sbin:{0}/usr/bin:{0}/sbin:{0}/bin",
-        workdir.display()
+    // Standard PATH inside the chroot
+    env_map.insert(
+        "PATH".into(),
+        "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin".into(),
     );
-    let system_path = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
-    env_map.insert("PATH".into(), format!("{image_path}:{system_path}"));
     env_map
         .entry("HOME".into())
         .or_insert_with(|| "/root".into());
@@ -164,29 +150,36 @@ pub async fn spawn_workload(
 
     let _ = tokio::fs::create_dir_all("/var/lib/dd/workloads/logs").await;
 
+    // Prepare chroot: bind-mount /proc, /sys, /dev, and copy resolv.conf for DNS
+    setup_chroot_mounts(&workdir).await?;
+
+    // Working directory inside the chroot
+    let cwd = if !config.working_dir.is_empty() && config.working_dir != "/" {
+        config.working_dir.clone()
+    } else {
+        "/".into()
+    };
+
+    // Build the inner command (what runs inside chroot)
+    let inner_cmd = if args.is_empty() {
+        program.clone()
+    } else {
+        format!("{} {}", program, args.join(" "))
+    };
+
     let mut cmd = if tty {
-        let mut c = Command::new("script");
-        c.arg("-qfc");
-        c.arg(format!("{} {}", resolved_program, args.join(" ")));
-        c.arg("/dev/null");
+        let mut c = Command::new("chroot");
+        c.arg(workdir.as_os_str());
+        c.args(["script", "-qfc", &inner_cmd, "/dev/null"]);
         c
     } else {
-        let mut c = Command::new(&resolved_program);
+        let mut c = Command::new("chroot");
+        c.arg(workdir.as_os_str());
+        c.arg(&program);
         c.args(&args);
         c
     };
 
-    // Set working directory to the image's configured workdir (inside extracted image)
-    let cwd = if !config.working_dir.is_empty() && config.working_dir != "/" {
-        let img_cwd = workdir.join(config.working_dir.trim_start_matches('/'));
-        if img_cwd.exists() {
-            img_cwd
-        } else {
-            workdir.clone()
-        }
-    } else {
-        workdir.clone()
-    };
     cmd.current_dir(&cwd);
 
     cmd.env_clear();
@@ -205,12 +198,35 @@ pub async fn spawn_workload(
     let child = cmd.spawn().map_err(|e| format!("spawn {program}: {e}"))?;
 
     eprintln!(
-        "dd-agent: spawned {app_name} (pid={}) — {program} {:?}",
+        "dd-agent: spawned {app_name} (pid={}) — chroot {} {program} {:?}",
         child.id().unwrap_or(0),
+        workdir.display(),
         args
     );
 
     Ok(child)
+}
+
+/// Set up bind mounts inside the chroot rootfs for /proc, /sys, /dev, and DNS.
+async fn setup_chroot_mounts(rootfs: &Path) -> Result<(), String> {
+    use tokio::process::Command;
+
+    for dir in &["proc", "sys", "dev"] {
+        let target = rootfs.join(dir);
+        let _ = tokio::fs::create_dir_all(&target).await;
+        let source = format!("/{dir}");
+        let _ = Command::new("mount")
+            .args(["--bind", &source, &target.to_string_lossy()])
+            .output()
+            .await;
+    }
+
+    // Copy resolv.conf for DNS resolution
+    let etc = rootfs.join("etc");
+    let _ = tokio::fs::create_dir_all(&etc).await;
+    let _ = tokio::fs::copy("/etc/resolv.conf", etc.join("resolv.conf")).await;
+
+    Ok(())
 }
 
 /// Spawn a direct command (not from an OCI image). For system tools like tmux, bash, etc.

--- a/agent/src/server.rs
+++ b/agent/src/server.rs
@@ -1641,7 +1641,7 @@ async fn fleet_dashboard_html(state: &AgentState) -> Html<String> {
         };
         rows.push_str(&format!(
             r#"<tr>
-                <td><a href="https://{hostname}">{hostname}</a></td>
+                <td><a href="/agent/{agent_id}">{hostname}</a></td>
                 <td>{vm}</td>
                 <td><span style="color:{status_color}">{status}</span></td>
                 <td>{attestation}</td>
@@ -1650,6 +1650,7 @@ async fn fleet_dashboard_html(state: &AgentState) -> Html<String> {
                 <td>{mem}</td>
                 <td>{last_seen}</td>
             </tr>"#,
+            agent_id = a.agent_id,
             hostname = a.hostname,
             vm = a.vm_name,
             status_color = status_color,
@@ -1709,6 +1710,105 @@ async fn fleet_dashboard_html(state: &AgentState) -> Html<String> {
             )
         },
     ))
+}
+
+// ── Agent detail page (register mode) ─────────────────────────────────
+
+async fn agent_detail(Path(agent_id): Path<String>, State(state): State<AgentState>) -> Response {
+    let agents = state.agent_registry.lock().await;
+    let Some(a) = agents.get(&agent_id) else {
+        return (axum::http::StatusCode::NOT_FOUND, "agent not found").into_response();
+    };
+
+    let status_color = match a.status.as_str() {
+        "healthy" => "#a6e3a1",
+        "stale" => "#fab387",
+        "dead" => "#f38ba8",
+        _ => "#a6adc8",
+    };
+
+    let now = chrono::Utc::now();
+    let age_secs = now.signed_duration_since(a.last_seen).num_seconds();
+    let last_seen = if age_secs < 60 {
+        format!("{age_secs}s ago")
+    } else if age_secs < 3600 {
+        format!("{}m ago", age_secs / 60)
+    } else {
+        format!("{}h ago", age_secs / 3600)
+    };
+
+    let mem_str = if a.memory_total_mb > 0 {
+        format!("{}M / {}M", a.memory_used_mb, a.memory_total_mb)
+    } else {
+        "-".into()
+    };
+
+    let deployments_list = if a.deployment_names.is_empty() {
+        format!(
+            "<span class=\"dim\">{} deployment(s)</span>",
+            a.deployment_count
+        )
+    } else {
+        a.deployment_names
+            .iter()
+            .map(|d| format!("<li>{d}</li>"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
+
+    let html = format!(
+        r#"<!DOCTYPE html>
+<html><head><meta charset="utf-8"><title>{hostname} — DD Fleet</title>
+<style>
+  body {{ margin:0; background:#1e1e2e; color:#cdd6f4; font-family:'JetBrains Mono',monospace; padding:24px; }}
+  h1 {{ color:#89b4fa; margin:0 0 4px; font-size:20px; }}
+  .sub {{ color:#585b70; font-size:12px; margin-bottom:24px; }}
+  a {{ color:#89b4fa; text-decoration:none; }} a:hover {{ text-decoration:underline; }}
+  .back {{ font-size:13px; margin-bottom:20px; }}
+  .card {{ background:#181825; border:1px solid #313244; border-radius:8px; padding:20px; margin-bottom:16px; }}
+  .row {{ display:flex; justify-content:space-between; padding:8px 0; border-bottom:1px solid #313244; }}
+  .row:last-child {{ border-bottom:none; }}
+  .label {{ color:#a6adc8; font-size:12px; text-transform:uppercase; }}
+  .value {{ font-size:14px; }}
+  .section {{ color:#a6adc8; font-size:12px; text-transform:uppercase; margin:20px 0 8px; }}
+  .dim {{ color:#585b70; }}
+  ul {{ margin:0; padding:0 0 0 20px; }} li {{ padding:2px 0; font-size:14px; }}
+</style></head><body>
+<div class="back"><a href="/">&larr; fleet</a></div>
+<h1>{hostname}</h1>
+<div class="sub">{agent_id}</div>
+
+<div class="card">
+  <div class="row"><span class="label">Status</span><span class="value" style="color:{status_color}">{status}</span></div>
+  <div class="row"><span class="label">VM</span><span class="value">{vm}</span></div>
+  <div class="row"><span class="label">Attestation</span><span class="value">{attestation}</span></div>
+  <div class="row"><span class="label">Registered</span><span class="value">{registered_at}</span></div>
+  <div class="row"><span class="label">Last Seen</span><span class="value">{last_seen}</span></div>
+  <div class="row"><span class="label">Tunnel</span><span class="value"><a href="https://{hostname}" target="_blank">{hostname} &nearr;</a></span></div>
+</div>
+
+<div class="card">
+  <div class="row"><span class="label">CPU</span><span class="value">{cpu}%</span></div>
+  <div class="row"><span class="label">Memory</span><span class="value">{mem}</span></div>
+</div>
+
+<div class="section">Workloads</div>
+<div class="card"><ul>{deployments}</ul></div>
+</body></html>"#,
+        hostname = a.hostname,
+        agent_id = a.agent_id,
+        status_color = status_color,
+        status = a.status,
+        vm = a.vm_name,
+        attestation = a.attestation_type,
+        registered_at = a.registered_at,
+        last_seen = last_seen,
+        cpu = a.cpu_percent,
+        mem = mem_str,
+        deployments = deployments_list,
+    );
+
+    Html(html).into_response()
 }
 
 // ── Scraper + Deregister endpoints (register mode) ──────────────────────
@@ -2153,6 +2253,7 @@ pub fn build_router(state: AgentState) -> Router {
     if state.register_mode {
         router = router
             .route("/", get(fleet_dashboard))
+            .route("/agent/{agent_id}", get(agent_detail))
             .route("/register", get(ws_register))
             .route("/scraper", get(ws_scraper))
             .route("/deregister", post(post_deregister));


### PR DESCRIPTION
## Summary
- **Chroot OCI workloads** — container rootfs is extracted and workloads run chrooted into it, removing the Docker runtime dependency on agent nodes. Bind-mounts /proc, /sys, /dev and copies /etc/resolv.conf for DNS. Fixes openclaw and signal-cli workloads that assume a container filesystem layout.
- **Register-issued auth tokens** — agents receive auth tokens at registration time and auto-reconnect on disconnection
- **Sealed VM image** — dd-agent runs as PID 1 with dm-verity, static binary, tmpfs for workloads, and a CI workflow to build the sealed image
- **Static IP networking** — fixes for sealed VM boot with static network configuration
- **Fleet agent detail page** — clicking an agent in the fleet dashboard now opens a detail view with status, VM, attestation, tunnel link, resource usage, and workload list (previously navigated away to the tunnel URL with no way to inspect agent metadata)

## Test plan
- [ ] Staging deploy passes smoke check and hello-world integration test
- [ ] Fleet dashboard loads and agent hostname links navigate to detail page
- [ ] Agent detail page shows correct metadata and back link returns to fleet
- [ ] Chrooted workloads start and run correctly on agent nodes
- [ ] Agent auto-reconnects after disconnect

🤖 Generated with [Claude Code](https://claude.com/claude-code)