### PR TITLE
feat(auth): accept GitHub PAT as Bearer token for CI access

### DIFF
--- a/agent/src/server.rs
+++ b/agent/src/server.rs
@@ -375,6 +375,18 @@ async fn resolve_auth(
         }
     }
 
+    // 5. GitHub PAT fallback: accept a Bearer token and verify against
+    //    GitHub regardless of auth mode. This lets CI tools (e.g. GitHub
+    //    Actions with a PAT in secrets) authenticate using the same
+    //    verify_github_token the OAuth flow uses. Only reached when steps
+    //    1–4 didn't match — no JWT cookie, no session, and auth mode
+    //    isn't Password (which short-circuits on header mismatch above).
+    if let Some(token) = extract_auth(headers) {
+        if verify_github_token(&token, &state.owner).await.is_ok() {
+            return Ok(Some("github-pat".to_string()));
+        }
+    }
+
     Err(AppError::Unauthorized)
 }
 


### PR DESCRIPTION
## Summary

Add a fallback auth step to `resolve_auth` in `agent/src/server.rs` (+12 lines) that verifies any `Authorization: Bearer <token>` against the GitHub API using the existing `verify_github_token` function. This lets CI tools authenticate to dd-agent's protected endpoints (`/deployments`, `/exec`) with a GitHub PAT stored in secrets.

## How it works

Auth resolution order (steps 1–4 unchanged):

| Step | Method | Mode gate | Short-circuits? |
|------|--------|-----------|-----------------|
| 1 | `dd_auth` JWT cookie | any | no |
| 2 | Session cookie | any | no |
| 3 | `DD_PASSWORD` Bearer | Password only | yes (401 on mismatch) |
| 4 | GitHub token in header/query | GitHub OAuth only | yes |
| **5** | **GitHub PAT Bearer fallback** | **any** | **no (soft — swallows verify errors)** |

Step 5 only fires when steps 1–4 all skip. In practice that means: no JWT cookie, no session, auth mode isn't Password (which short-circuits), and auth mode isn't GitHub OAuth. This is the exact scenario CI tools hit — raw Bearer token, no cookies, agent in default auth mode.

The verify calls `GET /user` + `GET /user/orgs` on api.github.com — same as the existing OAuth flow. If the PAT owner is the DD_OWNER user or a member of the DD_OWNER org, auth passes.

## Usage from CI

```yaml
# In the GitHub Action:
curl -fsS \
  -H "Authorization: Bearer ${{ secrets.DD_AGENT_PAT }}" \
  http://${VM_IP}:8080/deployments | jq .
```

Where `DD_AGENT_PAT` is a GitHub PAT for a user in the `devopsdefender` org (or the `devopsdefender` user directly).

## Performance

`verify_github_token` makes 1–2 HTTP round-trips to api.github.com per request (~200ms). Acceptable for CI (handful of requests per deploy). Browser/session traffic hits steps 1–2 and never reaches step 5.

## Test plan

- [x] `cargo fmt && cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` passes
- [ ] After merge + release: from a GH Action, `curl -H "Authorization: Bearer <pat>" http://<vm>:8080/deployments` returns deployment list instead of 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)