### PR TITLE
feat: per-PR ephemeral preview envs with PAT browser auth

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -32,6 +32,43 @@ permissions:
   contents: read
 
 jobs:
+  # PR preview envs (dd_env=pr-*) accumulate during active PRs — every
+  # push STONITHs the old VM into TERMINATED. PR close runs
+  # pr-teardown.yml which deletes them, but between pushes they stack
+  # up. This job reaps them in place.
+  reap-pr-previews:
+    runs-on: ubuntu-latest
+    environment: staging
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: 'projects/654815109728/locations/global/workloadIdentityPools/github-actions-pool/providers/github-provider'
+          service_account: 'easyenclave-staging-ci@eestaging.iam.gserviceaccount.com'
+      - uses: google-github-actions/setup-gcloud@v2
+      - name: Reap TERMINATED dd-pr-* VMs
+        env:
+          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+          GCP_ZONE: us-central1-c
+        run: |
+          # gcloud filter regex: `~` matches against the value. Anchor
+          # to start so we don't accidentally match an env like
+          # "foo-pr-bar" in the future.
+          DEAD=$(gcloud compute instances list \
+            --project="$GCP_PROJECT_ID" \
+            --filter='labels.devopsdefender=managed AND labels.dd_env~"^pr-" AND status=TERMINATED' \
+            --format="value(name)")
+          if [ -z "$DEAD" ]; then
+            echo "No TERMINATED dd-pr-* VMs to reap."
+            exit 0
+          fi
+          echo "Reaping: $(echo "$DEAD" | tr '\n' ' ')"
+          # shellcheck disable=SC2086
+          gcloud compute instances delete $DEAD \
+            --project="$GCP_PROJECT_ID" --zone="$GCP_ZONE" --quiet
+
   reap-staging:
     runs-on: ubuntu-latest
     environment: staging

--- a/.github/workflows/pr-teardown.yml
+++ b/.github/workflows/pr-teardown.yml
@@ -1,0 +1,105 @@
+name: PR Teardown
+
+# Cleanup the per-PR ephemeral preview env created by release.yml:
+# delete the VM, the Cloudflare tunnel, and the DNS CNAME for
+# pr-{N}.{domain}. Idempotent — skips silently if nothing to reap.
+#
+# STONITH normally poweroffs the VM when its tunnel is deleted, but
+# closing a PR doesn't trigger STONITH on its own. This workflow does
+# the equivalent cleanup from outside the VM.
+
+on:
+  pull_request:
+    types: [closed]
+
+concurrency:
+  group: dd-pr-teardown-${{ github.event.number }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  DD_ENV: pr-${{ github.event.number }}
+  DD_HOSTNAME: pr-${{ github.event.number }}.${{ vars.DD_CF_DOMAIN || 'devopsdefender.com' }}
+  GCP_ZONE: us-central1-c
+
+jobs:
+  teardown:
+    runs-on: ubuntu-latest
+    environment: staging
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: 'projects/654815109728/locations/global/workloadIdentityPools/github-actions-pool/providers/github-provider'
+          service_account: 'easyenclave-staging-ci@eestaging.iam.gserviceaccount.com'
+      - uses: google-github-actions/setup-gcloud@v2
+
+      - name: Delete PR VMs
+        env:
+          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+        run: |
+          VMS=$(gcloud compute instances list \
+            --project="$GCP_PROJECT_ID" \
+            --filter="labels.devopsdefender=managed AND labels.dd_env=${DD_ENV}" \
+            --format="value(name)")
+          if [ -z "$VMS" ]; then
+            echo "No dd-${DD_ENV} VMs to delete."
+          else
+            echo "Deleting: $(echo "$VMS" | tr '\n' ' ')"
+            # shellcheck disable=SC2086
+            gcloud compute instances delete $VMS \
+              --project="$GCP_PROJECT_ID" --zone="$GCP_ZONE" --quiet
+          fi
+
+      - name: Delete CF tunnels for this PR
+        env:
+          CF_API_TOKEN: ${{ secrets.DD_CP_CF_API_TOKEN }}
+          CF_ACCOUNT_ID: ${{ secrets.DD_CP_CF_ACCOUNT_ID }}
+        run: |
+          # Tunnels are named `dd-{DD_ENV}-{uuid}` (see
+          # dd-common/src/tunnel.rs::create_agent_tunnel). List all
+          # tunnels with the dd-{DD_ENV}- prefix and delete each.
+          resp=$(curl -fsS \
+            -H "Authorization: Bearer ${CF_API_TOKEN}" \
+            "https://api.cloudflare.com/client/v4/accounts/${CF_ACCOUNT_ID}/cfd_tunnel?is_deleted=false&per_page=200")
+          ids=$(echo "$resp" | jq -r --arg prefix "dd-${DD_ENV}-" \
+            '.result[] | select(.name | startswith($prefix)) | .id')
+          if [ -z "$ids" ]; then
+            echo "No CF tunnels with prefix dd-${DD_ENV}-"
+          else
+            for id in $ids; do
+              echo "Deleting tunnel $id"
+              # Drain connections first (some stale connections block delete).
+              curl -fsS -X DELETE \
+                -H "Authorization: Bearer ${CF_API_TOKEN}" \
+                "https://api.cloudflare.com/client/v4/accounts/${CF_ACCOUNT_ID}/cfd_tunnel/${id}/connections" \
+                >/dev/null || true
+              curl -fsS -X DELETE \
+                -H "Authorization: Bearer ${CF_API_TOKEN}" \
+                "https://api.cloudflare.com/client/v4/accounts/${CF_ACCOUNT_ID}/cfd_tunnel/${id}" \
+                >/dev/null || echo "::warning::tunnel $id delete failed (may already be gone)"
+            done
+          fi
+
+      - name: Delete DNS CNAME for PR hostname
+        env:
+          CF_API_TOKEN: ${{ secrets.DD_CP_CF_API_TOKEN }}
+          CF_ZONE_ID: ${{ secrets.DD_CP_CF_ZONE_ID }}
+        run: |
+          record_id=$(curl -fsS \
+            -H "Authorization: Bearer ${CF_API_TOKEN}" \
+            "https://api.cloudflare.com/client/v4/zones/${CF_ZONE_ID}/dns_records?type=CNAME&name=${DD_HOSTNAME}" \
+            | jq -r '.result[0].id // empty')
+          if [ -z "$record_id" ]; then
+            echo "No CNAME for ${DD_HOSTNAME}"
+          else
+            echo "Deleting CNAME record $record_id (${DD_HOSTNAME})"
+            curl -fsS -X DELETE \
+              -H "Authorization: Bearer ${CF_API_TOKEN}" \
+              "https://api.cloudflare.com/client/v4/zones/${CF_ZONE_ID}/dns_records/${record_id}" \
+              >/dev/null
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,7 +127,10 @@ jobs:
       pull-requests: write
     env:
       DD_ENV: ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || 'staging' }}
-      DD_HOSTNAME: ${{ github.event_name == 'pull_request' && format('pr-{0}.{1}', github.event.number, env.DD_DOMAIN) || format('app-staging.{0}', env.DD_DOMAIN) }}
+      # `env.DD_DOMAIN` can't be read at job-env evaluation time — only
+      # `vars`, `secrets`, `inputs`, `github`, `runner`, `needs`, `matrix`
+      # are available. Inline the default instead of referencing env.
+      DD_HOSTNAME: ${{ github.event_name == 'pull_request' && format('pr-{0}.{1}', github.event.number, vars.DD_CF_DOMAIN || 'devopsdefender.com') || format('app-staging.{0}', vars.DD_CF_DOMAIN || 'devopsdefender.com') }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,6 @@ permissions:
   contents: write
 
 env:
-  DD_ENV: staging
   DD_DOMAIN: ${{ vars.DD_CF_DOMAIN || 'devopsdefender.com' }}
   GCP_ZONE: us-central1-c
 
@@ -112,10 +111,12 @@ jobs:
             | tail -n +12 \
             | xargs -rI{} gh release delete {} --yes --cleanup-tag
 
-  # Deploy the freshly-built binary to staging. Only runs on PRs and
-  # manual dispatches — main/v* produce releases that production-deploy
-  # picks up separately.
-  deploy-staging:
+  # Deploy the freshly-built binary to a preview env. PRs get their own
+  # ephemeral env at pr-{N}.{domain} with DD_ENV=pr-{N} (hostname-isolated,
+  # no OAuth — browser access via /auth/pat). Manual dispatches redeploy
+  # the shared staging env. main/v* produce releases that
+  # production-deploy picks up separately.
+  deploy-preview:
     if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     needs: build
     runs-on: ubuntu-latest
@@ -123,6 +124,10 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      pull-requests: write
+    env:
+      DD_ENV: ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || 'staging' }}
+      DD_HOSTNAME: ${{ github.event_name == 'pull_request' && format('pr-{0}.{1}', github.event.number, env.DD_DOMAIN) || format('app-staging.{0}', env.DD_DOMAIN) }}
     steps:
       - uses: actions/checkout@v4
 
@@ -138,24 +143,27 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.DD_CP_CF_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.DD_CP_CF_ACCOUNT_ID }}
           CLOUDFLARE_ZONE_ID: ${{ secrets.DD_CP_CF_ZONE_ID }}
-          DD_GITHUB_CLIENT_ID: ${{ vars.DD_GITHUB_CLIENT_ID || secrets.DD_GITHUB_CLIENT_ID }}
-          DD_GITHUB_CALLBACK_URL: ${{ vars.DD_GITHUB_CALLBACK_URL }}
-          DD_GITHUB_CLIENT_SECRET: ${{ secrets.DD_GITHUB_CLIENT_SECRET }}
+          # OAuth is only wired for the shared staging env. PR previews
+          # leave these unset; dd-web disables /auth/github/* and serves
+          # /auth/pat for browser access instead.
+          DD_GITHUB_CLIENT_ID: ${{ github.event_name == 'workflow_dispatch' && (vars.DD_GITHUB_CLIENT_ID || secrets.DD_GITHUB_CLIENT_ID) || '' }}
+          DD_GITHUB_CALLBACK_URL: ${{ github.event_name == 'workflow_dispatch' && vars.DD_GITHUB_CALLBACK_URL || '' }}
+          DD_GITHUB_CLIENT_SECRET: ${{ github.event_name == 'workflow_dispatch' && secrets.DD_GITHUB_CLIENT_SECRET || '' }}
           DD_RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || needs.build.outputs.tag }}
         run: scripts/gcp-deploy.sh
 
       - name: Wait for agent health (streams serial console)
         env:
-          AGENT_URL: https://app-staging.${{ env.DD_DOMAIN }}
+          AGENT_URL: https://${{ env.DD_HOSTNAME }}
           GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
           GCP_ZONE: ${{ env.GCP_ZONE }}
         run: |
           VM_NAME=$(gcloud compute instances list \
             --project="$GCP_PROJECT_ID" \
-            --filter="labels.devopsdefender=managed AND labels.dd_env=staging" \
+            --filter="labels.devopsdefender=managed AND labels.dd_env=${DD_ENV}" \
             --format="value(name)" --sort-by=~creationTimestamp | head -1)
           if [ -z "$VM_NAME" ]; then
-            echo "::error::no dd-staging VM found — gcp-deploy.sh must have failed"
+            echo "::error::no dd-${DD_ENV} VM found — gcp-deploy.sh must have failed"
             exit 1
           fi
           echo "Watching VM: $VM_NAME (zone: $GCP_ZONE)"
@@ -197,7 +205,7 @@ jobs:
 
       - name: Verify NEW VM via TDX attestation (OIDC)
         env:
-          AGENT_URL: https://app-staging.${{ env.DD_DOMAIN }}
+          AGENT_URL: https://${{ env.DD_HOSTNAME }}
         run: |
           # The /cp/attest endpoint is new in this refactor. Old staging
           # VMs return 404 from it — so a 200 with a non-zero MRTD is
@@ -253,44 +261,78 @@ jobs:
           echo "::error::/cp/attest never returned a valid quote — stale tunnel or new VM never came up"
           exit 1
 
-      - name: Verify STONITH halted prior staging VM(s)
+      - name: Verify STONITH halted prior VM(s) in this env
         env:
           GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
           GCP_ZONE: ${{ env.GCP_ZONE }}
         run: |
           # STONITH (dd-register deletes the old tunnel → old cloudflared
           # exits → old dd-register poweroffs the VM) is the ONLY cleanup
-          # mechanism. If it fails, we want the deploy to fail too so the
-          # regression is loud — don't paper over it with a belt-and-
-          # suspenders GCP delete.
-          #
-          # Give STONITH up to 60s to propagate (tunnel delete → cf
-          # edge drops connection → cloudflared reconnect retries time
-          # out → process exits → dd-register runs `poweroff`).
+          # mechanism. Scoped to this env (staging or pr-N) — PR previews
+          # are hostname-isolated from each other, so this only reaps
+          # prior deploys of the same PR (re-pushes) or the shared staging.
           NEW_VM=$(gcloud compute instances list \
             --project="$GCP_PROJECT_ID" \
-            --filter="labels.devopsdefender=managed AND labels.dd_env=staging" \
+            --filter="labels.devopsdefender=managed AND labels.dd_env=${DD_ENV}" \
             --format="value(name)" --sort-by=~creationTimestamp | head -1)
           echo "new VM: $NEW_VM"
 
-          # 24 × 5s = 120s. Watchdog poll is 10s with a 15s initial
-          # delay (dd-register/src/lib.rs); kernel reboot + GCP state
-          # transition adds a few seconds. 120s gives comfortable
-          # headroom over a worst-case ~30s detect.
           for i in $(seq 1 24); do
             SURVIVORS=$(gcloud compute instances list \
               --project="$GCP_PROJECT_ID" \
-              --filter="labels.devopsdefender=managed AND labels.dd_env=staging AND status=RUNNING" \
+              --filter="labels.devopsdefender=managed AND labels.dd_env=${DD_ENV} AND status=RUNNING" \
               --format="value(name)" \
               | grep -vx "$NEW_VM" || true)
             if [ -z "$SURVIVORS" ]; then
-              echo "STONITH verified — only $NEW_VM running"
+              echo "STONITH verified — only $NEW_VM running in dd_env=${DD_ENV}"
               exit 0
             fi
             echo "  still running besides $NEW_VM: $(echo "$SURVIVORS" | tr '\n' ' ')"
             echo "  waiting for STONITH poweroff... (${i}/24)"
             sleep 5
           done
-          echo "::error::STONITH failed — old dd-staging VM(s) still RUNNING:"
+          echo "::error::STONITH failed — old dd-${DD_ENV} VM(s) still RUNNING:"
           echo "$SURVIVORS"
           exit 1
+
+      - name: Comment preview URL on PR
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const url = `https://${process.env.DD_HOSTNAME}`;
+            const body = [
+              `### DD preview ready`,
+              ``,
+              `**URL:** ${url}`,
+              ``,
+              `Browser login: paste \`gh auth token\` output at ${url}/auth/pat`,
+              ``,
+              `CLI / curl: \`curl -H "Authorization: Bearer $(gh auth token)" ${url}/\``,
+              ``,
+              `Register endpoint for a local agent: \`wss://${process.env.DD_HOSTNAME}/register\``,
+            ].join('\n');
+
+            // Update existing bot comment if present, else create.
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const marker = '### DD preview ready';
+            const existing = comments.find(c => c.user.type === 'Bot' && c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }

--- a/crates/dd-web/src/auth.rs
+++ b/crates/dd-web/src/auth.rs
@@ -1,8 +1,8 @@
 use std::time::{Duration, Instant};
 
-use axum::extract::State;
+use axum::extract::{Form, State};
 use axum::http::header::{AUTHORIZATION, COOKIE, SET_COOKIE};
-use axum::http::{HeaderMap, HeaderValue, Uri};
+use axum::http::{HeaderMap, HeaderValue, StatusCode, Uri};
 use axum::response::{Html, IntoResponse, Redirect, Response};
 use serde::Deserialize;
 
@@ -84,8 +84,16 @@ fn response_with_cookie(response: impl IntoResponse, cookie: String) -> Response
     response
 }
 
-fn github_oauth_redirect(next: &Uri) -> Redirect {
-    let mut url = reqwest::Url::parse("http://localhost/auth/github/start").unwrap();
+/// Redirect unauthenticated browsers to the right login page.
+/// OAuth-enabled envs (production, shared staging) go through
+/// `/auth/github/start`; ephemeral PR envs go to the PAT form.
+fn login_redirect(state: &WebState, next: &Uri) -> Redirect {
+    let target = if state.config.github_client_id.is_some() {
+        "/auth/github/start"
+    } else {
+        "/auth/pat"
+    };
+    let mut url = reqwest::Url::parse(&format!("http://localhost{target}")).unwrap();
     let next_path = next
         .path_and_query()
         .map(|value| value.as_str())
@@ -186,7 +194,7 @@ pub async fn require_browser_auth(
 ) -> Result<Option<String>, Response> {
     match resolve_auth(state, headers).await {
         Ok(login) => Ok(login),
-        Err(AppError::Unauthorized) => Err(github_oauth_redirect(uri).into_response()),
+        Err(AppError::Unauthorized) => Err(login_redirect(state, uri).into_response()),
         Err(e) => Err(e.into_response()),
     }
 }
@@ -299,6 +307,14 @@ pub async fn github_start(
     State(state): State<WebState>,
     query: axum::extract::Query<AuthStartQuery>,
 ) -> Result<Redirect, AppError> {
+    let (client_id, callback_url) = match (
+        state.config.github_client_id.as_deref(),
+        state.config.github_callback_url.as_deref(),
+    ) {
+        (Some(id), Some(cb)) => (id, cb),
+        _ => return Err(AppError::NotFound),
+    };
+
     let next_path = sanitize_next_path(query.next.as_deref());
     let state_id = uuid::Uuid::new_v4().simple().to_string();
 
@@ -312,8 +328,8 @@ pub async fn github_start(
 
     let mut url = reqwest::Url::parse("https://github.com/login/oauth/authorize").unwrap();
     url.query_pairs_mut()
-        .append_pair("client_id", &state.config.github_client_id)
-        .append_pair("redirect_uri", &state.config.github_callback_url)
+        .append_pair("client_id", client_id)
+        .append_pair("redirect_uri", callback_url)
         .append_pair("scope", "read:user read:org")
         .append_pair("state", &state_id);
     Ok(Redirect::to(url.as_str()))
@@ -324,6 +340,15 @@ pub async fn github_callback(
     State(state): State<WebState>,
     query: axum::extract::Query<GithubCallbackQuery>,
 ) -> Result<Response, AppError> {
+    let (client_id, client_secret, callback_url) = match (
+        state.config.github_client_id.as_deref(),
+        state.config.github_client_secret.as_deref(),
+        state.config.github_callback_url.as_deref(),
+    ) {
+        (Some(id), Some(secret), Some(cb)) => (id, secret, cb),
+        _ => return Err(AppError::NotFound),
+    };
+
     if let Some(error) = query.error.as_deref() {
         let description = query.error_description.as_deref().unwrap_or(error);
         return Err(AppError::External(description.into()));
@@ -355,10 +380,10 @@ pub async fn github_callback(
         .header("Accept", "application/json")
         .header("User-Agent", "dd-web")
         .form(&[
-            ("client_id", state.config.github_client_id.as_str()),
-            ("client_secret", state.config.github_client_secret.as_str()),
+            ("client_id", client_id),
+            ("client_secret", client_secret),
             ("code", code),
-            ("redirect_uri", state.config.github_callback_url.as_str()),
+            ("redirect_uri", callback_url),
             ("state", state_id),
         ])
         .send()
@@ -434,6 +459,87 @@ pub async fn github_callback(
     Ok(response)
 }
 
+// ── PAT login (for ephemeral per-PR envs without an OAuth app) ──────────
+
+#[derive(Debug, Deserialize)]
+pub struct PatLoginForm {
+    pat: String,
+    next: Option<String>,
+}
+
+/// GET /auth/pat -- HTML form that accepts a GitHub PAT.
+/// The dev runs `gh auth token` locally and pastes the output.
+pub async fn pat_login_page(query: axum::extract::Query<AuthStartQuery>) -> Html<String> {
+    let next = sanitize_next_path(query.next.as_deref());
+    let content = format!(
+        r#"<h1>DD preview — PAT login</h1>
+<div class="sub">This is a per-PR preview environment. Browser access uses a GitHub Personal Access Token.</div>
+<p style="margin:16px 0;color:#a6adc8;font-size:13px">Run <code>gh auth token</code> locally and paste the output below. The token is checked against GitHub and a session cookie is set.</p>
+<form method="POST" action="/auth/pat" style="margin-top:16px">
+  <input type="hidden" name="next" value="{next}">
+  <input type="password" name="pat" placeholder="ghp_... or gho_..." autocomplete="off" autofocus
+         style="width:100%;padding:10px;background:#181825;border:1px solid #313244;border-radius:6px;color:#cdd6f4;font-family:inherit;font-size:13px">
+  <button type="submit"
+          style="margin-top:12px;padding:10px 20px;background:#89b4fa;color:#1e1e2e;border:0;border-radius:6px;font-weight:700;cursor:pointer">
+    Log in
+  </button>
+</form>"#,
+        next = html_escape(&next),
+    );
+    Html(page_shell("Log in — DD preview", "", &content))
+}
+
+fn html_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+}
+
+/// POST /auth/pat -- validate the PAT via GitHub API, set session cookie, redirect.
+pub async fn pat_submit(
+    State(state): State<WebState>,
+    Form(form): Form<PatLoginForm>,
+) -> Result<Response, Response> {
+    let next = sanitize_next_path(form.next.as_deref());
+    let pat = form.pat.trim();
+
+    if pat.is_empty() {
+        return Err(pat_error_page("Missing token."));
+    }
+
+    if verify_github_token(pat, &state.config.owner).await.is_err() {
+        return Err(pat_error_page(&format!(
+            "Token rejected. It must belong to a GitHub user or member of `{}`.",
+            html_escape(&state.config.owner)
+        )));
+    }
+
+    let session_id = uuid::Uuid::new_v4().simple().to_string();
+    state.sessions.lock().await.insert(
+        session_id.clone(),
+        BrowserSession {
+            token: pat.to_string(),
+            expires_at: Instant::now() + SESSION_TTL,
+        },
+    );
+
+    Ok(response_with_cookie(
+        Redirect::to(&next),
+        build_session_cookie(&session_id, SESSION_TTL.as_secs()),
+    ))
+}
+
+fn pat_error_page(msg: &str) -> Response {
+    let content = format!(
+        r#"<h1>Log in failed</h1>
+<div class="sub" style="color:#f38ba8">{msg}</div>
+<p style="margin-top:16px"><a href="/auth/pat">Try again</a></p>"#
+    );
+    let html = Html(page_shell("Log in — DD preview", "", &content));
+    (StatusCode::UNAUTHORIZED, html).into_response()
+}
+
 /// GET /auth/logout -- clear session + dd_auth cookies
 pub async fn logout(State(state): State<WebState>, headers: HeaderMap) -> Response {
     if let Some(session_id) = extract_cookie(&headers, SESSION_COOKIE) {
@@ -454,10 +560,16 @@ pub async fn logout(State(state): State<WebState>, headers: HeaderMap) -> Respon
 }
 
 /// GET /logged-out -- simple confirmation page
-pub async fn logged_out_page() -> Html<String> {
-    let content = r#"<h1>Logged out</h1>
+pub async fn logged_out_page(State(state): State<WebState>) -> Html<String> {
+    let login_path = if state.config.github_client_id.is_some() {
+        "/auth/github/start?next=/"
+    } else {
+        "/auth/pat?next=/"
+    };
+    let content = format!(
+        r#"<h1>Logged out</h1>
 <div class="sub">Session cleared.</div>
-<p><a href="/auth/github/start?next=/">Log in again</a></p>"#;
-    let nav = "";
-    Html(page_shell("Logged out -- DD Fleet", nav, content))
+<p><a href="{login_path}">Log in again</a></p>"#
+    );
+    Html(page_shell("Logged out -- DD Fleet", "", &content))
 }

--- a/crates/dd-web/src/config.rs
+++ b/crates/dd-web/src/config.rs
@@ -3,9 +3,13 @@ use dd_common::tunnel::CfConfig;
 /// Configuration for the dd-web fleet dashboard.
 pub struct Config {
     pub cf: CfConfig,
-    pub github_client_id: String,
-    pub github_client_secret: String,
-    pub github_callback_url: String,
+    /// GitHub OAuth app credentials. Either all three are `Some`
+    /// (production, shared staging) or all three are `None` (ephemeral
+    /// per-PR envs, which use the `/auth/pat` form for browser access
+    /// instead of OAuth). OAuth routes are inactive when None.
+    pub github_client_id: Option<String>,
+    pub github_client_secret: Option<String>,
+    pub github_callback_url: Option<String>,
     pub owner: String,
     pub domain: String,
     pub hostname: String,
@@ -33,18 +37,26 @@ impl Config {
             std::process::exit(1);
         });
 
-        let github_client_id = std::env::var("DD_GITHUB_CLIENT_ID").unwrap_or_else(|_| {
-            eprintln!("dd-web: DD_GITHUB_CLIENT_ID required");
+        // OAuth is optional. Production and shared-staging set all three;
+        // per-PR ephemeral envs leave them unset and rely on the PAT form.
+        // If client_id is set, secret must be set too — half-configured
+        // OAuth is always a mistake.
+        let github_client_id = std::env::var("DD_GITHUB_CLIENT_ID")
+            .ok()
+            .filter(|s| !s.is_empty());
+        let github_client_secret = std::env::var("DD_GITHUB_CLIENT_SECRET")
+            .ok()
+            .filter(|s| !s.is_empty());
+        if github_client_id.is_some() != github_client_secret.is_some() {
+            eprintln!(
+                "dd-web: DD_GITHUB_CLIENT_ID and DD_GITHUB_CLIENT_SECRET must be set together"
+            );
             std::process::exit(1);
+        }
+        let github_callback_url = github_client_id.as_ref().map(|_| {
+            std::env::var("DD_GITHUB_CALLBACK_URL")
+                .unwrap_or_else(|_| format!("https://{hostname}/auth/github/callback"))
         });
-
-        let github_client_secret = std::env::var("DD_GITHUB_CLIENT_SECRET").unwrap_or_else(|_| {
-            eprintln!("dd-web: DD_GITHUB_CLIENT_SECRET required");
-            std::process::exit(1);
-        });
-
-        let github_callback_url = std::env::var("DD_GITHUB_CALLBACK_URL")
-            .unwrap_or_else(|_| format!("https://{hostname}/auth/github/callback"));
 
         // DD_OWNER is required. Previously defaulted to empty, and
         // resolve_auth short-circuited to Ok(None) on an empty owner,

--- a/crates/dd-web/src/router.rs
+++ b/crates/dd-web/src/router.rs
@@ -30,6 +30,10 @@ pub fn build_router(state: WebState) -> Router {
         .route("/federate", get(federate::federate))
         .route("/auth/github/start", get(auth::github_start))
         .route("/auth/github/callback", get(auth::github_callback))
+        .route(
+            "/auth/pat",
+            get(auth::pat_login_page).post(auth::pat_submit),
+        )
         .route("/auth/logout", get(auth::logout))
         .route("/logged-out", get(auth::logged_out_page))
         .with_state(state)

--- a/scripts/gcp-deploy.sh
+++ b/scripts/gcp-deploy.sh
@@ -14,22 +14,28 @@
 # Required env vars (set by the workflow):
 #   GCP_PROJECT_ID          — GCP project where the VM lives
 #   GCP_ZONE                — GCP zone (e.g. us-central1-c)
-#   DD_ENV                  — staging or production
+#   DD_ENV                  — staging, production, or pr-{num} (ephemeral per-PR)
 #   DD_DOMAIN               — Public domain (e.g. devopsdefender.com)
 #   CLOUDFLARE_API_TOKEN    — CF API token (dd-register uses it)
 #   CLOUDFLARE_ACCOUNT_ID   — CF account ID
 #   CLOUDFLARE_ZONE_ID      — CF zone ID
-#   DD_GITHUB_CLIENT_ID     — GitHub OAuth client ID (dd-web uses it)
-#   DD_GITHUB_CLIENT_SECRET — GitHub OAuth client secret
 #
 # Optional env vars:
+#   DD_HOSTNAME             — public hostname override. If unset, derived
+#                             from DD_ENV (production → app.$DOMAIN,
+#                             anything else → app-staging.$DOMAIN). Set
+#                             explicitly for per-PR envs (pr-42.$DOMAIN).
+#   DD_GITHUB_CLIENT_ID     — GitHub OAuth client ID. If unset, dd-web
+#                             disables OAuth login and only PAT auth works.
+#                             Per-PR envs leave this unset.
+#   DD_GITHUB_CLIENT_SECRET — GitHub OAuth client secret (paired with above)
+#   DD_GITHUB_CALLBACK_URL  — OAuth callback, default https://{hostname}/auth/github/callback
 #   EE_IMAGE_FAMILY         — easyenclave GCP image family
 #   EE_IMAGE_PROJECT        — project hosting the image
 #   DD_RELEASE_TAG          — GitHub release tag on devopsdefender/dd
 #                             (defaults to 'latest'; PRs override with pr-{sha12})
 #   VM_MACHINE_TYPE         — default c3-standard-4
 #   VM_DISK_SIZE            — default 10GB
-#   DD_GITHUB_CALLBACK_URL  — default https://{hostname}/auth/github/callback
 
 set -euo pipefail
 
@@ -44,11 +50,15 @@ VM_NAME="dd-${DD_ENV}-$(date +%s)"
 VM_MACHINE_TYPE="${VM_MACHINE_TYPE:-c3-standard-4}"
 VM_DISK_SIZE="${VM_DISK_SIZE:-10GB}"
 
-if [ "${DD_ENV}" = "production" ]; then
-  DD_HOSTNAME="app.${DD_DOMAIN}"
-else
-  DD_HOSTNAME="app-staging.${DD_DOMAIN}"
+if [ -z "${DD_HOSTNAME:-}" ]; then
+  if [ "${DD_ENV}" = "production" ]; then
+    DD_HOSTNAME="app.${DD_DOMAIN}"
+  else
+    DD_HOSTNAME="app-staging.${DD_DOMAIN}"
+  fi
 fi
+DD_GITHUB_CLIENT_ID="${DD_GITHUB_CLIENT_ID:-}"
+DD_GITHUB_CLIENT_SECRET="${DD_GITHUB_CLIENT_SECRET:-}"
 DD_GITHUB_CALLBACK_URL="${DD_GITHUB_CALLBACK_URL:-https://${DD_HOSTNAME}/auth/github/callback}"
 
 # ── Build the workload spec ──────────────────────────────────────────────
@@ -88,22 +98,26 @@ EE_BOOT_WORKLOADS=$(jq -c -n \
       },
       "cmd": ["devopsdefender"],
       "app_name": "dd-management",
-      "env": [
-        "DD_MODE=management",
-        ("DD_CF_API_TOKEN="   + $cf_token),
-        ("DD_CF_ACCOUNT_ID="  + $cf_account),
-        ("DD_CF_ZONE_ID="     + $cf_zone),
-        ("DD_CF_DOMAIN="      + $domain),
-        ("DD_HOSTNAME="       + $hostname),
-        ("DD_ENV="            + $env),
-        "DD_OWNER=devopsdefender",
-        ("DD_GITHUB_CLIENT_ID="     + $gh_client_id),
-        ("DD_GITHUB_CLIENT_SECRET=" + $gh_client_secret),
-        ("DD_GITHUB_CALLBACK_URL="  + $gh_callback),
-        "DD_REGISTER_PORT=8081",
-        "DD_OIDC_AUDIENCE=dd-web",
-        "DD_PORT=8080"
-      ]
+      "env": (
+        [
+          "DD_MODE=management",
+          ("DD_CF_API_TOKEN="   + $cf_token),
+          ("DD_CF_ACCOUNT_ID="  + $cf_account),
+          ("DD_CF_ZONE_ID="     + $cf_zone),
+          ("DD_CF_DOMAIN="      + $domain),
+          ("DD_HOSTNAME="       + $hostname),
+          ("DD_ENV="            + $env),
+          "DD_OWNER=devopsdefender",
+          "DD_REGISTER_PORT=8081",
+          "DD_OIDC_AUDIENCE=dd-web",
+          "DD_PORT=8080"
+        ]
+        + (if $gh_client_id == "" then [] else [
+          ("DD_GITHUB_CLIENT_ID="     + $gh_client_id),
+          ("DD_GITHUB_CLIENT_SECRET=" + $gh_client_secret),
+          ("DD_GITHUB_CALLBACK_URL="  + $gh_callback)
+        ] end)
+      )
     }
   ]')
 


### PR DESCRIPTION
## Summary

- Each PR deploys its own control-plane to `pr-{N}.devopsdefender.com`, isolated by hostname and `DD_ENV=pr-{N}` (no more single shared `app-staging`)
- Browser login: `/auth/pat` form accepts a GitHub PAT (`gh auth token`), validated against `DD_OWNER` via `api.github.com/user`. Reuses the existing session-cookie machinery.
- OAuth (`DD_GITHUB_CLIENT_ID`) is now optional in `dd-web`. When unset, `/auth/github/*` returns 404 and browsers are redirected to `/auth/pat` instead.
- `release.yml`'s `deploy-staging` job is renamed to `deploy-preview`, computes `DD_ENV` + `DD_HOSTNAME` from `github.event_name` and `github.event.number`, and posts a comment on the PR with the preview URL.
- New `pr-teardown.yml` on `pull_request: closed` deletes the VM, CF tunnel(s), and DNS CNAME.
- `cleanup.yml` gains a `reap-pr-previews` job for TERMINATED `dd-pr-*` VMs that accumulate between pushes.

Machine auth is unchanged: `/cp/attest` still takes GitHub Actions OIDC, `/register` still takes Noise XX.

## What this PR does NOT do

- Retire the shared `app-staging` env (workflow_dispatch still targets it)
- Local-agent install script (lives on the closed `feat/installer` branch)
- GPU passthrough for a local agent

Those are follow-ups once the per-PR flow is proven.

## Test plan

This PR exercises itself — on open, CI will:

- [ ] Build + publish pre-release `pr-{sha12}`
- [ ] Deploy a VM to `pr-{this-PR}.devopsdefender.com`
- [ ] `/health` returns 200 via the new CF tunnel
- [ ] `/cp/attest` returns a non-zero MRTD (OIDC-gated)
- [ ] STONITH leaves exactly one `dd_env=pr-{this-PR}` VM RUNNING
- [ ] Bot comments preview URL on this PR
- [ ] `curl -H "Authorization: Bearer \$(gh auth token)" https://pr-{N}.devopsdefender.com/` returns 200
- [ ] Browser hit to `/` redirects to `/auth/pat`; form accepts PAT, sets cookie, redirects to dashboard
- [ ] On close, `pr-teardown.yml` deletes VM + tunnel + DNS

🤖 Generated with [Claude Code](https://claude.com/claude-code)