### PR TITLE
feat(staging-deploy): stream serial console during health wait

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -80,19 +80,59 @@ jobs:
       # DD_HOSTNAME is set by gcp-deploy.sh to app-staging.${DD_DOMAIN},
       # which is the tunnel hostname. CI polls it directly.
 
-      - name: Wait for agent health
+      - name: Wait for agent health (streams serial console)
         env:
           AGENT_URL: https://app-staging.${{ env.DD_DOMAIN }}
+          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+          GCP_ZONE: ${{ env.GCP_ZONE }}
         run: |
+          # Resolve the VM that gcp-deploy.sh just created. dd-staging-$(date +%s)
+          # naming means the newest matching VM is the right one.
+          VM_NAME=$(gcloud compute instances list \
+            --project="$GCP_PROJECT_ID" \
+            --filter="labels.devopsdefender=managed AND labels.dd_env=staging" \
+            --format="value(name)" --sort-by=~creationTimestamp | head -1)
+          if [ -z "$VM_NAME" ]; then
+            echo "::error::no dd-staging VM found — gcp-deploy.sh must have failed"
+            exit 1
+          fi
+          echo "Watching VM: $VM_NAME (zone: $GCP_ZONE)"
+
+          LAST_LINES=0
           for i in $(seq 1 60); do
-            curl -fsS "${AGENT_URL}/health" >/dev/null 2>&1 && {
+            # Pull full serial log; print only new lines since last iter.
+            # This gives a live-streaming boot console in the Action log
+            # so failures (fast-fail in initrd, DHCP hang, libcontainer
+            # pull error, etc.) are visible without shelling into GCP.
+            gcloud compute instances get-serial-port-output "$VM_NAME" \
+              --project="$GCP_PROJECT_ID" --zone="$GCP_ZONE" 2>/dev/null \
+              > /tmp/serial.log || true
+            TOTAL_LINES=$(wc -l < /tmp/serial.log)
+            if [ "$TOTAL_LINES" -gt "$LAST_LINES" ]; then
+              tail -n +$((LAST_LINES + 1)) /tmp/serial.log \
+                | sed 's/^/[serial] /'
+              LAST_LINES=$TOTAL_LINES
+            fi
+
+            # Fatal patterns — early-fail instead of waiting the full 5 min.
+            if grep -qE "FATAL|Kernel panic|Invalid ELF header|/bin/sh: can't access tty" /tmp/serial.log; then
+              echo "::error::boot failed — serial log shows fatal pattern"
+              exit 1
+            fi
+
+            # Success: /health returns 200 via the Cloudflare tunnel.
+            # That tests the full chain: VM boot → easyenclave init →
+            # libcontainer pulls dd-register/dd-web → cloudflared tunnel up.
+            if curl -fsS "${AGENT_URL}/health" >/dev/null 2>&1; then
               echo "Agent healthy at ${AGENT_URL}"
               exit 0
-            }
+            fi
             echo "  waiting for tunnel... (${i}/60)"
             sleep 5
           done
           echo "::error::Agent not healthy within 5 minutes"
+          echo "--- final serial tail ---"
+          tail -80 /tmp/serial.log | sed 's/^/[serial] /'
           exit 1
 
       - name: Verify dashboard renders (OIDC)


### PR DESCRIPTION
## Summary

Today the staging-deploy workflow just \`curl /health\` for 5 minutes and gives zero insight into what the VM is doing. When easyenclave fails to boot, we only see "Agent not healthy within 5 minutes" and have to shell into GCP to pull \`get-serial-port-output\` by hand.

Motivated by [this failure](https://github.com/devopsdefender/dd/actions/runs/24288262210) where the VM dropped to a busybox shell in the initrd and the Action run was a complete mystery until I manually pulled the console.

## Change

The "Wait for agent health" step now:

1. Resolves the newest \`dd-staging-*\` VM by label
2. Each iteration, pulls full \`gcloud compute instances get-serial-port-output\`, line-diffs against what was already printed, emits new lines prefixed with \`[serial] \` to the Action log
3. Early-fails on fatal patterns (\`FATAL\`, \`Kernel panic\`, \`Invalid ELF header\`, busybox shell-drop marker) instead of waiting the full 5 min
4. On timeout, dumps the final serial tail (80 lines)

Success condition is still \`/health\` returning 200 via the Cloudflare tunnel — that's the full-chain health check.

## Test plan

- [ ] Merge + next staging-deploy run shows \`[serial] ...\` lines interleaved with \`waiting for tunnel...\` in the Action log
- [ ] Force a failure (temporarily break something) → workflow early-fails on fatal pattern instead of waiting 5 min

The underlying boot failure that prompted this is fixed separately in [easyenclave#52](https://github.com/easyenclave/easyenclave/pull/52).

🤖 Generated with [Claude Code](https://claude.com/claude-code)