### PR TITLE
fix(deploy): use easyenclave-staging image family instead of sha pin

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The enclave runtime itself is [EasyEnclave](https://github.com/easyenclave/easye
 
 ## How it's deployed
 
-Both management VMs (`app.devopsdefender.com`, `app-staging.devopsdefender.com`) and worker VMs **boot from a sealed easyenclave image**. No cloud-init, no stock Ubuntu, no runtime `apt-get install`. The TDX VM's rootfs is the published `easyenclave-<sha>` image from [easyenclave/easyenclave releases](https://github.com/easyenclave/easyenclave/releases), attestable against a single UKI SHA256.
+Both management VMs (`app.devopsdefender.com`, `app-staging.devopsdefender.com`) and worker VMs **boot from a sealed easyenclave image**. No cloud-init, no stock Ubuntu, no runtime `apt-get install`. The TDX VM's rootfs is the latest image in the `easyenclave-staging` family published by [easyenclave/easyenclave](https://github.com/easyenclave/easyenclave/releases), attestable against a single UKI SHA256.
 
 dd's three binaries ship as OCI container images on ghcr.io:
 
@@ -27,7 +27,7 @@ dd's three binaries ship as OCI container images on ghcr.io:
 
 Image builds: `.github/workflows/push-management-images.yml` (on push to main).
 
-Per-VM configuration (CF credentials, GitHub OAuth, the workload spec itself) is passed to easyenclave at boot via **GCE instance metadata** — the `ee-config` attribute, a JSON object read by `easyenclave::init::fetch_gce_metadata_config()` and applied as env vars. `scripts/gcp-deploy.sh` builds the spec and invokes `gcloud compute instances create --image=easyenclave-<sha> --metadata-from-file=ee-config=...`.
+Per-VM configuration (CF credentials, GitHub OAuth, the workload spec itself) is passed to easyenclave at boot via **GCE instance metadata** — the `ee-config` attribute, a JSON object read by `easyenclave::init::fetch_gce_metadata_config()` and applied as env vars. `scripts/gcp-deploy.sh` builds the spec and invokes `gcloud compute instances create --image-family=easyenclave-staging --metadata-from-file=ee-config=...` — no sha12 pin to maintain.
 
 ## Build
 

--- a/scripts/gcp-deploy.sh
+++ b/scripts/gcp-deploy.sh
@@ -24,7 +24,7 @@
 #   DD_GITHUB_CLIENT_SECRET — GitHub OAuth client secret
 #
 # Optional env vars (override the pinned defaults):
-#   EE_IMAGE                — easyenclave sealed image name
+#   EE_IMAGE_FAMILY         — easyenclave GCP image family
 #   EE_IMAGE_PROJECT        — project hosting the image
 #   DD_REGISTER_IMAGE       — ghcr.io/devopsdefender/dd-register:<tag>
 #   DD_WEB_IMAGE            — ghcr.io/devopsdefender/dd-web:<tag>
@@ -35,15 +35,17 @@
 
 set -euo pipefail
 
-# ── Pinned image SHAs ─────────────────────────────────────────────────────
-# Bump these to rotate to newer sealed builds. Keep them pinned (not
-# :latest) so a rebuild of main doesn't silently change what's deployed.
+# ── easyenclave image family ──────────────────────────────────────────────
+# Resolved at deploy time via GCE's image-family selector — picks the
+# newest non-deprecated image in the family. No sha12 to hand-bump.
 #
-# easyenclave-9ff1a1fca190: first image with the Rust-native container
-# runtime (libcontainer) + libseccomp.so.2 in the rootfs. easyenclave-
-# 75e0b30fa162 and earlier couldn't actually run OCI workloads.
-EE_IMAGE="${EE_IMAGE:-easyenclave-9ff1a1fca190}"
+#   easyenclave-staging → rolling main, rotates on every push (5 kept)
+#   easyenclave-stable  → v* tags, kept forever
+#
+# For DD production, override to easyenclave-stable once a v-tag exists.
+EE_IMAGE_FAMILY="${EE_IMAGE_FAMILY:-easyenclave-staging}"
 EE_IMAGE_PROJECT="${EE_IMAGE_PROJECT:-easyenclave}"
+# dd container images are still sha-pinned (bump when you cut a release).
 DD_REGISTER_IMAGE="${DD_REGISTER_IMAGE:-ghcr.io/devopsdefender/dd-register:31ff718b169b}"
 DD_WEB_IMAGE="${DD_WEB_IMAGE:-ghcr.io/devopsdefender/dd-web:31ff718b169b}"
 
@@ -134,13 +136,13 @@ gcloud compute instances create "$VM_NAME" \
   --confidential-compute-type=TDX \
   --maintenance-policy=TERMINATE \
   --boot-disk-size="$VM_DISK_SIZE" \
-  --image="$EE_IMAGE" \
+  --image-family="$EE_IMAGE_FAMILY" \
   --image-project="$EE_IMAGE_PROJECT" \
   --metadata-from-file=ee-config=/tmp/ee-config.json \
   --labels=devopsdefender=managed,dd_env="${DD_ENV}" \
   --tags=dd-management
 
 echo "VM: $VM_NAME"
-echo "  image:    $EE_IMAGE ($EE_IMAGE_PROJECT)"
+echo "  image:    family $EE_IMAGE_FAMILY ($EE_IMAGE_PROJECT)"
 echo "  hostname: $DD_HOSTNAME"
 echo "  workloads: dd-register, dd-web"


### PR DESCRIPTION
## Summary

Kills the hardcoded \`EE_IMAGE=easyenclave-9ff1a1fca190\` in \`scripts/gcp-deploy.sh\` that was getting hand-bumped on every easyenclave release — and why dd staging ended up stuck on a known-broken image for days (nobody rolled the pin forward).

Switch to GCP's image-family selector: \`--image-family=easyenclave-staging --image-project=easyenclave\`. GCP picks the newest non-deprecated image in the family at deploy time. No sha12 pin to maintain.

## Coordination

- [easyenclave#51](https://github.com/easyenclave/easyenclave/pull/51) adds \`--family=easyenclave-staging\` / \`--family=easyenclave-stable\` to the image-build workflow. New images get the family automatically.
- Backfill on the 5 existing staging images is done (\`gcloud compute images update --family=easyenclave-staging\`) — \`describe-from-family easyenclave-staging\` already resolves to the latest image (\`easyenclave-aad569da18bd\`).
- This PR can merge independently of easyenclave#51 landing, because the backfill means the family is already populated on the GCP side.

## DD production note

Both DD environments currently default to \`easyenclave-staging\`. For production, once the first \`v*\` tag is cut on easyenclave, bump the \`production-deploy.yml\` env to \`EE_IMAGE_FAMILY=easyenclave-stable\` — no code change needed, the knob is already exposed.

## Test plan

- [ ] CI green
- [ ] Post-merge: trigger staging-deploy → confirm VM boots from \`easyenclave-aad569da18bd\` (via image-family lookup), dd-register + dd-web pulled as OCI workloads, \`/health\` returns 200 on \`app-staging.devopsdefender.com\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)