### PR TITLE
fix: bump EE_IMAGE pin to easyenclave-9ff1a1fca190 (first image with working container runtime)

### DIFF
--- a/scripts/gcp-deploy.sh
+++ b/scripts/gcp-deploy.sh
@@ -38,7 +38,11 @@ set -euo pipefail
 # ── Pinned image SHAs ─────────────────────────────────────────────────────
 # Bump these to rotate to newer sealed builds. Keep them pinned (not
 # :latest) so a rebuild of main doesn't silently change what's deployed.
-EE_IMAGE="${EE_IMAGE:-easyenclave-75e0b30fa162}"
+#
+# easyenclave-9ff1a1fca190: first image with the Rust-native container
+# runtime (libcontainer) + libseccomp.so.2 in the rootfs. easyenclave-
+# 75e0b30fa162 and earlier couldn't actually run OCI workloads.
+EE_IMAGE="${EE_IMAGE:-easyenclave-9ff1a1fca190}"
 EE_IMAGE_PROJECT="${EE_IMAGE_PROJECT:-easyenclave}"
 DD_REGISTER_IMAGE="${DD_REGISTER_IMAGE:-ghcr.io/devopsdefender/dd-register:31ff718b169b}"
 DD_WEB_IMAGE="${DD_WEB_IMAGE:-ghcr.io/devopsdefender/dd-web:31ff718b169b}"


### PR DESCRIPTION
## Summary

Bump `EE_IMAGE` in `scripts/gcp-deploy.sh` from `easyenclave-75e0b30fa162` to `easyenclave-9ff1a1fca190` — the first sealed image where OCI container workloads actually work.

## Background

When dd#74 merged, the staging-deploy run created a VM from \`easyenclave-75e0b30fa162\` and its cleanup+deploy ran, but /health never came up. Two serial bugs:

1. **Pre-easyenclave#46**: \`src/container.rs\` used \`bollard\` pointing at \`/run/podman/podman.sock\`, but \`mkosi.conf\` never installed podman in the rootfs. Every \`EE_BOOT_WORKLOADS\` with an \`image:\` ref silently failed at \`pull_and_run\`.

2. **Post-easyenclave#46 (libcontainer swap), pre-easyenclave#47**: the Rust-native libcontainer crate links against libseccomp, but the sealed rootfs was missing \`libseccomp.so.2\`. easyenclave would start, fail to dynamically load the shared object, and exit — which panicked the kernel because PID 1 died:

\`\`\`
[  2.890] Kernel panic - not syncing: Attempted to kill init!
[  2.896] libseccomp.so.v... (interleaved)
\`\`\`

3. **Post-easyenclave#47**: \`libseccomp2\` added to \`mkosi.conf\` Packages. Image \`easyenclave-9ff1a1fca190\` passes the full \`image.yml\` pipeline including \`smoke-test\` which boots a real TDX VM to \`easyenclave: listening on\`.

## Also applied (not in this PR, but unblocks the rollout)

- **Cross-project image grant**: \`compute.imageUser\` on \`easyenclave-9ff1a1fca190\` granted to \`easyenclave-staging-ci@eestaging.iam.gserviceaccount.com\` and \`654815109728-compute@developer.gserviceaccount.com\` (the runtime identity of the VM).

## Ghcr pins unchanged

\`dd-register\`/\`dd-web\` remain pinned at \`:31ff718b169b\` (the manual-dispatch tag from dd#73). push-management-images.yml is currently building \`:18158c8bd438\` (dd#75 merge commit) on main — a follow-up can bump to that or switch to \`:latest\` for rolling staging.

## Test plan

- [ ] PR merges → staging-deploy.yml fires on the \`scripts/gcp-deploy.sh\` path change
- [ ] cleanup deletes the old (dead) staging VM
- [ ] deploy creates a new VM from \`easyenclave-9ff1a1fca190\`
- [ ] Serial console shows \`easyenclave: init: gce-meta env EE_BOOT_WORKLOADS=<redacted>\`
- [ ] Serial shows libcontainer pulling \`ghcr.io/devopsdefender/dd-register:31ff718b169b\` and \`dd-web:31ff718b169b\`
- [ ] cloudflared comes up inside dd-register's container, provisions the staging tunnel
- [ ] \`/health\` on \`app-staging.devopsdefender.com\` returns 200
- [ ] \`Verify dashboard renders (OIDC)\` step in staging-deploy passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)