### PR TITLE
fix(ci): add STONITH verify step to production-deploy

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -109,3 +109,41 @@ jobs:
           done
           echo "::error::dashboard / never returned 200 (last HTTP ${code})"
           exit 1
+
+      - name: Verify STONITH halted prior production VM(s)
+        env:
+          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+          GCP_ZONE: ${{ env.GCP_ZONE }}
+        run: |
+          # Mirror of release.yml's verify-step for PR previews. Give
+          # STONITH-by-tunnel-delete 120s to work on well-behaved old
+          # prod VMs (their cloudflared exits → dd-register poweroffs
+          # → GCP TERMINATED → cleanup.yml reaps). After the timeout,
+          # force-delete any remaining RUNNING prod VMs so we don't
+          # leak compute indefinitely.
+          NEW_VM=$(gcloud compute instances list \
+            --project="$GCP_PROJECT_ID" \
+            --filter="labels.devopsdefender=managed AND labels.dd_env=production" \
+            --format="value(name)" --sort-by=~creationTimestamp | head -1)
+          echo "new VM: $NEW_VM"
+          SURVIVORS=""
+          for i in $(seq 1 24); do
+            SURVIVORS=$(gcloud compute instances list \
+              --project="$GCP_PROJECT_ID" \
+              --filter="labels.devopsdefender=managed AND labels.dd_env=production AND status=RUNNING" \
+              --format="value(name)" \
+              | grep -vx "$NEW_VM" || true)
+            if [ -z "$SURVIVORS" ]; then
+              echo "STONITH verified — only $NEW_VM running in prod"
+              exit 0
+            fi
+            echo "  still running besides $NEW_VM: $(echo "$SURVIVORS" | tr '\n' ' ')"
+            echo "  waiting for STONITH poweroff... (${i}/24)"
+            sleep 5
+          done
+          echo "::warning::STONITH-by-tunnel-delete timed out in prod; force-deleting:"
+          echo "$SURVIVORS"
+          # shellcheck disable=SC2086
+          gcloud compute instances delete $SURVIVORS \
+            --project="$GCP_PROJECT_ID" --zone="$GCP_ZONE" --quiet || true
+          echo "zombies reaped; $NEW_VM is the only production VM"


### PR DESCRIPTION
## Summary

\`release.yml\` verifies that STONITH actually halted the old PR-preview VM after every deploy; \`production-deploy.yml\` didn't have the matching check, so a zombie prod VM (one that refuses to self-poweroff) would just stick around consuming compute with no loud signal.

After #101 the self-watchdog is more conservative about calling \`kernel_poweroff\` (requires 3 consecutive failed checks), so a genuinely stuck old VM is slightly more likely to survive than before. Prod now needs the same safety net \`release.yml\` uses.

## What the new step does

Mirrors \`release.yml\` lines 254-300 scoped to \`dd_env=production\`:

1. After \`/health\` and dashboard-render verification pass, identify the newly-created VM by \`creationTimestamp DESC\`.
2. Poll every 5s for up to 120s looking for any other RUNNING VM under the same env label.
3. If one is still running after 120s, \`gcloud compute instances delete\` it (with \`|| true\` so we don't fail the deploy on a flaky delete).

## Test plan

- [x] YAML parses
- [ ] Next push-to-main triggers Production Deploy → new verify step runs → passes cleanly when STONITH works
- [ ] (Manual) Leave a stale prod VM RUNNING before a deploy; confirm the step force-deletes it and the deploy still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)