### PR TITLE
Fix: boot image loop skips gaps (DD_BOOT_IMAGE_2 unreachable)

### DIFF
--- a/agent/src/bin/dd-agent/main.rs
+++ b/agent/src/bin/dd-agent/main.rs
@@ -477,9 +477,6 @@ async fn run_agent_mode(cfg: AgentRuntimeConfig) {
             format!("DD_BOOT_IMAGE_{i}")
         };
         let Ok(image) = std::env::var(&image_key) else {
-            if i > 0 {
-                break;
-            }
             continue;
         };
         let app_name = if i == 0 {


### PR DESCRIPTION
DD_BOOT_IMAGE_2 was unreachable if DD_BOOT_IMAGE_1 wasn't set — the loop broke at the first missing index. Now it continues through all 0-9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)