### PR TITLE
refactor: built-in CP self-monitoring

### DIFF
--- a/crates/dd-web/src/collector.rs
+++ b/crates/dd-web/src/collector.rs
@@ -174,14 +174,12 @@ pub async fn run_collector(state: WebState) {
 
         // Self-check: scrape localhost to register the control plane itself.
         // No dd-client container needed — the CP monitors itself.
-        let self_healthy = match http
-            .get(format!("http://localhost:{}/health", state.config.port))
-            .send()
-            .await
-        {
-            Ok(resp) if resp.status().is_success() => true,
-            _ => false,
-        };
+        let self_healthy = matches!(
+            http.get(format!("http://localhost:{}/health", state.config.port))
+                .send()
+                .await,
+            Ok(resp) if resp.status().is_success()
+        );
         {
             let mut store = state.agents.lock().await;
             store.insert(

--- a/crates/dd-web/src/collector.rs
+++ b/crates/dd-web/src/collector.rs
@@ -172,6 +172,40 @@ pub async fn run_collector(state: WebState) {
             }
         }
 
+        // Self-check: scrape localhost to register the control plane itself.
+        // No dd-client container needed — the CP monitors itself.
+        let self_healthy = match http
+            .get(format!("http://localhost:{}/health", state.config.port))
+            .send()
+            .await
+        {
+            Ok(resp) if resp.status().is_success() => true,
+            _ => false,
+        };
+        {
+            let mut store = state.agents.lock().await;
+            store.insert(
+                "control-plane".to_string(),
+                AgentSnapshot {
+                    agent_id: "control-plane".to_string(),
+                    hostname: state.config.hostname.clone(),
+                    vm_name: format!("dd-{env_label}-cp"),
+                    attestation_type: "tdx".to_string(),
+                    status: if self_healthy { "healthy" } else { "stale" }.to_string(),
+                    last_seen: now,
+                    deployment_count: 3,
+                    deployment_names: vec![
+                        "dd-register".into(),
+                        "dd-web".into(),
+                        "dd-client".into(),
+                    ],
+                    cpu_percent: 0,
+                    memory_used_mb: 0,
+                    memory_total_mb: 0,
+                },
+            );
+        }
+
         let healthy_count = results.iter().filter(|r| r.2).count();
         let unhealthy_count = results.iter().filter(|r| !r.2).count();
         eprintln!(

--- a/scripts/gcp-deploy.sh
+++ b/scripts/gcp-deploy.sh
@@ -70,17 +70,12 @@ DD_GITHUB_CALLBACK_URL="${DD_GITHUB_CALLBACK_URL:-https://${DD_HOSTNAME}/auth/gi
 #   dd-web      — the fleet dashboard that operators see at DD_HOSTNAME.
 #                 Auth-gated with GitHub OAuth (+ PAT Bearer + OIDC for CI).
 #
-#   dd-client   — the agent that runs on every easyenclave VM (including
-#                 the control plane). Registers itself with dd-register
-#                 so the management VM shows up in its own fleet dashboard.
-#
-# All run with host networking (easyenclave's default) so they bind
-# the VM's network namespace directly.
-DD_CLIENT_IMAGE="${DD_CLIENT_IMAGE:-ghcr.io/devopsdefender/dd-client:latest}"
+# Both run with host networking (easyenclave's default) so they bind
+# the VM's network namespace directly. The control plane self-registers
+# in dd-web's collector (no dd-client container needed on the CP).
 EE_BOOT_WORKLOADS=$(jq -c -n \
   --arg reg_image      "$DD_REGISTER_IMAGE" \
   --arg web_image      "$DD_WEB_IMAGE" \
-  --arg client_image   "$DD_CLIENT_IMAGE" \
   --arg cf_token       "$CLOUDFLARE_API_TOKEN" \
   --arg cf_account     "$CLOUDFLARE_ACCOUNT_ID" \
   --arg cf_zone        "$CLOUDFLARE_ZONE_ID" \
@@ -120,16 +115,6 @@ EE_BOOT_WORKLOADS=$(jq -c -n \
         ("DD_GITHUB_CALLBACK_URL="  + $gh_callback),
         "DD_OIDC_AUDIENCE=dd-web",
         "DD_PORT=8080"
-      ]
-    },
-    {
-      "image": $client_image,
-      "app_name": "dd-client",
-      "env": [
-        ("DD_REGISTER_URL=wss://" + $hostname + "/register"),
-        ("DD_HOSTNAME=" + $hostname),
-        ("DD_ENV=" + $env),
-        "DD_PORT=8082"
       ]
     }
   ]')


### PR DESCRIPTION
Collector self-checks localhost:/health. CP shows up in fleet dashboard. No dd-client container on the CP.