### PR TITLE
fix(register): clean up stale agent entries on re-registration

### DIFF
--- a/agent/src/server.rs
+++ b/agent/src/server.rs
@@ -2393,8 +2393,43 @@ async fn handle_ws_register(socket: WebSocket, state: AgentState) {
         Err(_) => return,
     };
 
-    // Create tunnel
     let client = reqwest::Client::new();
+
+    // Re-registration cleanup: if any existing entries match this vm_name,
+    // remove their tunnels + registry entries before issuing a new agent_id.
+    // Without this the fleet dashboard accumulates stale entries on every
+    // dd-agent release, since each redeploy generates a new agent_id but
+    // the scraper-based cleanup only fires after multiple failed scrapes.
+    let stale: Vec<(String, String)> = {
+        let registry = state.agent_registry.lock().await;
+        registry
+            .values()
+            .filter(|a| a.vm_name == reg.vm_name)
+            .map(|a| (a.agent_id.clone(), a.hostname.clone()))
+            .collect()
+    };
+    if !stale.is_empty() {
+        for (old_agent_id, old_hostname) in &stale {
+            if let Err(e) =
+                crate::tunnel::remove_agent(&client, &cf, old_agent_id, old_hostname).await
+            {
+                eprintln!("dd-register: stale tunnel cleanup failed for {old_hostname}: {e}");
+                // Don't block re-registration on CF API hiccups; the next
+                // scraper pass will retry.
+            } else {
+                eprintln!(
+                    "dd-register: removed stale tunnel for vm {} (agent_id={old_agent_id}, hostname={old_hostname})",
+                    reg.vm_name
+                );
+            }
+        }
+        let mut registry = state.agent_registry.lock().await;
+        for (old_agent_id, _) in &stale {
+            registry.remove(old_agent_id);
+        }
+    }
+
+    // Create tunnel
     let agent_id = uuid::Uuid::new_v4().to_string();
     let tunnel_info =
         match crate::tunnel::create_agent_tunnel(&client, &cf, &agent_id, &reg.vm_name, None).await


### PR DESCRIPTION
## Summary

When a marketplace VM is destroyed and recreated by a deploy workflow, the new dd-agent generates a fresh `agent_id` (UUID) and connects to the register. \`ws_register\` creates a brand-new Cloudflare tunnel for the new agent_id and inserts a new entry into \`state.agent_registry\` — but **it never removes the old entry for the same \`vm_name\`**. The fleet dashboard accumulates stale entries: old agent_id with old hostname slug, alongside the new one. Clicking the stale link in the dashboard leads to a dead-feeling URL like \`dd-staging-{old_agent_id}.devopsdefender.com\` even though the live agent has a different agent_id.

The scraper does eventually clean stale entries via mark-stale → mark-dead → \`remove_agent\`, but that takes multiple failed scrape passes and leaves duplicates in the dashboard meanwhile.

## Fix

In \`handle_ws_register\` (\`agent/src/server.rs\`), after parsing the registration request and before creating the new tunnel, sweep \`agent_registry\` for entries with matching \`vm_name\`. For each, call \`crate::tunnel::remove_agent\` to delete the CF tunnel + DNS record, then drop the registry entry.

- **vm_name as dedupe key.** \`agent_id\` is regenerated per registration; \`vm_name\` is stable across redeploys (\`dd-vm-staging\`, \`dd-vm-production\`, etc.) and is what the workflows pass in. Different VMs have different vm_names so there's no risk of collapsing distinct agents.
- **Lock released across CF API calls.** Collect stale list under the lock, drop it, run \`remove_agent\` round-trips without holding the lock, then re-acquire to remove the entries. Avoids blocking other handlers on CF API latency.
- **Cleanup failures don't block re-registration.** If CF is having a bad day, \`eprintln!\` the error and proceed; the scraper acts as a fallback.

## Why this surfaces now

Comes out of the marketplace#37 openclaw debug iteration. After multiple staging redeploys to iterate on \`apps/openclaw/deploy.json\`, the user clicked an agent in the fleet UI and landed on \`https://dd-staging-2bf28d2d-….devopsdefender.com\` (an old agent_id), but \`/health\` on that hostname returned \`agent_id: ffc88802-…\` (the live one). The mismatch was the giveaway that re-registration only "half" works.

## Test plan

- [x] \`cargo fmt -p dd-agent\`
- [x] \`cargo clippy -p dd-agent --all-targets -- -D warnings\` clean
- [x] \`cargo test -p dd-agent\` passes
- [ ] After release: trigger \`staging-deploy.yml\` twice in a row; confirm fleet UI shows only one entry for \`dd-vm-staging\` with the latest agent_id, and \`curl https://dd-staging-{first_agent_id}.devopsdefender.com/health\` returns NXDOMAIN/tunnel-not-found instead of routing to a live agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)