### PR TITLE
fix(stonith): watchdog requires 3 consecutive gone-readings before poweroff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -364,6 +364,7 @@ dependencies = [
  "dd-common",
  "futures-util",
  "libc",
+ "rand 0.8.5",
  "reqwest",
  "serde",
  "serde_json",

--- a/crates/dd-register/Cargo.toml
+++ b/crates/dd-register/Cargo.toml
@@ -21,6 +21,7 @@ futures-util = "0.3"
 # `poweroff` proved unreliable (busybox tries to signal a systemd-style
 # PID 1, which easyenclave isn't, then no-ops).
 libc = "0.2"
+rand = "0.8"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/dd-register/src/lib.rs
+++ b/crates/dd-register/src/lib.rs
@@ -112,29 +112,72 @@ pub async fn prepare() -> Router {
     // Self-STONITH watchdog. cloudflared is known to retry indefinitely
     // when its tunnel is deleted remotely instead of exiting, which
     // breaks the cloudflared-child-exit → poweroff path above. Poll
-    // CF API every 30s; when we confirm our own tunnel is gone,
+    // CF API every 10s; when we confirm our own tunnel is gone,
     // poweroff directly — no dependency on cloudflared's behaviour.
+    //
+    // Require N consecutive "gone" readings before acting. `tunnel_exists`
+    // returns false on ANY error (network flake, CF 5xx, auth hiccup),
+    // not just on "tunnel deleted", so a single reading would let one
+    // CF API blip kill a healthy VM. We saw this happen on 2026-04-16
+    // around 21:01 UTC: prod VM self-STONITHed 7 minutes after a clean
+    // deploy when CF transiently failed the check during high API load
+    // (agent registration burst). Three consecutive failures at 10s
+    // apart = 30s of real outage before we act — still well under
+    // release.yml's STONITH verify budget.
+    // Poll cadence is jittered so many fleet VMs don't all hit the CF
+    // API at the same wall-clock ticks (which would make transient
+    // rate-limit / 5xx events correlate across the fleet). Full-jitter
+    // backoff on the initial sleep spreads startup-aligned VMs; small
+    // per-cycle jitter keeps them desynced.
+    const WATCHDOG_POLL_BASE_SECS: u64 = 10;
+    const WATCHDOG_POLL_JITTER_SECS: u64 = 4; // effective range 8-12s
+    const WATCHDOG_INITIAL_MIN_SECS: u64 = 10; // never check before CF propagation
+    const WATCHDOG_INITIAL_MAX_SECS: u64 = 25; // spread startup across 15s window
+    const WATCHDOG_REQUIRED_CONSECUTIVE_GONE: u32 = 3;
     let wd_cf = cf.clone();
     let wd_tunnel_id = tunnel_info.tunnel_id.clone();
     tokio::spawn(async move {
+        use rand::Rng;
         let http = reqwest::Client::builder()
             .timeout(std::time::Duration::from_secs(10))
             .build()
             .unwrap_or_else(|_| reqwest::Client::new());
-        // Give the freshly-created tunnel a moment to propagate in CF's
-        // eventual-consistency layer before the first check.
-        tokio::time::sleep(std::time::Duration::from_secs(15)).await;
-        // 10s poll. CF API call is sub-second; cost is negligible.
-        // Worst-case detection after a STONITH delete: 10s (next poll
-        // tick) + reboot syscall + GCP state transition. Keeps the
-        // verify-step window in release.yml tight.
+        // Randomised initial delay spreads fleet startups; the rest of
+        // the CF propagation window is covered by tolerating the first
+        // few checks via the consecutive-gone threshold.
+        let initial_delay = {
+            let mut rng = rand::thread_rng();
+            rng.gen_range(WATCHDOG_INITIAL_MIN_SECS..=WATCHDOG_INITIAL_MAX_SECS)
+        };
+        tokio::time::sleep(std::time::Duration::from_secs(initial_delay)).await;
+        let mut consecutive_gone: u32 = 0;
         loop {
-            if !tunnel::tunnel_exists(&http, &wd_cf, &wd_tunnel_id).await {
-                eprintln!("dd-register: own tunnel {wd_tunnel_id} gone — self-STONITH poweroff");
-                kernel_poweroff();
-                return;
+            if tunnel::tunnel_exists(&http, &wd_cf, &wd_tunnel_id).await {
+                if consecutive_gone > 0 {
+                    eprintln!(
+                        "dd-register: watchdog recovered — tunnel {wd_tunnel_id} reappeared after {consecutive_gone} missed check(s)"
+                    );
+                }
+                consecutive_gone = 0;
+            } else {
+                consecutive_gone += 1;
+                eprintln!(
+                    "dd-register: watchdog: tunnel {wd_tunnel_id} check failed ({consecutive_gone}/{WATCHDOG_REQUIRED_CONSECUTIVE_GONE})"
+                );
+                if consecutive_gone >= WATCHDOG_REQUIRED_CONSECUTIVE_GONE {
+                    eprintln!(
+                        "dd-register: own tunnel {wd_tunnel_id} gone (confirmed by {consecutive_gone} consecutive checks) — self-STONITH poweroff"
+                    );
+                    kernel_poweroff();
+                    return;
+                }
             }
-            tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+            let sleep_secs = {
+                let mut rng = rand::thread_rng();
+                let jitter = rng.gen_range(0..=WATCHDOG_POLL_JITTER_SECS);
+                WATCHDOG_POLL_BASE_SECS + jitter - WATCHDOG_POLL_JITTER_SECS / 2
+            };
+            tokio::time::sleep(std::time::Duration::from_secs(sleep_secs)).await;
         }
     });
 


### PR DESCRIPTION
## Summary

`dd-register`'s self-STONITH watchdog polls `tunnel_exists()` every 10 s and calls `kernel_poweroff()` when the tunnel is gone. Problem: `tunnel_exists()` returns `false` on **any** error, including a transient CF 5xx or network flake — so one API blip killed a healthy VM.

## The incident

Production VM \`dd-production-1776372866\` started at 20:54:42 UTC (the auto-deploy triggered by #99's merge), served traffic cleanly, and self-STONITHed at 21:01:42 UTC — 7 minutes later. Cloudflare was under higher API load at that moment (our new local TDX+GPU agent was registering + tunnel creation). The watchdog's single missed check flipped the VM off.

## Fix

Require **3 consecutive** "gone" readings at 10 s apart = 30 s of real outage before the watchdog trusts the signal. Reset the counter on any successful check. Well within \`release.yml\`'s STONITH verify budget (120 s).

Log lines:
- Each missed check: \`watchdog: tunnel {id} check failed (N/3)\`
- Recovery: \`watchdog recovered — tunnel {id} reappeared after N missed check(s)\`
- Kill: \`own tunnel {id} gone (confirmed by 3 consecutive checks) — self-STONITH poweroff\`

## Knock-on effect

Once this merges and main auto-deploys to production, the prod CP comes back up at \`app.devopsdefender.com\` with the hardened watchdog. Without this, the same class of transient failure could take prod down again at any time.

## Test plan

- [x] cargo fmt, clippy, build all pass
- [ ] deploy-preview shows the hardened log lines under steady-state polling
- [ ] post-merge production-deploy brings \`app.devopsdefender.com\` back up
- [ ] prod survives the next CF API hiccup (observation-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)