### PR TITLE
feat: Dockerize dd-register and dd-web + ghcr push workflow

### DIFF
--- a/.github/workflows/push-management-images.yml
+++ b/.github/workflows/push-management-images.yml
@@ -1,0 +1,78 @@
+name: Push Management Images
+
+# Builds container images for dd-register and dd-web and pushes to
+# ghcr.io. These images are deployed as workloads inside easyenclave-
+# sealed TDX VMs that serve as dd management VMs
+# (app-staging.devopsdefender.com, app.devopsdefender.com).
+#
+# On PRs: builds both images (validates Dockerfile + compiles),
+#         but does NOT push — only main pushes publish.
+# On push to main: builds and pushes both to ghcr.io with tags
+#                  :<sha12> and :latest.
+# workflow_dispatch: manual trigger.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "crates/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/push-management-images.yml"
+  pull_request:
+    paths:
+      - "crates/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/push-management-images.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: push-management-images-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write   # push to ghcr.io
+
+jobs:
+  push:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - name: dd-register
+            dockerfile: crates/dd-register/Dockerfile
+          - name: dd-web
+            dockerfile: crates/dd-web/Dockerfile
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Compute short sha
+        id: meta
+        run: echo "sha12=$(echo ${{ github.sha }} | cut -c1-12)" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to ghcr.io
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push ${{ matrix.image.name }}
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.image.dockerfile }}
+          push: ${{ github.event_name != 'pull_request' }}
+          platforms: linux/amd64
+          tags: |
+            ghcr.io/devopsdefender/${{ matrix.image.name }}:${{ steps.meta.outputs.sha12 }}
+            ghcr.io/devopsdefender/${{ matrix.image.name }}:latest
+          cache-from: type=gha,scope=${{ matrix.image.name }}
+          cache-to: type=gha,scope=${{ matrix.image.name }},mode=max

--- a/.github/workflows/push-management-images.yml
+++ b/.github/workflows/push-management-images.yml
@@ -46,6 +46,8 @@ jobs:
             dockerfile: crates/dd-register/Dockerfile
           - name: dd-web
             dockerfile: crates/dd-web/Dockerfile
+          - name: dd-client
+            dockerfile: crates/dd-client/Dockerfile
     steps:
       - uses: actions/checkout@v4
 

--- a/crates/dd-client/Dockerfile
+++ b/crates/dd-client/Dockerfile
@@ -1,0 +1,28 @@
+# dd-client — in-enclave agent web UI. Runs inside an easyenclave-
+# sealed TDX VM as a workload alongside whatever the VM is hosting
+# (e.g. openclaw, a worker workload). Talks to the local
+# /var/lib/easyenclave/agent.sock and serves a browser UI + terminal.
+#
+# Build context MUST be the repo root (workspace). The
+# push-management-images workflow sets context: . and
+# file: crates/dd-client/Dockerfile.
+
+FROM rust:1-bookworm AS builder
+WORKDIR /src
+COPY . .
+RUN cargo build --release -p dd-client
+
+# Runtime: debian-slim + cloudflared. dd-client receives a tunnel
+# token from dd-register during Noise-XX handshake and spawns
+# cloudflared as a subprocess to serve its web UI publicly.
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates curl \
+    && curl -fsSL -o /usr/local/bin/cloudflared \
+        https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64 \
+    && chmod +x /usr/local/bin/cloudflared \
+    && apt-get purge -y curl \
+    && apt-get autoremove -y \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /src/target/release/dd-client /usr/local/bin/dd-client
+ENTRYPOINT ["/usr/local/bin/dd-client"]

--- a/crates/dd-register/Dockerfile
+++ b/crates/dd-register/Dockerfile
@@ -1,0 +1,26 @@
+# dd-register — tunnel provisioning service. Runs inside an
+# easyenclave-sealed TDX VM as a boot workload.
+#
+# Build context MUST be the repo root (workspace root) so that the
+# dd-common path dep resolves. The push-management-images workflow
+# sets context: . and file: crates/dd-register/Dockerfile.
+
+FROM rust:1-bookworm AS builder
+WORKDIR /src
+COPY . .
+RUN cargo build --release -p dd-register
+
+# Runtime: debian-slim + cloudflared. dd-register spawns cloudflared
+# as a subprocess (via dd-common::tunnel) to run the tunnel it
+# provisions through the Cloudflare API.
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates curl \
+    && curl -fsSL -o /usr/local/bin/cloudflared \
+        https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64 \
+    && chmod +x /usr/local/bin/cloudflared \
+    && apt-get purge -y curl \
+    && apt-get autoremove -y \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /src/target/release/dd-register /usr/local/bin/dd-register
+ENTRYPOINT ["/usr/local/bin/dd-register"]

--- a/crates/dd-web/Dockerfile
+++ b/crates/dd-web/Dockerfile
@@ -1,0 +1,21 @@
+# dd-web — fleet dashboard, auth, collector. Runs inside an
+# easyenclave-sealed TDX VM as a boot workload alongside dd-register.
+#
+# Build context MUST be the repo root. The push-management-images
+# workflow sets context: . and file: crates/dd-web/Dockerfile.
+
+FROM rust:1-bookworm AS builder
+WORKDIR /src
+COPY . .
+RUN cargo build --release -p dd-web
+
+# Runtime: plain debian-slim. No cloudflared — dd-web doesn't create
+# tunnels (that's dd-register's job). dd-web talks to the local
+# easyenclave socket and to GitHub / Cloudflare HTTPS APIs, so
+# ca-certificates is all we need beyond the binary itself.
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /src/target/release/dd-web /usr/local/bin/dd-web
+ENTRYPOINT ["/usr/local/bin/dd-web"]


### PR DESCRIPTION
## Summary

Package `dd-register` and `dd-web` as OCI container images and set up a GitHub Actions workflow that pushes them to `ghcr.io` on every main commit.

This is **PR 2 of 3** in the migration of dd's management VMs (`app-staging.devopsdefender.com`, `app.devopsdefender.com`) from stock-Ubuntu GCE instances to easyenclave-sealed TDX VMs. PRs 1 and 3:

1. **easyenclave/easyenclave#45** — add GCE instance metadata as a boot config source (in review)
2. **This PR** — Dockerize + push binaries to ghcr
3. **Next** — rewrite `scripts/gcp-deploy.sh` to boot from `easyenclave-<sha>` and pass `EE_BOOT_WORKLOADS` referencing the ghcr images

## New files

- \`crates/dd-register/Dockerfile\` — multi-stage build (rust:1-bookworm → debian:bookworm-slim). Runtime image includes \`cloudflared\` because dd-register spawns it as a subprocess via \`dd-common::tunnel\`.
- \`crates/dd-web/Dockerfile\` — same pattern minus cloudflared. Just \`ca-certificates\` for outbound HTTPS to GitHub + Cloudflare.
- \`.github/workflows/push-management-images.yml\` — matrix build of both images, push to \`ghcr.io/devopsdefender/dd-register\` and \`ghcr.io/devopsdefender/dd-web\` tagged \`:<sha12>\` and \`:latest\`. Uses \`GITHUB_TOKEN\` with \`packages: write\`; no new secrets.

## Why both Dockerfiles use \`context: .\` (repo root)

Both crates path-depend on \`dd-common\` via \`{ path = \"../dd-common\" }\`, so the Docker build context has to include the whole workspace. The workflow sets \`context: .\` and \`file: crates/<name>/Dockerfile\`.

## Package visibility (post-merge manual step)

ghcr packages created by workflows are private by default. For the dd management VMs to pull them from easyenclave (where there's no registry credential at boot), the packages need to be set to **Public** after the first push, via:
\`\`\`
Settings → Packages → dd-register → Change visibility → Public
\`\`\`
and same for dd-web. One-time per package. Alternatively PR 3 can pass a ghcr pull token to the VM via \`ee-config\`, but public is simpler.

## Test plan

- [ ] PR CI builds both images (PR event → no push, just validation)
- [ ] After merge to main, images land at \`ghcr.io/devopsdefender/dd-register:<sha12>\` and \`ghcr.io/devopsdefender/dd-web:<sha12>\`
- [ ] \`docker pull ghcr.io/devopsdefender/dd-register:<sha12>\` succeeds
- [ ] \`docker run --rm ghcr.io/devopsdefender/dd-register --version\` or equivalent shows a valid binary
- [ ] Set package visibility to Public on both
- [ ] PR 3 can pin to \`:<sha12>\` tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)