### PR TITLE
Volume mount support for container deployments

### DIFF
--- a/agent/src/bin/dd-agent/main.rs
+++ b/agent/src/bin/dd-agent/main.rs
@@ -502,6 +502,7 @@ async fn run_agent_mode(cfg: AgentRuntimeConfig) {
             image: Some(image),
             env,
             app_name: Some(app_name),
+            volumes: None,
             app_version: None,
             tty: false,
         };
@@ -533,6 +534,7 @@ async fn run_agent_mode(cfg: AgentRuntimeConfig) {
             image: None,
             env,
             app_name: Some(app_name),
+            volumes: None,
             app_version: None,
             tty,
         };

--- a/agent/src/container.rs
+++ b/agent/src/container.rs
@@ -26,6 +26,7 @@ pub async fn pull_and_run(
     image: &str,
     name: &str,
     env: Option<Vec<String>>,
+    volumes: Option<Vec<String>>,
     network_host: bool,
 ) -> Result<String, String> {
     let docker = connect()?;
@@ -59,6 +60,7 @@ pub async fn pull_and_run(
 
     // Create container
     let host_config = bollard::models::HostConfig {
+        binds: volumes,
         network_mode: if network_host {
             Some("host".to_string())
         } else {

--- a/agent/src/noise.rs
+++ b/agent/src/noise.rs
@@ -325,7 +325,7 @@ async fn handle_session(
                         let req = crate::server::DeployRequest {
                             cmd, image, env,
                             app_name: app_name.clone(),
-                            app_version: None, tty,
+                            volumes: None, app_version: None, tty,
                         };
                         let (id, status) = crate::server::execute_deploy(deployments, req).await;
                         NoiseMessage::Ok {

--- a/agent/src/server.rs
+++ b/agent/src/server.rs
@@ -41,6 +41,8 @@ pub struct DeployRequest {
     #[serde(default)]
     pub env: Option<Vec<String>>,
     #[serde(default)]
+    pub volumes: Option<Vec<String>>,
+    #[serde(default)]
     pub app_name: Option<String>,
     #[serde(default)]
     pub app_version: Option<String>,
@@ -1418,7 +1420,7 @@ async fn handle_ws_noise_cmd(socket: WebSocket, state: AgentState) {
                         let req = DeployRequest {
                             cmd, image, env,
                             app_name: app_name.clone(),
-                            app_version: None, tty,
+                            volumes: None, app_version: None, tty,
                         };
                         let (id, status) = execute_deploy(&state.deployments, req).await;
                         crate::noise::NoiseMessage::Ok {
@@ -2475,6 +2477,7 @@ async fn new_terminal(
         cmd: vec!["bash".into()],
         image: None,
         env: None,
+        volumes: None,
         app_name: Some(name.clone()),
         app_version: None,
         tty: true,
@@ -2579,7 +2582,7 @@ async fn run_deploy(
 
     if let Some(ref image) = req.image {
         // Container path — pull and run via bollard
-        match crate::container::pull_and_run(image, &app_name, req.env, true).await {
+        match crate::container::pull_and_run(image, &app_name, req.env, req.volumes, true).await {
             Ok(container_id) => {
                 eprintln!("dd-agent: deployment {dep_id} running (container={container_id})");
                 let mut deps = deployments.lock().await;


### PR DESCRIPTION
## Summary
Add `volumes` field to the deploy API for bind-mounting host paths into containers (e.g. openclaw config file).

```json
POST /deploy
{
  "image": "ghcr.io/openclaw/openclaw:latest",
  "app_name": "openclaw",
  "volumes": ["/var/lib/openclaw:/home/node/.openclaw"],
  "env": ["OPENAI_API_KEY=..."]
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)