### PR TITLE
fix(stonith): identify old tunnels by ingress, verify halt

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -252,3 +252,41 @@ jobs:
           done
           echo "::error::/cp/attest never returned a valid quote — stale tunnel or new VM never came up"
           exit 1
+
+      - name: Verify STONITH halted prior staging VM(s)
+        env:
+          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+          GCP_ZONE: ${{ env.GCP_ZONE }}
+        run: |
+          # STONITH (dd-register deletes the old tunnel → old cloudflared
+          # exits → old dd-register poweroffs the VM) is the ONLY cleanup
+          # mechanism. If it fails, we want the deploy to fail too so the
+          # regression is loud — don't paper over it with a belt-and-
+          # suspenders GCP delete.
+          #
+          # Give STONITH up to 60s to propagate (tunnel delete → cf
+          # edge drops connection → cloudflared reconnect retries time
+          # out → process exits → dd-register runs `poweroff`).
+          NEW_VM=$(gcloud compute instances list \
+            --project="$GCP_PROJECT_ID" \
+            --filter="labels.devopsdefender=managed AND labels.dd_env=staging" \
+            --format="value(name)" --sort-by=~creationTimestamp | head -1)
+          echo "new VM: $NEW_VM"
+
+          for i in $(seq 1 12); do
+            SURVIVORS=$(gcloud compute instances list \
+              --project="$GCP_PROJECT_ID" \
+              --filter="labels.devopsdefender=managed AND labels.dd_env=staging AND status=RUNNING" \
+              --format="value(name)" \
+              | grep -vx "$NEW_VM" || true)
+            if [ -z "$SURVIVORS" ]; then
+              echo "STONITH verified — only $NEW_VM running"
+              exit 0
+            fi
+            echo "  still running besides $NEW_VM: $(echo "$SURVIVORS" | tr '\n' ' ')"
+            echo "  waiting for STONITH poweroff... (${i}/12)"
+            sleep 5
+          done
+          echo "::error::STONITH failed — old dd-staging VM(s) still RUNNING:"
+          echo "$SURVIVORS"
+          exit 1

--- a/crates/dd-common/src/tunnel.rs
+++ b/crates/dd-common/src/tunnel.rs
@@ -214,6 +214,42 @@ pub async fn list_tunnels(
     Ok(body["result"].as_array().cloned().unwrap_or_default())
 }
 
+/// Fetch the list of hostnames a tunnel's ingress config routes to.
+///
+/// Used by STONITH to identify stale tunnels by the hostname they serve
+/// rather than by reconstructing `{name}.{domain}` — which breaks when
+/// the tunnel's hostname was overridden at creation (e.g. CP tunnels
+/// all serve `app-{env}.{domain}` regardless of tunnel name).
+pub async fn tunnel_ingress_hostnames(
+    client: &reqwest::Client,
+    cf: &CfConfig,
+    tunnel_id: &str,
+) -> Result<Vec<String>, String> {
+    let resp = client
+        .get(format!(
+            "{CF_API}/accounts/{}/cfd_tunnel/{tunnel_id}/configurations",
+            cf.account_id
+        ))
+        .header("Authorization", format!("Bearer {}", cf.api_token))
+        .send()
+        .await
+        .map_err(|e| format!("tunnel config fetch: {e}"))?;
+
+    if !resp.status().is_success() {
+        return Ok(Vec::new());
+    }
+
+    let body: serde_json::Value = resp.json().await.map_err(|e| format!("parse: {e}"))?;
+    Ok(body["result"]["config"]["ingress"]
+        .as_array()
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|r| r["hostname"].as_str().map(String::from))
+                .collect()
+        })
+        .unwrap_or_default())
+}
+
 // -- Internal helpers ---------------------------------------------------------
 
 pub async fn configure_ingress(

--- a/crates/dd-register/src/lib.rs
+++ b/crates/dd-register/src/lib.rs
@@ -321,9 +321,18 @@ async fn stonith_old_registers(state: &AppState) {
             continue;
         }
 
-        // Check if this tunnel serves our hostname (same DNS CNAME target).
-        let tun_hostname = format!("{name}.{}", state.cf.domain);
-        if tun_hostname != state.hostname {
+        // Previously: reconstruct `{name}.{domain}` and compare to
+        // state.hostname. That breaks for CP tunnels, whose hostname
+        // is overridden to `app-{env}.{domain}` and doesn't match the
+        // tunnel name. Ask CF what this tunnel actually serves.
+        let serves_our_host = match tunnel::tunnel_ingress_hostnames(&http, &state.cf, id).await {
+            Ok(hosts) => hosts.iter().any(|h| h == &state.hostname),
+            Err(e) => {
+                eprintln!("dd-register: STONITH: config fetch failed for {name}: {e}");
+                false
+            }
+        };
+        if !serves_our_host {
             continue;
         }
 
@@ -333,8 +342,10 @@ async fn stonith_old_registers(state: &AppState) {
         } else {
             eprintln!("dd-register: STONITH: killed old tunnel {name}");
         }
-
-        // Also clean up the DNS record if it still points to the old tunnel.
-        let _ = tunnel::delete_dns_record(&http, &state.cf, &tun_hostname).await;
     }
+
+    // DNS record now points at our new tunnel (create_agent_tunnel
+    // overwrote it). The old-tunnel DNS cleanup the previous code did
+    // here was a no-op because the record name matched ours; leaving
+    // it out so we don't risk deleting our own record.
 }


### PR DESCRIPTION
## Summary

- STONITH was silently broken for CP tunnels. Old code reconstructed hostname as \`{tunnel_name}.{domain}\` and compared against \`state.hostname\`, but CP tunnels override hostname to \`app-{env}.{domain}\` at creation — the reconstruction never matched, every tunnel was skipped, no old VM ever got its tunnel deleted
- Ask CF what each tunnel actually serves via its ingress config (new \`tunnel_ingress_hostnames\` helper in \`dd-common/src/tunnel.rs\`). STONITH tunnels whose configured hostname matches ours
- Add verification step to \`release.yml\`: after staging deploy, confirm exactly one dd-staging VM is RUNNING. If old VMs survived STONITH, the deploy fails loudly
- **No GCP-side cleanup fallback by design** — STONITH is the mechanism, regressions should be loud

## Why this was invisible

STONITH = dd-register deletes old tunnel → old cloudflared exits → old dd-register sees child exit → calls \`poweroff\`. It relied on identifying the old tunnel by hostname, which broke when we started overriding hostnames for the CP. Since nothing failed loudly, old VMs accumulated silently.

## Test plan

- [x] \`cargo check --workspace\` clean
- [ ] Fresh PR run deploys a new staging VM and verifies the previous one halts (no surviving RUNNING VMs beyond the new one)
- [ ] If STONITH regresses in the future, the \"Verify STONITH halted prior staging VM(s)\" step fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)