### PR TITLE
feat: capture post_deploy step output and surface failures in /health

### DIFF
--- a/agent/src/bin/dd-agent/server/deploy.rs
+++ b/agent/src/bin/dd-agent/server/deploy.rs
@@ -11,6 +11,17 @@ use tokio::sync::Mutex;
 use super::{require_browser_token, verify_owner, AgentState};
 
 #[derive(Debug, Clone, Serialize)]
+pub struct PostDeployStep {
+    pub cmd: Vec<String>,
+    pub exit_code: i64,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub stdout: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub stderr: String,
+    pub duration_ms: u64,
+}
+
+#[derive(Debug, Clone, Serialize)]
 pub struct DeploymentInfo {
     pub id: String,
     pub pid: Option<u32>,
@@ -22,6 +33,8 @@ pub struct DeploymentInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error_message: Option<String>,
     pub started_at: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub post_deploy_steps: Vec<PostDeployStep>,
 }
 
 pub type Deployments = Arc<Mutex<HashMap<String, DeploymentInfo>>>;
@@ -232,6 +245,7 @@ pub async fn execute_deploy_with_handles(
         status: "deploying".into(),
         error_message: None,
         started_at: chrono::Utc::now().to_rfc3339(),
+        post_deploy_steps: Vec::new(),
     };
     deployments.lock().await.insert(dep_id.clone(), info);
 
@@ -295,8 +309,23 @@ async fn run_deploy(
                             continue;
                         }
                         eprintln!("dd-agent: post-deploy exec: {}", cmd.join(" "));
-                        match dd_agent::container::exec(&app_name, cmd).await {
+                        let started = std::time::Instant::now();
+                        let result = dd_agent::container::exec(&app_name, cmd).await;
+                        let duration_ms = started.elapsed().as_millis() as u64;
+                        match result {
                             Ok((code, stdout, stderr)) => {
+                                {
+                                    let mut deps = deployments.lock().await;
+                                    if let Some(info) = deps.get_mut(&dep_id) {
+                                        info.post_deploy_steps.push(PostDeployStep {
+                                            cmd: cmd.clone(),
+                                            exit_code: code,
+                                            stdout: stdout.clone(),
+                                            stderr: stderr.clone(),
+                                            duration_ms,
+                                        });
+                                    }
+                                }
                                 if code != 0 {
                                     eprintln!(
                                         "dd-agent: post-deploy cmd failed (exit {}): {}{}",
@@ -324,6 +353,18 @@ async fn run_deploy(
                                 }
                             }
                             Err(e) => {
+                                {
+                                    let mut deps = deployments.lock().await;
+                                    if let Some(info) = deps.get_mut(&dep_id) {
+                                        info.post_deploy_steps.push(PostDeployStep {
+                                            cmd: cmd.clone(),
+                                            exit_code: -1,
+                                            stdout: String::new(),
+                                            stderr: e.clone(),
+                                            duration_ms,
+                                        });
+                                    }
+                                }
                                 set_deploy_failed(
                                     &deployments,
                                     &dep_id,

--- a/agent/src/bin/dd-agent/server/mod.rs
+++ b/agent/src/bin/dd-agent/server/mod.rs
@@ -27,6 +27,21 @@ pub use deploy::{
 // ── Types ─────────────────────────────────────────────────────────────────
 
 #[derive(Debug, Clone, Serialize)]
+pub struct DeploymentSummary {
+    pub app_name: String,
+    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_message: Option<String>,
+    /// Argv of the most recent post_deploy step (if any).
+    /// Useful for CI to identify which step a failed deploy stopped on
+    /// without exposing stdout/stderr on the unauthenticated /health endpoint.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_step_cmd: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_step_exit_code: Option<i64>,
+}
+
+#[derive(Debug, Clone, Serialize)]
 pub struct HealthResponse {
     pub ok: bool,
     pub agent_id: String,
@@ -35,6 +50,13 @@ pub struct HealthResponse {
     pub attestation_type: String,
     pub deployment_count: usize,
     pub deployments: Vec<String>,
+    /// All deployments with status + last-step metadata, regardless of state.
+    /// `deployments` above keeps the existing running-only Vec<String> shape for
+    /// back-compat; this field is the richer view CI uses to detect failures.
+    /// Stdout/stderr are deliberately *not* exposed here — fetch
+    /// /deployments/{id} (auth required) for full output.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub all_deployments: Vec<DeploymentSummary>,
     pub uptime_seconds: u64,
     pub cpu_percent: u64,
     pub memory_used_mb: u64,
@@ -389,6 +411,19 @@ async fn health(State(state): State<AgentState>) -> Json<HealthResponse> {
         .filter(|d| d.status == "running")
         .map(|d| d.app_name.clone())
         .collect();
+    let all_deployments: Vec<DeploymentSummary> = deps
+        .values()
+        .map(|d| {
+            let last_step = d.post_deploy_steps.last();
+            DeploymentSummary {
+                app_name: d.app_name.clone(),
+                status: d.status.clone(),
+                error_message: d.error_message.clone(),
+                last_step_cmd: last_step.map(|s| s.cmd.clone()),
+                last_step_exit_code: last_step.map(|s| s.exit_code),
+            }
+        })
+        .collect();
     drop(deps);
     let metrics = collect_metrics().await;
     Json(HealthResponse {
@@ -399,6 +434,7 @@ async fn health(State(state): State<AgentState>) -> Json<HealthResponse> {
         attestation_type: state.attestation_type.clone(),
         deployment_count,
         deployments: deployment_names,
+        all_deployments,
         uptime_seconds: state.started_at.elapsed().as_secs(),
         cpu_percent: metrics.cpu_pct,
         memory_used_mb: parse_size_mb(&metrics.mem_used),


### PR DESCRIPTION
## Summary

Two related changes that together let CI see why a workload deploy failed without needing an auth credential against dd-agent.

### 1. Capture every post_deploy step

New `PostDeployStep { cmd, exit_code, stdout, stderr, duration_ms }` is appended to `DeploymentInfo.post_deploy_steps` for every exec the `run_deploy` loop runs against the workload container — both successful and failed steps, plus a synthetic `exit_code=-1` entry for the case where `container::exec` itself errors before the command runs.

Previously the stdout/stderr from each post_deploy command was `eprintln!`'d to dd-agent's stderr and discarded. The authenticated `/deployments/{id}` endpoint already returned `DeploymentInfo`, so it now picks up the new field for free — no new routes required to get full output.

### 2. Surface a sanitized summary on /health

New `DeploymentSummary { app_name, status, error_message, last_step_cmd, last_step_exit_code }` and a `HealthResponse.all_deployments` field populated from every entry in the deployments map (not just `status == "running"`). This gives CI enough to detect _"openclaw status=failed, last step `[sh -c ollama launch …]` exit 1"_ by polling `/health`, which is already unauthenticated.

**Stdout and stderr are deliberately NOT included in the summary** so `/health` stays safe to expose publicly — full output remains behind `verify_owner` on `/deployments/{id}`.

The existing `deployments: Vec<String>` field is preserved as running-only for back-compat with anything that already parses `/health`.

## Why

Debugging a marketplace workload deploy currently requires SSH-ing into the VM and reading dd-agent's stderr or container logs. With this change, the GH Actions workflow can poll the agent's existing `/health` endpoint and on a `failed` status print the failing step + exit code straight into the action log. Comes out of the marketplace#37 openclaw debug iteration where an `ollama launch` failure was invisible to CI.

## Base

Stacked on `feat/bootstrap-local-register` because `deploy.rs` only exists on that branch — needs to be rebased onto main once the bootstrap branch lands.

## Test plan

- [x] `cargo fmt -p dd-agent`
- [x] `cargo clippy -p dd-agent --all-targets -- -D warnings` clean
- [x] `cargo test -p dd-agent` passes (5 existing tests, no new ones added — pure additive struct fields + capture loop)
- [ ] After merge: marketplace follow-up to rewrite the workflow's verify step to use `all_deployments` and print failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)