### PR TITLE
chore: retire shared app-staging env

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,13 @@
 name: Release
 
 # Build the static musl binary, publish it as a GitHub release asset,
-# and (on PRs) deploy it to staging. Replaces the Docker build+push
-# pipeline — easyenclave fetches the asset directly via its
-# github_release workload source.
+# and (on PRs) deploy it to an ephemeral per-PR preview. Replaces the
+# Docker build+push pipeline — easyenclave fetches the asset directly
+# via its github_release workload source.
 #
-# PR:             pre-release tagged pr-{sha12}, then full staging deploy.
+# PR:             pre-release tagged pr-{sha12}, then full PR-preview deploy.
 # push to main:   rolling `latest` release (no deploy — that's production)
 # push v* tag:    versioned release (no deploy)
-# workflow_dispatch: manual trigger, defaults to latest
 
 on:
   push:
@@ -27,12 +26,6 @@ on:
       - "Cargo.lock"
       - "scripts/gcp-deploy.sh"
       - ".github/workflows/release.yml"
-  workflow_dispatch:
-    inputs:
-      release_tag:
-        description: 'Existing release tag to (re)deploy to staging'
-        required: false
-        default: 'latest'
 
 concurrency:
   group: dd-release-${{ github.ref }}
@@ -111,13 +104,12 @@ jobs:
             | tail -n +12 \
             | xargs -rI{} gh release delete {} --yes --cleanup-tag
 
-  # Deploy the freshly-built binary to a preview env. PRs get their own
-  # ephemeral env at pr-{N}.{domain} with DD_ENV=pr-{N} (hostname-isolated,
-  # no OAuth — browser access via /auth/pat). Manual dispatches redeploy
-  # the shared staging env. main/v* produce releases that
-  # production-deploy picks up separately.
+  # Deploy the freshly-built binary to the PR's ephemeral preview.
+  # Each PR gets its own env at pr-{N}.{domain} with DD_ENV=pr-{N}
+  # (hostname-isolated, no OAuth — browser access via /auth/pat).
+  # main/v* produce releases that production-deploy picks up separately.
   deploy-preview:
-    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'pull_request'
     needs: build
     runs-on: ubuntu-latest
     environment: staging
@@ -126,11 +118,8 @@ jobs:
       id-token: write
       pull-requests: write
     env:
-      DD_ENV: ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || 'staging' }}
-      # `env.DD_DOMAIN` can't be read at job-env evaluation time — only
-      # `vars`, `secrets`, `inputs`, `github`, `runner`, `needs`, `matrix`
-      # are available. Inline the default instead of referencing env.
-      DD_HOSTNAME: ${{ github.event_name == 'pull_request' && format('pr-{0}.{1}', github.event.number, vars.DD_CF_DOMAIN || 'devopsdefender.com') || format('app-staging.{0}', vars.DD_CF_DOMAIN || 'devopsdefender.com') }}
+      DD_ENV: pr-${{ github.event.number }}
+      DD_HOSTNAME: pr-${{ github.event.number }}.${{ vars.DD_CF_DOMAIN || 'devopsdefender.com' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -146,13 +135,11 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.DD_CP_CF_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.DD_CP_CF_ACCOUNT_ID }}
           CLOUDFLARE_ZONE_ID: ${{ secrets.DD_CP_CF_ZONE_ID }}
-          # OAuth is only wired for the shared staging env. PR previews
-          # leave these unset; dd-web disables /auth/github/* and serves
-          # /auth/pat for browser access instead.
-          DD_GITHUB_CLIENT_ID: ${{ github.event_name == 'workflow_dispatch' && (vars.DD_GITHUB_CLIENT_ID || secrets.DD_GITHUB_CLIENT_ID) || '' }}
-          DD_GITHUB_CALLBACK_URL: ${{ github.event_name == 'workflow_dispatch' && vars.DD_GITHUB_CALLBACK_URL || '' }}
-          DD_GITHUB_CLIENT_SECRET: ${{ github.event_name == 'workflow_dispatch' && secrets.DD_GITHUB_CLIENT_SECRET || '' }}
-          DD_RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || needs.build.outputs.tag }}
+          # OAuth env vars intentionally omitted — gcp-deploy.sh sees
+          # empty DD_GITHUB_CLIENT_ID and skips them in the workload
+          # spec. dd-web then disables /auth/github/* and serves
+          # /auth/pat for browser access.
+          DD_RELEASE_TAG: ${{ needs.build.outputs.tag }}
         run: scripts/gcp-deploy.sh
 
       - name: Wait for agent health (streams serial console)
@@ -271,9 +258,9 @@ jobs:
         run: |
           # STONITH (dd-register deletes the old tunnel → old cloudflared
           # exits → old dd-register poweroffs the VM) is the ONLY cleanup
-          # mechanism. Scoped to this env (staging or pr-N) — PR previews
-          # are hostname-isolated from each other, so this only reaps
-          # prior deploys of the same PR (re-pushes) or the shared staging.
+          # mechanism. Scoped to this PR's env — previews are
+          # hostname-isolated from each other, so this only reaps prior
+          # deploys of the same PR (re-pushes).
           NEW_VM=$(gcloud compute instances list \
             --project="$GCP_PROJECT_ID" \
             --filter="labels.devopsdefender=managed AND labels.dd_env=${DD_ENV}" \
@@ -299,7 +286,6 @@ jobs:
           exit 1
 
       - name: Comment preview URL on PR
-        if: github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/retire-staging.yml
+++ b/.github/workflows/retire-staging.yml
@@ -1,0 +1,98 @@
+name: Retire Staging
+
+# One-shot cleanup of the shared `app-staging.{domain}` env.
+# Per-PR preview envs (deploy-preview in release.yml) fully replace
+# the old shared staging, so this workflow reaps whatever's left:
+#   - any `dd_env=staging` VMs (RUNNING or TERMINATED)
+#   - any CF tunnels named `dd-staging-*`
+#   - the CF CNAME for `app-staging.{domain}`
+#
+# Idempotent — skips silently if nothing to delete. Run manually once
+# via the Actions UI, then this workflow can be deleted.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  DD_DOMAIN: ${{ vars.DD_CF_DOMAIN || 'devopsdefender.com' }}
+  GCP_ZONE: us-central1-c
+
+jobs:
+  retire:
+    runs-on: ubuntu-latest
+    environment: staging
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: 'projects/654815109728/locations/global/workloadIdentityPools/github-actions-pool/providers/github-provider'
+          service_account: 'easyenclave-staging-ci@eestaging.iam.gserviceaccount.com'
+      - uses: google-github-actions/setup-gcloud@v2
+
+      - name: Delete staging VMs
+        env:
+          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+        run: |
+          VMS=$(gcloud compute instances list \
+            --project="$GCP_PROJECT_ID" \
+            --filter="labels.devopsdefender=managed AND labels.dd_env=staging" \
+            --format="value(name)")
+          if [ -z "$VMS" ]; then
+            echo "No dd-staging VMs to delete."
+          else
+            echo "Deleting: $(echo "$VMS" | tr '\n' ' ')"
+            # shellcheck disable=SC2086
+            gcloud compute instances delete $VMS \
+              --project="$GCP_PROJECT_ID" --zone="$GCP_ZONE" --quiet
+          fi
+
+      - name: Delete CF tunnels with dd-staging- prefix
+        env:
+          CF_API_TOKEN: ${{ secrets.DD_CP_CF_API_TOKEN }}
+          CF_ACCOUNT_ID: ${{ secrets.DD_CP_CF_ACCOUNT_ID }}
+        run: |
+          resp=$(curl -fsS \
+            -H "Authorization: Bearer ${CF_API_TOKEN}" \
+            "https://api.cloudflare.com/client/v4/accounts/${CF_ACCOUNT_ID}/cfd_tunnel?is_deleted=false&per_page=200")
+          ids=$(echo "$resp" | jq -r \
+            '.result[] | select(.name | startswith("dd-staging-")) | .id')
+          if [ -z "$ids" ]; then
+            echo "No CF tunnels with prefix dd-staging-"
+          else
+            for id in $ids; do
+              echo "Deleting tunnel $id"
+              curl -fsS -X DELETE \
+                -H "Authorization: Bearer ${CF_API_TOKEN}" \
+                "https://api.cloudflare.com/client/v4/accounts/${CF_ACCOUNT_ID}/cfd_tunnel/${id}/connections" \
+                >/dev/null || true
+              curl -fsS -X DELETE \
+                -H "Authorization: Bearer ${CF_API_TOKEN}" \
+                "https://api.cloudflare.com/client/v4/accounts/${CF_ACCOUNT_ID}/cfd_tunnel/${id}" \
+                >/dev/null || echo "::warning::tunnel $id delete failed"
+            done
+          fi
+
+      - name: Delete CNAME for app-staging
+        env:
+          CF_API_TOKEN: ${{ secrets.DD_CP_CF_API_TOKEN }}
+          CF_ZONE_ID: ${{ secrets.DD_CP_CF_ZONE_ID }}
+        run: |
+          host="app-staging.${DD_DOMAIN}"
+          record_id=$(curl -fsS \
+            -H "Authorization: Bearer ${CF_API_TOKEN}" \
+            "https://api.cloudflare.com/client/v4/zones/${CF_ZONE_ID}/dns_records?type=CNAME&name=${host}" \
+            | jq -r '.result[0].id // empty')
+          if [ -z "$record_id" ]; then
+            echo "No CNAME for ${host}"
+          else
+            echo "Deleting CNAME record $record_id (${host})"
+            curl -fsS -X DELETE \
+              -H "Authorization: Bearer ${CF_API_TOKEN}" \
+              "https://api.cloudflare.com/client/v4/zones/${CF_ZONE_ID}/dns_records/${record_id}" \
+              >/dev/null
+          fi

--- a/README.md
+++ b/README.md
@@ -44,17 +44,20 @@ Per-VM configuration (CF credentials, GitHub OAuth, the workload spec itself) is
 ## CI/CD
 
 ```
-PR              → pre-release tagged pr-{sha12}, then full staging deploy
+PR              → pre-release tagged pr-{sha12}, then ephemeral preview at pr-{N}.{domain}
+branch deleted  → pr-teardown.yml deletes the preview's VM, CF tunnel, and DNS
 push to main    → rolling `latest` release, then auto-deploy to production
 push v* tag     → versioned release (no auto-deploy)
 manual          → production-deploy.yml promotes any existing tag
 ```
 
-`.github/workflows/release.yml` builds the static musl binary, publishes it as a GitHub release asset, and on PRs deploys it to staging. The staging VM is verified via:
+Each PR gets its own isolated env at `pr-{N}.{domain}` with `DD_ENV=pr-{N}` — no more shared staging tier. `.github/workflows/release.yml` builds the static musl binary, publishes it as a GitHub release asset, deploys the PR's preview VM, and posts the URL back to the PR. The preview VM is verified via:
 
 1. `/health` via the Cloudflare tunnel
 2. `/cp/attest` returning a real TDX MRTD (cryptographic proof the freshly-deployed VM is running — old VMs don't have the endpoint and return 404)
-3. No other `dd-staging` VM is RUNNING after deploy (STONITH must have halted the previous instance)
+3. No other `dd-pr-{N}-*` VM is RUNNING after deploy (STONITH must have halted the previous instance of this PR)
+
+Browser access to a PR preview goes through `/auth/pat` (paste a GitHub PAT, validated against `DD_OWNER`). OAuth is only wired for production, which `production-deploy.yml` still targets at `app.{domain}`.
 
 ## STONITH
 


### PR DESCRIPTION
## Summary

Per-PR previews (from #95) fully replace the shared staging tier. This PR retires `app-staging.devopsdefender.com`:

- **New `retire-staging.yml`** — one-shot `workflow_dispatch` that deletes any lingering `dd_env=staging` VMs, CF tunnels prefixed `dd-staging-`, and the `app-staging.{domain}` DNS CNAME. Idempotent.
- **`release.yml`** — drops the `workflow_dispatch` trigger (it existed only to redeploy a tag to shared staging) and simplifies `deploy-preview` now that PR is the only codepath (no more env/OAuth ternaries).
- **`README.md`** — CI/CD section rewritten to describe per-PR previews; STONITH verification note updated.

## Rollout

After merge:

1. Run `retire-staging.yml` manually once via the Actions UI
2. Verify no `dd_env=staging` VMs, `dd-staging-*` tunnels, or `app-staging.{domain}` DNS records remain
3. Delete `retire-staging.yml` in a follow-up PR once rollout is confirmed

## Test plan

- [x] YAML parses for both `release.yml` and `retire-staging.yml`
- [x] `deploy-preview` only triggers on `pull_request` after this change
- [ ] On open, this PR deploys its own preview at `pr-{N}.devopsdefender.com` (sanity-check the simplified job)
- [ ] After merge, operator runs `retire-staging.yml` and confirms cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)