### PR TITLE
feat: post_deploy exec commands for container workloads

### DIFF
--- a/agent/src/bin/dd-agent/main.rs
+++ b/agent/src/bin/dd-agent/main.rs
@@ -505,6 +505,7 @@ async fn run_agent_mode(cfg: AgentRuntimeConfig) {
             volumes: None,
             app_version: None,
             tty: false,
+            post_deploy: None,
         };
         let (id, status) = dd_agent::server::execute_deploy(&deployments, req).await;
         eprintln!("dd-agent: boot container {id} {status}");
@@ -537,6 +538,7 @@ async fn run_agent_mode(cfg: AgentRuntimeConfig) {
             volumes: None,
             app_version: None,
             tty,
+            post_deploy: None,
         };
         let (id, status) = dd_agent::server::execute_deploy(&deployments, req).await;
         eprintln!("dd-agent: boot command {id} {status}");

--- a/agent/src/container.rs
+++ b/agent/src/container.rs
@@ -104,6 +104,60 @@ pub async fn pull_and_run(
     Ok(container.id)
 }
 
+/// Execute a command inside a running container. Returns (exit_code, stdout, stderr).
+pub async fn exec(container_name: &str, cmd: &[String]) -> Result<(i64, String, String), String> {
+    use bollard::exec::{CreateExecOptions, StartExecOptions};
+
+    let docker = connect()?;
+    let exec = docker
+        .create_exec(
+            container_name,
+            CreateExecOptions {
+                cmd: Some(cmd.to_vec()),
+                attach_stdout: Some(true),
+                attach_stderr: Some(true),
+                ..Default::default()
+            },
+        )
+        .await
+        .map_err(|e| format!("create exec: {e}"))?;
+
+    let output = docker
+        .start_exec(
+            &exec.id,
+            Some(StartExecOptions {
+                detach: false,
+                ..Default::default()
+            }),
+        )
+        .await
+        .map_err(|e| format!("start exec: {e}"))?;
+
+    let mut stdout = String::new();
+    let mut stderr = String::new();
+    if let bollard::exec::StartExecResults::Attached { mut output, .. } = output {
+        while let Some(Ok(msg)) = output.next().await {
+            match msg {
+                bollard::container::LogOutput::StdOut { message } => {
+                    stdout.push_str(&String::from_utf8_lossy(&message));
+                }
+                bollard::container::LogOutput::StdErr { message } => {
+                    stderr.push_str(&String::from_utf8_lossy(&message));
+                }
+                _ => {}
+            }
+        }
+    }
+
+    let inspect = docker
+        .inspect_exec(&exec.id)
+        .await
+        .map_err(|e| format!("inspect exec: {e}"))?;
+    let exit_code = inspect.exit_code.unwrap_or(-1);
+
+    Ok((exit_code, stdout, stderr))
+}
+
 /// Stop and remove a container.
 pub async fn stop(container_id: &str) -> Result<(), String> {
     let docker = connect()?;

--- a/agent/src/noise.rs
+++ b/agent/src/noise.rs
@@ -326,6 +326,7 @@ async fn handle_session(
                             cmd, image, env,
                             app_name: app_name.clone(),
                             volumes: None, app_version: None, tty,
+                            post_deploy: None,
                         };
                         let (id, status) = crate::server::execute_deploy(deployments, req).await;
                         NoiseMessage::Ok {

--- a/agent/src/server.rs
+++ b/agent/src/server.rs
@@ -66,6 +66,10 @@ pub struct DeployRequest {
     pub app_version: Option<String>,
     #[serde(default)]
     pub tty: bool,
+    /// Commands to exec inside the container after it starts.
+    /// Each entry is a list of strings (program + args).
+    #[serde(default)]
+    pub post_deploy: Option<Vec<Vec<String>>>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -1449,6 +1453,7 @@ async fn handle_ws_noise_cmd(socket: WebSocket, state: AgentState) {
                             cmd, image, env,
                             app_name: app_name.clone(),
                             volumes: None, app_version: None, tty,
+                            post_deploy: None,
                         };
                         let (id, status) = execute_deploy(&state.deployments, req).await;
                         crate::noise::NoiseMessage::Ok {
@@ -2510,6 +2515,7 @@ async fn new_terminal(
         app_name: Some(name.clone()),
         app_version: None,
         tty: true,
+        post_deploy: None,
     };
 
     let (id, _status) =
@@ -2688,8 +2694,66 @@ async fn run_deploy(
                 eprintln!("dd-agent: deployment {dep_id} running (container={container_id})");
                 let mut deps = deployments.lock().await;
                 if let Some(info) = deps.get_mut(&dep_id) {
-                    info.container_id = Some(container_id);
+                    info.container_id = Some(container_id.clone());
                     info.status = "running".into();
+                }
+                drop(deps);
+
+                // Run post-deploy commands inside the container
+                if let Some(ref commands) = req.post_deploy {
+                    // Wait for container to be ready
+                    for _ in 0..60 {
+                        if crate::container::is_running(&container_id).await {
+                            break;
+                        }
+                        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+                    }
+
+                    for cmd in commands {
+                        if cmd.is_empty() {
+                            continue;
+                        }
+                        eprintln!("dd-agent: post-deploy exec: {}", cmd.join(" "));
+                        match crate::container::exec(&app_name, cmd).await {
+                            Ok((code, stdout, stderr)) => {
+                                if code != 0 {
+                                    eprintln!(
+                                        "dd-agent: post-deploy cmd failed (exit {}): {}{}",
+                                        code,
+                                        stdout.trim(),
+                                        if stderr.is_empty() {
+                                            String::new()
+                                        } else {
+                                            format!(" stderr: {}", stderr.trim())
+                                        }
+                                    );
+                                    set_deploy_failed(
+                                        &deployments,
+                                        &dep_id,
+                                        &format!(
+                                            "post-deploy failed: {} (exit {code})",
+                                            cmd.join(" ")
+                                        ),
+                                    )
+                                    .await;
+                                    return;
+                                }
+                                if !stdout.trim().is_empty() {
+                                    eprintln!("dd-agent: post-deploy: {}", stdout.trim());
+                                }
+                            }
+                            Err(e) => {
+                                set_deploy_failed(
+                                    &deployments,
+                                    &dep_id,
+                                    &format!("post-deploy exec error: {e}"),
+                                )
+                                .await;
+                                return;
+                            }
+                        }
+                    }
+                    eprintln!("dd-agent: post-deploy commands complete for {app_name}");
                 }
             }
             Err(e) => {


### PR DESCRIPTION
## Summary
- Add `post_deploy` field to `DeployRequest` — list of commands to exec inside the container after it starts
- Add `container::exec()` using bollard exec API
- After container starts, waits for it to be running, then runs each command in sequence
- Fails the deployment if any post-deploy command returns non-zero

Example deploy with config:
```json
POST /deploy
{
  "image": "ghcr.io/openclaw/openclaw:latest",
  "app_name": "openclaw",
  "env": ["OPENAI_API_KEY=..."],
  "post_deploy": [
    ["openclaw", "config", "set", "gateway.mode", "local"],
    ["openclaw", "config", "set", "gateway.bind", "lan"],
    ["openclaw", "config", "set", "gateway.auth.mode", "token"]
  ]
}
```

## Test plan
- [ ] Deploy with `post_deploy` commands, verify they execute in order
- [ ] Deploy with a failing command, verify deployment status is "failed"
- [ ] Deploy without `post_deploy` (backwards compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)