### PR TITLE
ci: auth via GCP Workload Identity Federation

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -57,10 +57,18 @@ jobs:
   cleanup:
     runs-on: ubuntu-latest
     environment: production
+    permissions:
+      contents: read
+      id-token: write   # mint GitHub OIDC token for GCP WIF
     steps:
+      # GCP Workload Identity Federation (no stored SA key). Pool +
+      # provider in the easyenclave project (dd production's GCP),
+      # attribute condition covers 'devopsdefender/dd', SA binding
+      # is scoped to the same principal set.
       - uses: google-github-actions/auth@v2
         with:
-          credentials_json: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
+          workload_identity_provider: 'projects/779946350556/locations/global/workloadIdentityPools/github-actions-pool/providers/github-provider'
+          service_account: 'easyenclave-production-ci@easyenclave.iam.gserviceaccount.com'
       - uses: google-github-actions/setup-gcloud@v2
       - name: Delete managed VMs
         env:
@@ -81,12 +89,13 @@ jobs:
     environment: production
     permissions:
       contents: read
-      id-token: write   # for minting the GitHub Actions OIDC token
+      id-token: write   # mint GitHub OIDC token for GCP WIF + dd-web OIDC
     steps:
       - uses: actions/checkout@v4
       - uses: google-github-actions/auth@v2
         with:
-          credentials_json: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
+          workload_identity_provider: 'projects/779946350556/locations/global/workloadIdentityPools/github-actions-pool/providers/github-provider'
+          service_account: 'easyenclave-production-ci@easyenclave.iam.gserviceaccount.com'
       - uses: google-github-actions/setup-gcloud@v2
 
       - name: Create TDX VM

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -60,10 +60,18 @@ jobs:
   cleanup:
     runs-on: ubuntu-latest
     environment: staging
+    permissions:
+      contents: read
+      id-token: write   # mint GitHub OIDC token for GCP WIF
     steps:
+      # GCP Workload Identity Federation (no stored SA key). Pool +
+      # provider in the eestaging project (dd staging's GCP), attribute
+      # condition is `assertion.repository == 'devopsdefender/dd'`, SA
+      # binding is scoped to the same principal set.
       - uses: google-github-actions/auth@v2
         with:
-          credentials_json: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
+          workload_identity_provider: 'projects/654815109728/locations/global/workloadIdentityPools/github-actions-pool/providers/github-provider'
+          service_account: 'easyenclave-staging-ci@eestaging.iam.gserviceaccount.com'
       - uses: google-github-actions/setup-gcloud@v2
       - name: Delete managed VMs
         env:
@@ -84,12 +92,13 @@ jobs:
     environment: staging
     permissions:
       contents: read
-      id-token: write   # for minting the GitHub Actions OIDC token
+      id-token: write   # mint GitHub OIDC token for GCP WIF + dd-web OIDC
     steps:
       - uses: actions/checkout@v4
       - uses: google-github-actions/auth@v2
         with:
-          credentials_json: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
+          workload_identity_provider: 'projects/654815109728/locations/global/workloadIdentityPools/github-actions-pool/providers/github-provider'
+          service_account: 'easyenclave-staging-ci@eestaging.iam.gserviceaccount.com'
       - uses: google-github-actions/setup-gcloud@v2
 
       - name: Create TDX VM


### PR DESCRIPTION
## Summary

- Replace stored `GCP_SERVICE_ACCOUNT_KEY` in both staging and production deploy workflows with GitHub Actions OIDC via GCP Workload Identity Federation
- `cleanup` and `deploy` jobs in both workflows now mint a short-lived OIDC JWT (`id-token: write`) and trade it for a GCP access token by impersonating the respective CI service account

## GCP infra (already applied)

**Staging — `eestaging` project** (project number `654815109728`):
- Created pool `github-actions-pool` + provider `github-provider` (issuer `https://token.actions.githubusercontent.com`, attribute condition `assertion.repository == 'devopsdefender/dd'`)
- Added `roles/iam.workloadIdentityUser` on `easyenclave-staging-ci@eestaging.iam.gserviceaccount.com` for `principalSet://.../attribute.repository/devopsdefender/dd`

**Production — `easyenclave` project** (project number `779946350556`, shared with easyenclave image pipeline):
- Widened existing provider's attribute condition from `easyenclave/easyenclave` to `easyenclave/easyenclave || devopsdefender/dd`
- Added `roles/iam.workloadIdentityUser` on `easyenclave-production-ci@easyenclave.iam.gserviceaccount.com` for `principalSet://.../attribute.repository/devopsdefender/dd`

## Why OIDC over stored keys

- No secrets to rotate or leak
- Short-lived tokens (minutes, not forever)
- Claims-based scoping (repo, ref, workflow, environment) — a leaked workflow file can't authenticate from another repo
- Canonical GitHub Actions → GCP pattern

## Base branch

Targets `feat/rewrite` because dd#71 hasn't merged yet — this PR edits the post-rewrite workflow files. Once dd#71 merges, this can be retargeted to main.

## Test plan

- [ ] PR checks green (CI only — deploy workflows don't run on PR)
- [ ] After merge to `feat/rewrite` → rerun dd#71's staging-deploy → WIF-authed staging deploy succeeds
- [ ] After dd#71 + this merge to main → production-deploy fires → WIF-authed production deploy succeeds
- [ ] Delete `GCP_SERVICE_ACCOUNT_KEY` from the staging + production environment secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)