### PR TITLE
feat(ci): auto-deploy to production after Release succeeds on main

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -1,11 +1,18 @@
 name: Production Deploy
 
-# Manual production promotion. A push to main publishes a `latest`
-# release via release.yml but does NOT auto-deploy — an operator runs
-# this workflow when they're ready to promote the staging-verified
-# build to production.
+# Two triggers:
+#   - workflow_run: fires automatically after a successful Release run
+#     on main. Release publishes the `latest` tag, then this workflow
+#     deploys it to production. Sequential by design — if Release fails,
+#     we don't promote.
+#   - workflow_dispatch: manual re-deploy of any existing tag (e.g. a
+#     known-good v0.2.0 after a bad main push).
 
 on:
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
+    branches: [main]
   workflow_dispatch:
     inputs:
       release_tag:
@@ -29,6 +36,9 @@ jobs:
   # dd-register STONITHs the old VM on startup by deleting its CF
   # tunnel, so no explicit teardown here.
   deploy:
+    # workflow_run fires on every Release completion, including
+    # failures. Only promote on success.
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     environment: production
     permissions:
@@ -51,7 +61,9 @@ jobs:
           DD_GITHUB_CLIENT_ID: ${{ vars.DD_GITHUB_CLIENT_ID || secrets.DD_GITHUB_CLIENT_ID }}
           DD_GITHUB_CALLBACK_URL: ${{ vars.DD_GITHUB_CALLBACK_URL }}
           DD_GITHUB_CLIENT_SECRET: ${{ secrets.DD_GITHUB_CLIENT_SECRET }}
-          DD_RELEASE_TAG: ${{ inputs.release_tag }}
+          # workflow_run has no `inputs`; fall back to `latest`, which
+          # release.yml just (re)published on push to main.
+          DD_RELEASE_TAG: ${{ inputs.release_tag || 'latest' }}
         run: scripts/gcp-deploy.sh
 
       - name: Wait for agent health

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Per-VM configuration (CF credentials, GitHub OAuth, the workload spec itself) is
 
 ```
 PR              → pre-release tagged pr-{sha12}, then full staging deploy
-push to main    → rolling `latest` release (no auto-deploy)
+push to main    → rolling `latest` release, then auto-deploy to production
 push v* tag     → versioned release (no auto-deploy)
 manual          → production-deploy.yml promotes any existing tag
 ```


### PR DESCRIPTION
## Summary

Push-to-main now auto-deploys to production after a successful Release run. Previously only `latest` was published and an operator had to dispatch `production-deploy.yml` by hand.

- `workflow_run` trigger on `Release` completion, `branches: [main]`
- Deploy job gated by `github.event.workflow_run.conclusion == 'success'` — failed builds never promote
- `workflow_dispatch` still works for re-deploying a specific tag (`v0.2.0` rollback, etc.)
- `DD_RELEASE_TAG` falls back to `latest` when no input is provided

## Rollout note

Once merged, the next push to main will:
1. `Release` builds + publishes `latest`
2. `Production Deploy` fires automatically, pulls `latest`, STONITHs the old prod VM, brings up the new one at `app.devopsdefender.com`

## Test plan

- [x] YAML parses
- [ ] Next merge to main triggers Release → Production Deploy sequentially
- [ ] Failing a push (e.g. broken test) does NOT promote to production
- [ ] `workflow_dispatch` path still works manually with an explicit `release_tag`

🤖 Generated with [Claude Code](https://claude.com/claude-code)