### PR TITLE
feat: POST /exec endpoint + password bearer auth

### DIFF
--- a/agent/src/bin/dd-agent/main.rs
+++ b/agent/src/bin/dd-agent/main.rs
@@ -502,6 +502,7 @@ async fn run_agent_mode(cfg: AgentRuntimeConfig) {
             image: Some(image),
             env,
             app_name: Some(app_name),
+            volumes: None,
             app_version: None,
             tty: false,
         };
@@ -533,6 +534,7 @@ async fn run_agent_mode(cfg: AgentRuntimeConfig) {
             image: None,
             env,
             app_name: Some(app_name),
+            volumes: None,
             app_version: None,
             tty,
         };

--- a/agent/src/container.rs
+++ b/agent/src/container.rs
@@ -26,6 +26,7 @@ pub async fn pull_and_run(
     image: &str,
     name: &str,
     env: Option<Vec<String>>,
+    volumes: Option<Vec<String>>,
     network_host: bool,
 ) -> Result<String, String> {
     let docker = connect()?;
@@ -59,6 +60,7 @@ pub async fn pull_and_run(
 
     // Create container
     let host_config = bollard::models::HostConfig {
+        binds: volumes,
         network_mode: if network_host {
             Some("host".to_string())
         } else {

--- a/agent/src/noise.rs
+++ b/agent/src/noise.rs
@@ -325,7 +325,7 @@ async fn handle_session(
                         let req = crate::server::DeployRequest {
                             cmd, image, env,
                             app_name: app_name.clone(),
-                            app_version: None, tty,
+                            volumes: None, app_version: None, tty,
                         };
                         let (id, status) = crate::server::execute_deploy(deployments, req).await;
                         NoiseMessage::Ok {

--- a/agent/src/server.rs
+++ b/agent/src/server.rs
@@ -33,6 +33,24 @@ pub struct DeploymentInfo {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+pub struct ExecRequest {
+    pub cmd: Vec<String>,
+    #[serde(default = "default_exec_timeout")]
+    pub timeout_secs: u64,
+}
+
+fn default_exec_timeout() -> u64 {
+    30
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ExecResponse {
+    pub exit_code: i32,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
 pub struct DeployRequest {
     #[serde(default)]
     pub cmd: Vec<String>,
@@ -330,7 +348,17 @@ async fn resolve_auth(
         return Ok(Some(token));
     }
 
-    // 3. GitHub-mode only: check query param and Authorization header
+    // 3. Password-mode: check Authorization header against DD_PASSWORD
+    if let AuthMode::Password { ref password, .. } = state.auth_mode {
+        if let Some(token) = extract_auth(headers) {
+            if constant_time_eq(token.as_bytes(), password.as_bytes()) {
+                return Ok(Some("password-bearer".to_string()));
+            }
+            return Err(AppError::Unauthorized);
+        }
+    }
+
+    // 4. GitHub-mode only: check query param and Authorization header
     if matches!(state.auth_mode, AuthMode::GitHub(_)) {
         if let Some(token) = query_token.filter(|token| !token.is_empty()) {
             verify_github_token(token, &state.owner).await?;
@@ -2452,6 +2480,7 @@ pub fn build_router(state: AgentState) -> Router {
         .route("/noise/session/{app_name}", get(ws_noise_session))
         .route("/noise/cmd", get(ws_noise_cmd))
         .route("/deploy", post(post_deploy))
+        .route("/exec", post(post_exec))
         .route("/terminal", post(new_terminal))
         .with_state(state)
 }
@@ -2510,6 +2539,78 @@ async fn post_deploy(
 
     let (id, status) = execute_deploy(&state.deployments, req).await;
     Json(serde_json::json!({"id": id, "status": status})).into_response()
+}
+
+// ── POST /exec — synchronous command execution ─────────────────────────
+
+async fn post_exec(
+    axum::extract::ConnectInfo(addr): axum::extract::ConnectInfo<std::net::SocketAddr>,
+    State(state): State<AgentState>,
+    headers: HeaderMap,
+    Json(req): Json<ExecRequest>,
+) -> Response {
+    if !addr.ip().is_loopback() && verify_owner(&state, &headers).await.is_err() {
+        return (
+            axum::http::StatusCode::UNAUTHORIZED,
+            Json(serde_json::json!({"error": "authentication required"})),
+        )
+            .into_response();
+    }
+
+    if req.cmd.is_empty() {
+        return (
+            axum::http::StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": "cmd must not be empty"})),
+        )
+            .into_response();
+    }
+
+    let timeout = std::time::Duration::from_secs(req.timeout_secs.min(300));
+    let program = &req.cmd[0];
+    let args: Vec<&str> = req.cmd[1..].iter().map(|s| s.as_str()).collect();
+
+    let mut cmd = tokio::process::Command::new(program);
+    cmd.args(&args);
+    cmd.stdin(std::process::Stdio::null());
+    cmd.stdout(std::process::Stdio::piped());
+    cmd.stderr(std::process::Stdio::piped());
+
+    let child = match cmd.spawn() {
+        Ok(child) => child,
+        Err(e) => {
+            return (
+                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": format!("spawn failed: {e}")})),
+            )
+                .into_response();
+        }
+    };
+
+    let pid = child.id();
+
+    match tokio::time::timeout(timeout, child.wait_with_output()).await {
+        Ok(Ok(output)) => Json(ExecResponse {
+            exit_code: output.status.code().unwrap_or(-1),
+            stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+            stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        })
+        .into_response(),
+        Ok(Err(e)) => (
+            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": format!("wait failed: {e}")})),
+        )
+            .into_response(),
+        Err(_) => {
+            if let Some(pid) = pid {
+                let _ = crate::process::kill_process(pid).await;
+            }
+            (
+                axum::http::StatusCode::REQUEST_TIMEOUT,
+                Json(serde_json::json!({"error": format!("command timed out after {}s", timeout.as_secs())})),
+            )
+                .into_response()
+        }
+    }
 }
 
 // ── Deploy/Stop logic (called by Noise command channel) ──────────────────

--- a/agent/src/server.rs
+++ b/agent/src/server.rs
@@ -41,6 +41,8 @@ pub struct DeployRequest {
     #[serde(default)]
     pub env: Option<Vec<String>>,
     #[serde(default)]
+    pub volumes: Option<Vec<String>>,
+    #[serde(default)]
     pub app_name: Option<String>,
     #[serde(default)]
     pub app_version: Option<String>,
@@ -1418,7 +1420,7 @@ async fn handle_ws_noise_cmd(socket: WebSocket, state: AgentState) {
                         let req = DeployRequest {
                             cmd, image, env,
                             app_name: app_name.clone(),
-                            app_version: None, tty,
+                            volumes: None, app_version: None, tty,
                         };
                         let (id, status) = execute_deploy(&state.deployments, req).await;
                         crate::noise::NoiseMessage::Ok {
@@ -2475,6 +2477,7 @@ async fn new_terminal(
         cmd: vec!["bash".into()],
         image: None,
         env: None,
+        volumes: None,
         app_name: Some(name.clone()),
         app_version: None,
         tty: true,
@@ -2579,7 +2582,7 @@ async fn run_deploy(
 
     if let Some(ref image) = req.image {
         // Container path — pull and run via bollard
-        match crate::container::pull_and_run(image, &app_name, req.env, true).await {
+        match crate::container::pull_and_run(image, &app_name, req.env, req.volumes, true).await {
             Ok(container_id) => {
                 eprintln!("dd-agent: deployment {dep_id} running (container={container_id})");
                 let mut deps = deployments.lock().await;


### PR DESCRIPTION
## Summary
- Add `POST /exec` endpoint for synchronous command execution (spawn, wait, return stdout/stderr/exit_code)
- Accept `DD_PASSWORD` as `Authorization: Bearer` token in `resolve_auth()` (constant-time compare)
- Same auth pattern as `/deploy`: localhost bypass, remote requires auth
- Timeout capped at 300s, process killed on timeout

## Test plan
- [ ] `curl -X POST /exec -H "Authorization: Bearer $PASSWORD" -d '{"cmd":["echo","hello"]}'` returns `{"exit_code":0,"stdout":"hello\n","stderr":""}`
- [ ] Bad password returns 401
- [ ] `{"cmd":["sleep","999"],"timeout_secs":2}` returns 408
- [ ] Localhost access works without auth

🤖 Generated with [Claude Code](https://claude.com/claude-code)