### PR TITLE
feat: real PTY shell sessions via easyenclave attach

### DIFF
--- a/crates/dd-client/src/terminal.rs
+++ b/crates/dd-client/src/terminal.rs
@@ -322,47 +322,38 @@ pub async fn ws_session(
     Ok(ws.on_upgrade(move |socket| handle_ws_session(socket, state, app_name)))
 }
 
-/// Proxy WebSocket I/O to easyenclave exec.
+/// Proxy WebSocket I/O to a PTY-backed shell on easyenclave.
 ///
-/// dd-client never touches the workload process directly; interactive
-/// sessions go through the easyenclave exec API on /var/lib/easyenclave/agent.sock.
+/// `app_name` is kept in the URL for the existing client API and shown
+/// in the connect banner, but the shell itself is always `/bin/sh` on
+/// the host — easyenclave's `attach` socket method spawns a fresh PTY
+/// rather than touching any specific workload's stdio. The `app_name`
+/// path parameter is now scoping/UI rather than a backend selector.
 async fn handle_ws_session(socket: WebSocket, state: AppState, app_name: String) {
-    let (mut ws_tx, mut ws_rx) = socket.split();
+    let (mut ws_tx, ws_rx) = socket.split();
 
-    // Get attestation info from easyenclave health
+    // Banner: attestation info so the UI can display "TDX-attested" badges.
     let ee_health = state.ee_client.health().await.unwrap_or_default();
     let attestation_type = ee_health["attestation_type"].as_str().unwrap_or("unknown");
-
-    let attestation_msg = serde_json::json!({
+    let banner = serde_json::json!({
         "type": "attestation",
         "attestation_type": attestation_type,
         "vm_name": state.config.vm_name,
         "owner": state.config.owner,
     });
-    let _ = ws_tx
-        .send(Message::Text(attestation_msg.to_string().into()))
-        .await;
+    let _ = ws_tx.send(Message::Text(banner.to_string().into())).await;
 
-    // Check if the workload exists by listing deployments
-    let list_resp = state.ee_client.list().await.unwrap_or_default();
-    let deployments: Vec<&serde_json::Value> = list_resp["deployments"]
-        .as_array()
-        .map(|a| a.iter().collect())
-        .unwrap_or_default();
-    let exists = deployments.iter().any(|d| {
-        d["app_name"].as_str() == Some(app_name.as_str()) && d["status"].as_str() == Some("running")
-    });
+    // Open the attach session. easyenclave defaults to /bin/sh when cmd
+    // is empty.
+    let attach_stream = match state.ee_client.attach(&[]).await {
+        Ok(s) => s,
+        Err(e) => {
+            let err = serde_json::json!({"type": "error", "message": format!("attach: {e}")});
+            let _ = ws_tx.send(Message::Text(err.to_string().into())).await;
+            return;
+        }
+    };
 
-    if !exists {
-        let err = serde_json::json!({
-            "type": "error",
-            "message": format!("no running workload named '{app_name}'")
-        });
-        let _ = ws_tx.send(Message::Text(err.to_string().into())).await;
-        return;
-    }
-
-    // Send ok status
     let ok = serde_json::json!({
         "type": "ok",
         "status": format!("attached to {app_name}"),
@@ -370,94 +361,72 @@ async fn handle_ws_session(socket: WebSocket, state: AppState, app_name: String)
     });
     let _ = ws_tx.send(Message::Text(ok.to_string().into())).await;
 
-    // Proxy loop: stdin from WebSocket -> easyenclave exec,
-    // easyenclave stdout -> WebSocket.
-    //
-    // For interactive sessions, we open a persistent connection to
-    // easyenclave and relay data bidirectionally. Since the easyenclave
-    // unix socket uses request-response (not streaming), we use polling
-    // to get new log output while forwarding stdin as exec commands.
-    //
-    // The exec-based approach: each keystroke batch is sent as a write
-    // to the process stdin file descriptor. Log output is polled.
+    bridge_ws_to_attach(ws_tx, ws_rx, attach_stream).await;
+}
 
-    let ee_client = state.ee_client.clone();
-    let app_name_clone = app_name.clone();
+/// Pump bytes between the WebSocket and the attach UnixStream.
+///
+/// Wire format on the WS side stays as it was — JSON envelopes
+/// `{"type":"stdin","data":[bytes]}` from client and
+/// `{"type":"stdout","data":"<utf8>"}` to client — so the existing
+/// xterm.js page doesn't need to change.
+async fn bridge_ws_to_attach(
+    mut ws_tx: futures_util::stream::SplitSink<axum::extract::ws::WebSocket, Message>,
+    mut ws_rx: futures_util::stream::SplitStream<axum::extract::ws::WebSocket>,
+    attach: tokio::net::UnixStream,
+) {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
-    // Start a log-polling task that sends stdout to the WebSocket
-    let (stop_tx, mut stop_rx) = tokio::sync::oneshot::channel::<()>();
-    let (stdout_tx, mut stdout_rx) = tokio::sync::mpsc::channel::<String>(256);
+    let (mut sock_rd, mut sock_wr) = attach.into_split();
 
-    // Poll logs periodically
-    let poll_ee = ee_client.clone();
-    let poll_id = {
-        let deps = deployments
-            .iter()
-            .find(|d| d["app_name"].as_str() == Some(app_name_clone.as_str()));
-        deps.and_then(|d| d["id"].as_str())
-            .unwrap_or("")
-            .to_string()
-    };
-
-    let poll_handle = tokio::spawn(async move {
-        let mut last_line_count = 0usize;
-        let mut interval = tokio::time::interval(std::time::Duration::from_millis(500));
+    // sock → ws
+    let read_task = tokio::spawn(async move {
+        let mut buf = [0u8; 4096];
         loop {
-            tokio::select! {
-                _ = &mut stop_rx => break,
-                _ = interval.tick() => {
-                    let resp = poll_ee.logs(&poll_id).await.unwrap_or_default();
-                    if let Some(lines) = resp["lines"].as_array() {
-                        if lines.len() > last_line_count {
-                            for line in &lines[last_line_count..] {
-                                if let Some(text) = line.as_str() {
-                                    let _ = stdout_tx.send(format!("{text}\r\n")).await;
-                                }
-                            }
-                            last_line_count = lines.len();
-                        }
+            match sock_rd.read(&mut buf).await {
+                Ok(0) | Err(_) => break,
+                Ok(n) => {
+                    let chunk = String::from_utf8_lossy(&buf[..n]).to_string();
+                    let msg = serde_json::json!({ "type": "stdout", "data": chunk });
+                    if ws_tx
+                        .send(Message::Text(msg.to_string().into()))
+                        .await
+                        .is_err()
+                    {
+                        break;
                     }
                 }
             }
         }
+        // Close the WS cleanly.
+        let _ = ws_tx.close().await;
     });
 
-    // Bidirectional relay
-    loop {
-        tokio::select! {
-            Some(text) = stdout_rx.recv() => {
-                let msg = serde_json::json!({ "type": "stdout", "data": text });
-                if ws_tx.send(Message::Text(msg.to_string().into())).await.is_err() {
-                    break;
-                }
-            }
-            msg = ws_rx.next() => {
-                match msg {
-                    Some(Ok(Message::Text(text))) => {
-                        if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&text) {
-                            if parsed["type"] == "stdin" {
-                                if let Some(data) = parsed["data"].as_array() {
-                                    let bytes: Vec<u8> = data
-                                        .iter()
-                                        .filter_map(|v| v.as_u64().map(|b| b as u8))
-                                        .collect();
-                                    let input = String::from_utf8_lossy(&bytes).to_string();
-                                    // Execute the input as a command through easyenclave
-                                    // For a shell session, this writes to the process stdin
-                                    let _ = ee_client
-                                        .exec(&[input], 5)
-                                        .await;
-                                }
+    // ws → sock
+    while let Some(Ok(msg)) = ws_rx.next().await {
+        match msg {
+            Message::Text(text) => {
+                if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&text) {
+                    if parsed["type"] == "stdin" {
+                        if let Some(data) = parsed["data"].as_array() {
+                            let bytes: Vec<u8> = data
+                                .iter()
+                                .filter_map(|v| v.as_u64().map(|b| b as u8))
+                                .collect();
+                            if sock_wr.write_all(&bytes).await.is_err() {
+                                break;
                             }
                         }
                     }
-                    Some(Ok(Message::Close(_))) | None => break,
-                    _ => {}
                 }
             }
+            Message::Close(_) => break,
+            _ => {}
         }
     }
 
-    let _ = stop_tx.send(());
-    poll_handle.abort();
+    // Dropping sock_wr signals EOF to the child via easyenclave; the
+    // read_task will exit when the child output stops.
+    drop(sock_wr);
+    let _ = read_task.await;
 }

--- a/crates/dd-common/src/ee_client.rs
+++ b/crates/dd-common/src/ee_client.rs
@@ -1,9 +1,12 @@
 //! Unix socket client for the easyenclave API.
 //!
-//! Each method opens a short-lived connection, sends a JSON request
-//! (newline-delimited), reads one JSON response line, and disconnects.
+//! Most methods open a short-lived connection, send a JSON request
+//! (newline-delimited), read one JSON response line, and disconnect.
+//! `attach` is the exception — it sends the JSON handshake and then
+//! returns the live stream so the caller can bridge raw bytes (PTY
+//! shell sessions over WebSocket).
 
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::net::UnixStream;
 
 /// Client for the easyenclave daemon over a Unix socket.
@@ -96,5 +99,58 @@ impl EeClient {
     pub async fn logs(&self, id: &str) -> Result<serde_json::Value, String> {
         self.request(serde_json::json!({ "method": "logs", "id": id }))
             .await
+    }
+
+    /// Open an interactive PTY shell on the easyenclave socket.
+    ///
+    /// Sends `{"method":"attach","cmd":[...]}`, reads the JSON ack, and
+    /// returns the live `UnixStream` so the caller can bridge raw bytes
+    /// in both directions (typically to a WebSocket). After this call,
+    /// the socket connection is in raw byte-stream mode — no more JSON.
+    ///
+    /// `cmd` defaults to `["/bin/sh"]` server-side if empty.
+    pub async fn attach(&self, cmd: &[String]) -> Result<UnixStream, String> {
+        let mut stream = UnixStream::connect(&self.socket_path)
+            .await
+            .map_err(|e| format!("connect to {}: {e}", self.socket_path))?;
+
+        let req = serde_json::json!({ "method": "attach", "cmd": cmd });
+        let mut payload = serde_json::to_vec(&req).map_err(|e| format!("serialize: {e}"))?;
+        payload.push(b'\n');
+        stream
+            .write_all(&payload)
+            .await
+            .map_err(|e| format!("write attach: {e}"))?;
+
+        // Read exactly one line (the ack) from the stream without
+        // consuming any bytes after the newline. Manual byte loop so we
+        // don't pull a `BufReader` over the stream — that would buffer
+        // server-pushed bytes the caller hasn't asked for yet.
+        let mut line = Vec::new();
+        let mut byte = [0u8; 1];
+        loop {
+            let n = stream
+                .read(&mut byte)
+                .await
+                .map_err(|e| format!("read ack: {e}"))?;
+            if n == 0 {
+                return Err("attach ack EOF".into());
+            }
+            if byte[0] == b'\n' {
+                break;
+            }
+            line.push(byte[0]);
+            if line.len() > 4096 {
+                return Err("attach ack too long".into());
+            }
+        }
+
+        let ack: serde_json::Value = serde_json::from_slice(&line)
+            .map_err(|e| format!("parse ack {:?}: {e}", String::from_utf8_lossy(&line)))?;
+        if ack["ok"].as_bool() != Some(true) || ack["attached"].as_bool() != Some(true) {
+            return Err(format!("attach refused: {ack}"));
+        }
+
+        Ok(stream)
     }
 }

--- a/crates/dd-web/src/lib.rs
+++ b/crates/dd-web/src/lib.rs
@@ -15,6 +15,7 @@ pub mod fleet;
 pub mod html;
 pub mod router;
 pub mod state;
+pub mod terminal;
 
 use std::collections::HashMap;
 use std::sync::Arc;

--- a/crates/dd-web/src/router.rs
+++ b/crates/dd-web/src/router.rs
@@ -25,6 +25,8 @@ pub fn build_router(state: WebState) -> Router {
         .route("/cp/deployments", get(cp_deployments))
         .route("/cp/deployments/{id}/logs", get(cp_deployment_logs))
         .route("/cp/attest", get(cp_attest))
+        .route("/cp/shell", get(crate::terminal::shell_page))
+        .route("/cp/ws/shell", get(crate::terminal::ws_shell))
         .route("/federate", get(federate::federate))
         .route("/auth/github/start", get(auth::github_start))
         .route("/auth/github/callback", get(auth::github_callback))

--- a/crates/dd-web/src/terminal.rs
+++ b/crates/dd-web/src/terminal.rs
@@ -1,0 +1,162 @@
+//! Interactive shell into the management VM (CP).
+//!
+//! - GET /cp/shell → xterm.js HTML page
+//! - GET /cp/ws/shell → WebSocket bridge to easyenclave's `attach` socket method
+//!
+//! Same WS envelope as `dd-client/src/terminal.rs` so the on-the-wire
+//! protocol is symmetric across the fleet.
+
+use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
+use axum::extract::State;
+use axum::http::HeaderMap;
+use axum::response::{Html, IntoResponse, Response};
+use futures_util::{SinkExt, StreamExt};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+use crate::auth::require_browser_auth;
+use crate::state::WebState;
+
+pub async fn shell_page(
+    State(state): State<WebState>,
+    headers: HeaderMap,
+    axum::extract::OriginalUri(uri): axum::extract::OriginalUri,
+) -> Result<Response, Response> {
+    if !state.config.owner.is_empty() {
+        require_browser_auth(&state, &headers, &uri).await?;
+    }
+    Ok(Html(SHELL_HTML).into_response())
+}
+
+pub async fn ws_shell(
+    State(state): State<WebState>,
+    headers: HeaderMap,
+    axum::extract::OriginalUri(uri): axum::extract::OriginalUri,
+    ws: WebSocketUpgrade,
+) -> Result<Response, Response> {
+    if !state.config.owner.is_empty() {
+        require_browser_auth(&state, &headers, &uri).await?;
+    }
+    Ok(ws.on_upgrade(move |socket| handle_ws(socket, state)))
+}
+
+async fn handle_ws(socket: WebSocket, state: WebState) {
+    let (mut ws_tx, mut ws_rx) = socket.split();
+
+    let attach = match state.ee_client.attach(&[]).await {
+        Ok(s) => s,
+        Err(e) => {
+            let err = serde_json::json!({"type": "error", "message": format!("attach: {e}")});
+            let _ = ws_tx.send(Message::Text(err.to_string().into())).await;
+            return;
+        }
+    };
+    let ok = serde_json::json!({"type": "ok", "status": "attached to control-plane"});
+    let _ = ws_tx.send(Message::Text(ok.to_string().into())).await;
+
+    let (mut sock_rd, mut sock_wr) = attach.into_split();
+
+    // sock → ws
+    let read_task = tokio::spawn(async move {
+        let mut buf = [0u8; 4096];
+        loop {
+            match sock_rd.read(&mut buf).await {
+                Ok(0) | Err(_) => break,
+                Ok(n) => {
+                    let chunk = String::from_utf8_lossy(&buf[..n]).to_string();
+                    let msg = serde_json::json!({"type": "stdout", "data": chunk});
+                    if ws_tx
+                        .send(Message::Text(msg.to_string().into()))
+                        .await
+                        .is_err()
+                    {
+                        break;
+                    }
+                }
+            }
+        }
+        let _ = ws_tx.close().await;
+    });
+
+    // ws → sock
+    while let Some(Ok(msg)) = ws_rx.next().await {
+        match msg {
+            Message::Text(text) => {
+                if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&text) {
+                    if parsed["type"] == "stdin" {
+                        if let Some(data) = parsed["data"].as_array() {
+                            let bytes: Vec<u8> = data
+                                .iter()
+                                .filter_map(|v| v.as_u64().map(|b| b as u8))
+                                .collect();
+                            if sock_wr.write_all(&bytes).await.is_err() {
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+            Message::Close(_) => break,
+            _ => {}
+        }
+    }
+
+    drop(sock_wr);
+    let _ = read_task.await;
+}
+
+const SHELL_HTML: &str = r#"<!DOCTYPE html>
+<html><head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>DD — control-plane shell</title>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/xterm@5.3.0/css/xterm.min.css">
+<style>
+  *{box-sizing:border-box;margin:0;padding:0}
+  body{background:#1e1e2e;color:#cdd6f4;font-family:ui-monospace,monospace;display:flex;flex-direction:column;height:100vh}
+  header{padding:.5em 1em;border-bottom:1px solid #313244;display:flex;justify-content:space-between;align-items:center;font-size:.85em}
+  header a{color:#89b4fa;text-decoration:none}
+  #status{padding:.2em .5em;border-radius:4px;background:#313244}
+  #status.ok{background:#2d4a37;color:#a6e3a1}
+  #status.err{background:#4a2d34;color:#f38ba8}
+  #terminal{flex:1;padding:.5em;background:#11111b}
+</style>
+</head><body>
+<header>
+  <a href="/agent/control-plane">&larr; control-plane</a>
+  <div><span id="status">connecting</span></div>
+</header>
+<div id="terminal"></div>
+<script src="https://cdn.jsdelivr.net/npm/xterm@5.3.0/lib/xterm.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/xterm-addon-fit@0.8.0/lib/xterm-addon-fit.min.js"></script>
+<script>
+const term = new Terminal({fontFamily:'ui-monospace,monospace',fontSize:13,cursorBlink:true,
+  theme:{background:'#11111b',foreground:'#cdd6f4',cursor:'#f5e0dc'}});
+const fit = new FitAddon.FitAddon();
+term.loadAddon(fit);
+term.open(document.getElementById('terminal'));
+const fitNow = () => requestAnimationFrame(() => { try { fit.fit(); } catch (_) {} });
+fitNow();
+window.addEventListener('resize', fitNow);
+const status = document.getElementById('status');
+const setStatus = (t, c) => { status.textContent = t; status.className = c || ''; };
+
+const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
+const ws = new WebSocket(`${proto}//${location.host}/cp/ws/shell`);
+ws.onopen = () => setStatus('handshake', 'warn');
+ws.onmessage = (e) => {
+  try {
+    const m = JSON.parse(typeof e.data === 'string' ? e.data : new TextDecoder().decode(e.data));
+    if (m.type === 'stdout' || m.type === 'stderr') term.write(typeof m.data === 'string' ? m.data : String.fromCharCode(...m.data));
+    else if (m.type === 'ok') { setStatus(m.status || 'connected', 'ok'); term.focus(); }
+    else if (m.type === 'error') setStatus(m.message || 'error', 'err');
+  } catch (_) { term.write(typeof e.data === 'string' ? e.data : new TextDecoder().decode(e.data)); }
+};
+ws.onclose = () => { setStatus('disconnected', 'err'); term.write('\r\n[session ended]\r\n'); };
+ws.onerror = () => setStatus('connection error', 'err');
+term.onData((d) => {
+  if (ws.readyState === WebSocket.OPEN) {
+    ws.send(JSON.stringify({type:'stdin', data: Array.from(new TextEncoder().encode(d))}));
+  }
+});
+</script></body></html>
+"#;


### PR DESCRIPTION
## Summary

dd-client's \`/session/{app_name}\` was faking interactive shells: each keystroke went out as a separate \`easyenclave.exec()\` call with a 5-second timeout, and output was polled from \`logs()\` every 500ms. No persistent shell state — \`cd /tmp\` then \`pwd\` returned the wrong directory; vim/htop didn't render; arrow keys looked broken.

Replace with a real bridge to easyenclave's \`attach\` socket method (PTY-backed, raw byte stream).

## Changes

- **\`dd-common\`**: new \`EeClient::attach(cmd) -> Result<UnixStream>\`. Sends \`{\"method\":\"attach\",\"cmd\":[…]}\`, reads the JSON ack, returns the live stream so the caller can bridge raw bytes in both directions.
- **\`dd-client\`**: \`handle_ws_session\` refactored. Drops the polling task + per-keystroke exec hack. Two concurrent copies: WS→socket and socket→WS. WS envelope unchanged so the existing xterm.js page works without changes.
- **\`dd-web\`**: new \`terminal\` module with \`/cp/shell\` (xterm.js HTML, slim self-contained ~80 lines of JS — no per-app templating since CP only has one shell) and \`/cp/ws/shell\` (WS bridge to local easyenclave socket).
- Both routes gated by each crate's existing browser auth (\`require_browser_token\` for dd-client, \`require_browser_auth\` for dd-web).

The \`app_name\` path parameter on dd-client stays for UI scoping (banner text, URL semantics) but the backend always opens \`/bin/sh\` on the local easyenclave socket — easyenclave's \`attach\` spawns a fresh PTY rather than touching any specific workload's stdio.

## Test plan

- [x] \`cargo fmt --check && cargo clippy --all-targets -- -D warnings\` clean across the workspace
- [ ] Open \`https://app-staging.devopsdefender.com/cp/shell\`; \`pwd; cd /tmp; pwd\` shows persistent shell state
- [ ] Open any agent's \`/session/<app_name>\` via its tunnel; same persistent shell
- [ ] vim / htop / less render correctly (PTY working)
- [ ] WS close cleanly when shell exits

## Follow-up (not in this PR)

- Symmetric route names — drop \`/cp/*\` prefix on local-VM routes so dd-web and dd-client serve identical paths for their \"local\" view (\`/session\`, \`/deployments\`, \`/attest\`)
- Shared dashboard module in dd-common to deduplicate auth + HTML helpers
- Replace the logs page's 2s meta-refresh with real WS streaming via attach + tail -f

🤖 Generated with [Claude Code](https://claude.com/claude-code)