### PR TITLE
feat: zero-downtime deploy with STONITH

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -21,37 +21,10 @@ permissions:
   contents: read
 
 jobs:
-  cleanup:
-    runs-on: ubuntu-latest
-    environment: production
-    permissions:
-      contents: read
-      id-token: write   # mint GitHub OIDC token for GCP WIF
-    steps:
-      # GCP Workload Identity Federation (no stored SA key). Pool +
-      # provider in the easyenclave project (dd production's GCP),
-      # attribute condition covers 'devopsdefender/dd', SA binding
-      # is scoped to the same principal set.
-      - uses: google-github-actions/auth@v2
-        with:
-          workload_identity_provider: 'projects/779946350556/locations/global/workloadIdentityPools/github-actions-pool/providers/github-provider'
-          service_account: 'easyenclave-production-ci@easyenclave.iam.gserviceaccount.com'
-      - uses: google-github-actions/setup-gcloud@v2
-      - name: Delete managed VMs
-        env:
-          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
-        run: |
-          gcloud compute instances list \
-            --project="$GCP_PROJECT_ID" \
-            --filter="labels.devopsdefender=managed AND labels.dd_env=production" \
-            --format="value(name,zone.basename())" | while read -r name zone; do
-            [ -z "$name" ] && continue
-            echo "Deleting VM: $name ($zone)"
-            gcloud compute instances delete "$name" --project="$GCP_PROJECT_ID" --zone="$zone" --quiet || true
-          done
-
+  # No cleanup job — dd-register STONITHs the old VM on startup by
+  # deleting its CF tunnel, which causes cloudflared to exit and
+  # triggers poweroff on the old VM.
   deploy:
-    needs: [cleanup]
     runs-on: ubuntu-latest
     environment: production
     permissions:

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -4,8 +4,11 @@ on:
   push:
     branches: [main]
     paths:
+      - "crates/**"
       - "scripts/gcp-deploy.sh"
+      - "Dockerfile"
       - ".github/workflows/production-deploy.yml"
+      - ".github/workflows/push-management-images.yml"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -28,37 +28,10 @@ permissions:
   contents: read
 
 jobs:
-  cleanup:
-    runs-on: ubuntu-latest
-    environment: staging
-    permissions:
-      contents: read
-      id-token: write   # mint GitHub OIDC token for GCP WIF
-    steps:
-      # GCP Workload Identity Federation (no stored SA key). Pool +
-      # provider in the eestaging project (dd staging's GCP), attribute
-      # condition is `assertion.repository == 'devopsdefender/dd'`, SA
-      # binding is scoped to the same principal set.
-      - uses: google-github-actions/auth@v2
-        with:
-          workload_identity_provider: 'projects/654815109728/locations/global/workloadIdentityPools/github-actions-pool/providers/github-provider'
-          service_account: 'easyenclave-staging-ci@eestaging.iam.gserviceaccount.com'
-      - uses: google-github-actions/setup-gcloud@v2
-      - name: Delete managed VMs
-        env:
-          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
-        run: |
-          gcloud compute instances list \
-            --project="$GCP_PROJECT_ID" \
-            --filter="labels.devopsdefender=managed AND labels.dd_env=staging" \
-            --format="value(name,zone.basename())" | while read -r name zone; do
-            [ -z "$name" ] && continue
-            echo "Deleting VM: $name ($zone)"
-            gcloud compute instances delete "$name" --project="$GCP_PROJECT_ID" --zone="$zone" --quiet || true
-          done
-
+  # No cleanup job — dd-register STONITHs the old VM on startup by
+  # deleting its CF tunnel, which causes cloudflared to exit and
+  # triggers poweroff on the old VM.
   deploy:
-    needs: [cleanup]
     runs-on: ubuntu-latest
     environment: staging
     permissions:

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -1,11 +1,12 @@
 name: Staging Deploy
 
 on:
-  push:
+  pull_request:
     branches: [main]
     paths:
       - "crates/**"
       - "scripts/gcp-deploy.sh"
+      - "Dockerfile"
       - ".github/workflows/staging-deploy.yml"
       - ".github/workflows/push-management-images.yml"
   workflow_dispatch:

--- a/crates/dd-client/src/lib.rs
+++ b/crates/dd-client/src/lib.rs
@@ -136,6 +136,45 @@ async fn post_exec(
     Ok(Json(resp).into_response())
 }
 
+// ── Route: /re-register (POST) ──────────────────────────────────────────
+// Triggers re-registration with dd-register. Used by the collector to
+// migrate agents to a new register instance after a zero-downtime deploy.
+
+async fn post_re_register(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+) -> Result<Response, AppError> {
+    auth::verify_owner(&state, &headers).await?;
+
+    let register_url = state
+        .config
+        .register_url
+        .as_deref()
+        .ok_or_else(|| AppError::InvalidInput("no register URL configured".into()))?;
+
+    eprintln!("dd-client: re-registering with {register_url}");
+    match register_with_noise(register_url, &state.config.vm_name, &state.config.owner).await {
+        Ok(bootstrap) => {
+            eprintln!("dd-client: re-registered — hostname={}", bootstrap.hostname);
+
+            // Start new cloudflared if tunnel token changed.
+            if let Err(e) = start_cloudflared(&bootstrap.tunnel_token).await {
+                eprintln!("dd-client: cloudflared restart failed: {e}");
+            }
+
+            Ok(Json(serde_json::json!({
+                "ok": true,
+                "hostname": bootstrap.hostname,
+            }))
+            .into_response())
+        }
+        Err(e) => {
+            eprintln!("dd-client: re-registration failed: {e}");
+            Err(AppError::External(e))
+        }
+    }
+}
+
 // ── Registration via Noise WS ───────────────────────────────────────────
 
 async fn register_with_noise(
@@ -367,6 +406,7 @@ pub async fn run() {
             get(auth::login_page).post(auth::login_submit),
         )
         .route("/auth/logout", get(auth::logout))
+        .route("/re-register", post(post_re_register))
         .with_state(state);
 
     let addr = format!("0.0.0.0:{port}");

--- a/crates/dd-register/src/lib.rs
+++ b/crates/dd-register/src/lib.rs
@@ -22,6 +22,8 @@ struct AppState {
     hostname: String,
     registry: AgentRegistry,
     cf: tunnel::CfConfig,
+    /// Our own tunnel ID (used by STONITH to avoid killing ourselves).
+    self_tunnel_id: String,
     /// Base64-encoded HMAC secret for agent JWT verification.
     auth_public_key_b64: Option<String>,
     /// Auth issuer URL (https://<hostname>).
@@ -78,7 +80,9 @@ pub async fn run() {
 
     eprintln!("dd-register: tunnel created -- {}", tunnel_info.hostname);
 
-    // Start cloudflared with the tunnel token
+    // Start cloudflared with the tunnel token.
+    // If cloudflared exits (e.g. tunnel deleted by a new register's STONITH),
+    // power off the VM — this is the STONITH kill mechanism.
     let token = tunnel_info.tunnel_token.clone();
     tokio::spawn(async move {
         eprintln!("dd-register: starting cloudflared");
@@ -95,6 +99,8 @@ pub async fn run() {
             .expect("failed to spawn cloudflared");
         let status = child.wait().await;
         eprintln!("dd-register: cloudflared exited: {status:?}");
+        eprintln!("dd-register: tunnel lost — powering off (STONITH kill)");
+        let _ = tokio::process::Command::new("poweroff").spawn();
     });
 
     // Bootstrap registry from existing CF tunnels
@@ -151,15 +157,26 @@ pub async fn run() {
         hostname: hostname.clone(),
         registry,
         cf,
+        self_tunnel_id: tunnel_info.tunnel_id.clone(),
         auth_public_key_b64,
         auth_issuer,
     };
 
-    // Axum router: 3 endpoints
+    // STONITH: signal old register instances to shut down.
+    // After we've self-registered (our tunnel is live), find any OTHER
+    // tunnel serving the same hostname and tell it to power off.
+    let stonith_state = state.clone();
+    tokio::spawn(async move {
+        // Give cloudflared a moment to connect before we STONITH.
+        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+        stonith_old_registers(&stonith_state).await;
+    });
+
     let app = Router::new()
         .route("/register", get(ws_register))
         .route("/deregister", post(post_deregister))
         .route("/health", get(get_health))
+        .route("/stonith", post(post_stonith))
         .with_state(state);
 
     let addr = format!("0.0.0.0:{port}");
@@ -216,6 +233,7 @@ async fn post_deregister(
 
 async fn get_health(State(state): State<AppState>) -> impl IntoResponse {
     let agents = state.registry.lock().await;
+    let registered_count = agents.values().filter(|a| a.status == "healthy").count();
     let agent_list: Vec<serde_json::Value> = agents
         .values()
         .map(|a| {
@@ -232,6 +250,91 @@ async fn get_health(State(state): State<AppState>) -> impl IntoResponse {
         "ok": true,
         "hostname": state.hostname,
         "agent_count": agents.len(),
+        "registered_count": registered_count,
         "agents": agent_list,
     }))
+}
+
+// ── Route: /stonith (POST) ─────────────────────────────────────────────
+// Accepts a shutdown signal from a new register instance. Validates the
+// CF API token as a shared secret, then powers off the VM.
+
+async fn post_stonith(
+    State(state): State<AppState>,
+    headers: axum::http::HeaderMap,
+) -> impl IntoResponse {
+    // Validate: Authorization header must contain our CF API token.
+    let auth = headers
+        .get("authorization")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default();
+    let expected = format!("Bearer {}", state.cf.api_token);
+    if auth != expected {
+        return (
+            axum::http::StatusCode::UNAUTHORIZED,
+            Json(serde_json::json!({"ok": false, "error": "unauthorized"})),
+        );
+    }
+
+    eprintln!("dd-register: STONITH received — powering off");
+
+    // Spawn poweroff in background so we can return the response first.
+    tokio::spawn(async {
+        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+        eprintln!("dd-register: executing poweroff");
+        let _ = tokio::process::Command::new("poweroff")
+            .spawn()
+            .map_err(|e| eprintln!("dd-register: poweroff failed: {e}"));
+    });
+
+    (
+        axum::http::StatusCode::OK,
+        Json(serde_json::json!({"ok": true, "message": "shutting down"})),
+    )
+}
+
+// ── STONITH: delete old register tunnels to trigger poweroff ────────────
+// When we delete an old register's CF tunnel, its cloudflared exits, which
+// triggers `poweroff` (see the cloudflared spawn above). This is the kill
+// mechanism — no HTTP signal needed, just pull the tunnel out from under it.
+
+async fn stonith_old_registers(state: &AppState) {
+    let http = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(10))
+        .build()
+        .unwrap_or_else(|_| reqwest::Client::new());
+
+    let tunnels = match tunnel::list_tunnels(&http, &state.cf).await {
+        Ok(t) => t,
+        Err(e) => {
+            eprintln!("dd-register: STONITH: failed to list tunnels: {e}");
+            return;
+        }
+    };
+
+    let our_tunnel_id = &state.self_tunnel_id;
+
+    for t in &tunnels {
+        let name = t["name"].as_str().unwrap_or_default();
+        let id = t["id"].as_str().unwrap_or_default();
+        if id.is_empty() || id == our_tunnel_id {
+            continue;
+        }
+
+        // Check if this tunnel serves our hostname (same DNS CNAME target).
+        let tun_hostname = format!("{name}.{}", state.cf.domain);
+        if tun_hostname != state.hostname {
+            continue;
+        }
+
+        eprintln!("dd-register: STONITH: deleting old tunnel {name} ({id})");
+        if let Err(e) = tunnel::delete_tunnel_by_name(&http, &state.cf, name).await {
+            eprintln!("dd-register: STONITH: delete failed for {name}: {e}");
+        } else {
+            eprintln!("dd-register: STONITH: killed old tunnel {name}");
+        }
+
+        // Also clean up the DNS record if it still points to the old tunnel.
+        let _ = tunnel::delete_dns_record(&http, &state.cf, &tun_hostname).await;
+    }
 }

--- a/crates/dd-web/src/collector.rs
+++ b/crates/dd-web/src/collector.rs
@@ -172,6 +172,30 @@ pub async fn run_collector(state: WebState) {
             }
         }
 
+        // Re-register sweep: for agents bootstrapped from CF tunnels that
+        // haven't registered with the current dd-register (status "discovered"),
+        // trigger re-registration so they migrate to the new register instance.
+        {
+            let store = state.agents.lock().await;
+            let discovered: Vec<String> = store
+                .values()
+                .filter(|a| a.status == "discovered" || a.status == "stale")
+                .filter(|a| a.agent_id != "control-plane")
+                .map(|a| a.hostname.clone())
+                .collect();
+            drop(store);
+
+            for hostname in &discovered {
+                let url = format!("https://{hostname}/re-register");
+                match http.post(&url).send().await {
+                    Ok(resp) if resp.status().is_success() => {
+                        eprintln!("dd-web: collector triggered re-register on {hostname}");
+                    }
+                    _ => {} // Agent may not support re-register yet; ignore errors.
+                }
+            }
+        }
+
         // Self-check: query local easyenclave + localhost health to register
         // the control plane in the fleet dashboard.
         let self_healthy = matches!(


### PR DESCRIPTION
## Summary
- New register kills old VM on startup by deleting its CF tunnel (STONITH)
- Old cloudflared exits → triggers `poweroff` → VM shuts down cleanly
- Removes cleanup jobs from staging + production deploy workflows
- Adds `POST /re-register` on dd-client for agent migration
- Collector triggers re-register on discovered agents
- No CI involvement in old VM lifecycle — register handles it

## How it works
```
T=0    New VM created alongside old VM (old still serving)
T+30s  New register creates tunnel, DNS CNAME updates
T+35s  New register deletes old tunnel → old cloudflared exits → poweroff
T+60s  Collector discovers agents, triggers re-registration
T+90s  CI verify passes
```

## Test plan
- [ ] CI passes (build + clippy + fmt)
- [ ] Deploy staging — verify dashboard available throughout
- [ ] Check serial console for STONITH log lines
- [ ] Confirm old VM powers off after new one is healthy
- [ ] Deploy again to verify second STONITH cycle works

🤖 Generated with [Claude Code](https://claude.com/claude-code)