### PR TITLE
hygiene: require DD_OWNER + DD_ENV, fix silent fallbacks, refresh stale comments

### DIFF
--- a/crates/dd-client/src/terminal.rs
+++ b/crates/dd-client/src/terminal.rs
@@ -324,9 +324,8 @@ pub async fn ws_session(
 
 /// Proxy WebSocket I/O to easyenclave exec.
 ///
-/// Unlike the old dd-agent which attached directly to process stdin/stdout,
-/// dd-client proxies everything through the easyenclave unix socket.
-/// For interactive sessions, we use the easyenclave exec API.
+/// dd-client never touches the workload process directly; interactive
+/// sessions go through the easyenclave exec API on /var/lib/easyenclave/agent.sock.
 async fn handle_ws_session(socket: WebSocket, state: AppState, app_name: String) {
     let (mut ws_tx, mut ws_rx) = socket.split();
 

--- a/crates/dd-common/src/noise.rs
+++ b/crates/dd-common/src/noise.rs
@@ -1,8 +1,9 @@
 //! Noise XX handshake helpers for WebSocket channels.
 //!
-//! Consolidates the repeated handshake code from agent server.rs and
-//! dd-agent main.rs into two reusable async functions: one for the
-//! responder (register side) and one for the initiator (agent/scraper side).
+//! Two reusable async functions: one for the responder (dd-register)
+//! and one for the initiator (dd-client). Both use the same
+//! Noise_XX_25519_ChaChaPoly_SHA256 pattern with an attestation payload
+//! exchanged in msg3.
 
 use axum::extract::ws::{Message, WebSocket};
 use futures_util::stream::{SplitSink, SplitStream};
@@ -112,7 +113,7 @@ pub async fn noise_xx_responder_ws(
     Ok((transport, peer_payload))
 }
 
-/// Noise XX initiator (agent / scraper / client side).
+/// Noise XX initiator (dd-client side).
 ///
 /// Performs the three-message XX handshake:
 ///   1. Write msg1 (ephemeral key, empty payload).

--- a/crates/dd-common/src/tunnel.rs
+++ b/crates/dd-common/src/tunnel.rs
@@ -53,7 +53,12 @@ pub async fn create_agent_tunnel(
     _vm_name: &str,
     hostname_override: Option<&str>,
 ) -> Result<TunnelInfo, String> {
-    let env_label = std::env::var("DD_ENV").unwrap_or_else(|_| "dev".into());
+    // DD_ENV is required. Callers (dd-register, dd-web) fail fast at
+    // startup if it's not set, so by the time we're here it's always
+    // defined. Previously defaulted to "dev" silently, which in a prod
+    // VM would mint tunnels named `dd-dev-*` and never match the
+    // `dd-{prod_env}-*` filter in dd-web's collector.
+    let env_label = std::env::var("DD_ENV").expect("DD_ENV must be set before tunnel ops");
     let tunnel_name = format!("dd-{env_label}-{agent_id}");
     let tunnel_secret = uuid::Uuid::new_v4().to_string().replace('-', "");
     let hostname = hostname_override
@@ -185,7 +190,8 @@ pub async fn remove_agent(
     agent_id: &str,
     hostname: &str,
 ) -> Result<(), String> {
-    let env_label = std::env::var("DD_ENV").unwrap_or_else(|_| "dev".into());
+    // DD_ENV: see provision_tunnel above.
+    let env_label = std::env::var("DD_ENV").expect("DD_ENV must be set before tunnel ops");
     let tunnel_name = format!("dd-{env_label}-{agent_id}");
     delete_tunnel_by_name(client, cf, &tunnel_name).await?;
     delete_dns_record(client, cf, hostname).await?;

--- a/crates/dd-register/src/handler.rs
+++ b/crates/dd-register/src/handler.rs
@@ -1,7 +1,9 @@
 //! WebSocket registration handler and fleet registry types.
 //!
-//! Ported from agent/src/server.rs handle_ws_register. Uses dd_common::noise
-//! for the Noise XX handshake and dd_common::tunnel for CF tunnel operations.
+//! Implements `/register`: dd-client calls this over a WebSocket,
+//! performs a Noise XX handshake (dd_common::noise) with an attestation
+//! payload, and dd-register provisions a Cloudflare tunnel + DNS record
+//! for the agent via dd_common::tunnel.
 
 use axum::extract::ws::WebSocket;
 use dd_common::noise;
@@ -112,7 +114,7 @@ pub async fn handle_ws_register(
     let client = reqwest::Client::new();
 
     // Stale cleanup: remove old entries with same vm_name + delete their CF tunnels.
-    // Without this the fleet accumulates stale entries on every dd-agent redeploy.
+    // Without this the fleet accumulates stale entries on every VM redeploy.
     let stale: Vec<(String, String)> = {
         let registry = registry.lock().await;
         registry

--- a/crates/dd-web/src/auth.rs
+++ b/crates/dd-web/src/auth.rs
@@ -134,10 +134,10 @@ fn bearer_from_header(headers: &HeaderMap) -> Option<String> {
 
 /// Resolve authentication -- returns Ok(Some(login)) if authenticated, Err if rejected.
 async fn resolve_auth(state: &WebState, headers: &HeaderMap) -> Result<Option<String>, AppError> {
-    // No owner configured: allow all
-    if state.config.owner.is_empty() {
-        return Ok(None);
-    }
+    // DD_OWNER is now required in Config::from_env — if we reach here
+    // it's always non-empty. (Previously an empty owner silently
+    // disabled all auth, which was a fail-open bug.)
+    debug_assert!(!state.config.owner.is_empty());
 
     // 1. Check dd_auth JWT (domain-scoped cookie)
     if let Some(claims) = validate_auth_jwt(state, headers) {

--- a/crates/dd-web/src/config.rs
+++ b/crates/dd-web/src/config.rs
@@ -46,14 +46,26 @@ impl Config {
         let github_callback_url = std::env::var("DD_GITHUB_CALLBACK_URL")
             .unwrap_or_else(|_| format!("https://{hostname}/auth/github/callback"));
 
-        let owner = std::env::var("DD_OWNER").unwrap_or_default();
+        // DD_OWNER is required. Previously defaulted to empty, and
+        // resolve_auth short-circuited to Ok(None) on an empty owner,
+        // which silently disabled all authentication. Fail fast.
+        let owner = std::env::var("DD_OWNER").unwrap_or_else(|_| {
+            eprintln!("dd-web: DD_OWNER required (GitHub user or org that may access the fleet)");
+            std::process::exit(1);
+        });
 
         let port: u16 = std::env::var("DD_PORT")
             .ok()
             .and_then(|s| s.parse().ok())
             .unwrap_or(8080);
 
-        let env_label = std::env::var("DD_ENV").unwrap_or_else(|_| "dev".into());
+        // DD_ENV is required. Previously defaulted to "dev", which in
+        // production silently made the collector look for dd-dev-*
+        // tunnels and find nothing — empty fleet, no error.
+        let env_label = std::env::var("DD_ENV").unwrap_or_else(|_| {
+            eprintln!("dd-web: DD_ENV required (staging / production / dev)");
+            std::process::exit(1);
+        });
 
         let peers: Vec<String> = std::env::var("DD_PEERS")
             .ok()

--- a/crates/dd-web/src/federate.rs
+++ b/crates/dd-web/src/federate.rs
@@ -18,10 +18,14 @@ pub async fn query_peers(state: &WebState) -> Vec<AgentSnapshot> {
         return Vec::new();
     }
 
+    // Builder failure is a programming bug, not a runtime condition.
+    // Previously fell back to a client without the 5s timeout, which
+    // would mask the real bug AND potentially hang federated requests
+    // forever.
     let http = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(5))
         .build()
-        .unwrap_or_else(|_| reqwest::Client::new());
+        .expect("reqwest client builder");
 
     let futures: Vec<_> = state
         .config


### PR DESCRIPTION
## Summary

Audit surfaced several pre-rewrite fossils and fail-open fallbacks that the workspace split (dd#71) didn't catch. None are functional bugs today (the ops scripts always set the env vars), but each one would bite hard under the wrong conditions.

## Critical: fail-open auth on missing DD_OWNER

`dd-web/config.rs:49` defaulted `DD_OWNER` to empty, and `resolve_auth` at `auth.rs:137` short-circuited to `Ok(None)` on an empty owner — "no owner configured: allow all". Combined: **forgetting to set DD_OWNER silently disabled the entire auth gate.** Fail-open hiding inside an innocent-looking `unwrap_or_default()`.

**Fix:** make `DD_OWNER` required in `Config::from_env` (same `eprintln!; exit(1)` pattern as the other required env vars). The escape hatch in `resolve_auth` is downgraded to a `debug_assert`.

## High: silent DD_ENV default to "dev"

`dd-web/config.rs:56` + `dd-common/tunnel.rs:56,188` defaulted `DD_ENV` to `"dev"`. In a production VM that meant the collector looked for `dd-dev-*` tunnels and silently found nothing — empty fleet, no error signal.

**Fix:** required in dd-web config (fail fast at startup). In dd-common/tunnel.rs helpers it's `.expect()` — by the time they run, the binary has already required DD_ENV.

## High: federate.rs client builder fallback

```rust
let http = reqwest::Client::builder()
    .timeout(std::time::Duration::from_secs(5))
    .build()
    .unwrap_or_else(|_| reqwest::Client::new());  // ← silent no-timeout fallback
```

Builder failure is a programming bug, not a runtime condition. The fallback masked bugs AND returned a client without the 5s timeout, which would hang federated requests forever.

**Fix:** `.expect("reqwest client builder")`.

## Medium: stale pre-rewrite doc comments

- `dd-common/noise.rs` — removed references to "agent server.rs" and "dd-agent main.rs"
- `dd-client/terminal.rs` — removed "Unlike the old dd-agent which..." fossil comparison
- `dd-register/handler.rs` — "Ported from agent/src/server.rs" → current implementation description; "dd-agent redeploy" → "VM redeploy"

## Local verification

```
cargo build --workspace --release   # -Dwarnings clean
cargo clippy --workspace --all-targets  # -Dwarnings clean
cargo fmt --check                   # clean
cargo test --workspace              # ✅ 0 passed, 0 failed (no unit tests in workspace)
```

## Out of scope (kept diff narrow — separate PRs)

- **dd-client DD_OWNER fail-fast**: legitimately optional because dd-client bootstraps its owner from dd-register's Noise-XX handshake response when DD_REGISTER_URL is set.
- **dd-client socket error swallowing**: `.unwrap_or_default()` on every `ee_client.{list,health,logs}()` call — needs a handler-level error type refactor, ~10 touchpoints.
- **`|| true` swallowing in workflow cleanup steps** — cosmetic.

## Test plan

- [x] Cargo build + clippy + fmt clean locally
- [x] PR CI green (check, push × 3, also an older staging-deploy check set from before rebase — all ✅)
- [ ] After merge: verify production scripts still set DD_OWNER/DD_ENV (happy path, these fixes are no-ops)
- [ ] Manually try to boot dd-web with DD_OWNER unset → confirm it exits with a clear error message instead of silently disabling auth

🤖 Generated with [Claude Code](https://claude.com/claude-code)
