### PR TITLE
fix(dd-web): collector + bootstrap skip CP's own tunnel via real ingress

### DIFF
--- a/crates/dd-web/src/collector.rs
+++ b/crates/dd-web/src/collector.rs
@@ -33,8 +33,14 @@ pub async fn run_collector(state: WebState) {
     loop {
         ticker.tick().await;
 
-        // List CF tunnels
-        let tunnels = list_agent_tunnels(&http, &state.config.cf, &tunnel_prefix).await;
+        // List CF tunnels (excludes this CP's own tunnel via ingress-hostname match)
+        let tunnels = list_agent_tunnels(
+            &http,
+            &state.config.cf,
+            &tunnel_prefix,
+            &state.config.hostname,
+        )
+        .await;
         eprintln!(
             "dd-web: collector found {} tunnels matching {tunnel_prefix}*",
             tunnels.len()
@@ -266,6 +272,7 @@ async fn list_agent_tunnels(
     client: &reqwest::Client,
     cf: &tunnel::CfConfig,
     prefix: &str,
+    cp_hostname: &str,
 ) -> Vec<(String, String)> {
     let url = format!(
         "https://api.cloudflare.com/client/v4/accounts/{}/cfd_tunnel?is_deleted=false",
@@ -289,15 +296,44 @@ async fn list_agent_tunnels(
     let body: serde_json::Value = resp.json().await.unwrap_or_default();
     let mut tunnels = Vec::new();
 
-    if let Some(results) = body["result"].as_array() {
-        for t in results {
-            if let Some(name) = t["name"].as_str() {
-                if name.starts_with(prefix) {
-                    let hostname = format!("{name}.{}", cf.domain);
-                    tunnels.push((name.to_string(), hostname));
-                }
-            }
+    let Some(results) = body["result"].as_array() else {
+        return tunnels;
+    };
+    for t in results {
+        let Some(name) = t["name"].as_str() else {
+            continue;
+        };
+        if !name.starts_with(prefix) {
+            continue;
         }
+        let Some(tunnel_id) = t["id"].as_str() else {
+            continue;
+        };
+
+        // Resolve the tunnel's real ingress hostname instead of synthesising
+        // `{name}.{domain}`. Agent tunnels' names do match their hostnames,
+        // but the CP's own tunnel is named `dd-{env}-{vm-id}` while its real
+        // ingress is `app.{domain}` — synthesising would make the collector
+        // treat itself as an unreachable agent and orphan-delete its own
+        // tunnel (~5 min → self-STONITH). Fail closed on lookup error or
+        // empty ingress so a CF flake can't resurrect that bug.
+        let hostnames = match tunnel::tunnel_ingress_hostnames(client, cf, tunnel_id).await {
+            Ok(h) => h,
+            Err(e) => {
+                eprintln!("dd-web: ingress lookup failed for {name}: {e} — skipping this cycle");
+                continue;
+            }
+        };
+        if hostnames.is_empty() {
+            continue;
+        }
+        if hostnames.iter().any(|h| h == cp_hostname) {
+            continue; // our own tunnel — never scrape or orphan-delete
+        }
+        let Some(hostname) = hostnames.into_iter().next() else {
+            continue;
+        };
+        tunnels.push((name.to_string(), hostname));
     }
 
     tunnels

--- a/crates/dd-web/src/lib.rs
+++ b/crates/dd-web/src/lib.rs
@@ -77,32 +77,62 @@ pub async fn prepare() -> axum::Router {
             let now = chrono::Utc::now();
             let mut count = 0;
             for t in &tunnel_list {
-                if let Some(name) = t["name"].as_str() {
-                    if name.starts_with(&tunnel_prefix) {
-                        let hostname = format!("{name}.{}", web_state.config.cf.domain);
-                        let agent_id = name
-                            .strip_prefix(&tunnel_prefix)
-                            .unwrap_or(name)
-                            .to_string();
-                        store.insert(
-                            agent_id.clone(),
-                            state::AgentSnapshot {
-                                agent_id,
-                                hostname,
-                                vm_name: "unknown".to_string(),
-                                attestation_type: "unknown".to_string(),
-                                status: "stale".to_string(),
-                                last_seen: now,
-                                deployment_count: 0,
-                                deployment_names: Vec::new(),
-                                cpu_percent: 0,
-                                memory_used_mb: 0,
-                                memory_total_mb: 0,
-                            },
-                        );
-                        count += 1;
-                    }
+                let Some(name) = t["name"].as_str() else {
+                    continue;
+                };
+                if !name.starts_with(&tunnel_prefix) {
+                    continue;
                 }
+                let Some(tunnel_id) = t["id"].as_str() else {
+                    continue;
+                };
+                // Use the tunnel's real ingress hostname, not `{name}.{domain}`.
+                // See collector.rs::list_agent_tunnels for the rationale — if
+                // the CP's own tunnel got bootstrapped under a synthesised
+                // hostname, the collector would later orphan-delete it.
+                let hostnames = match tunnel::tunnel_ingress_hostnames(
+                    &http_client,
+                    &web_state.config.cf,
+                    tunnel_id,
+                )
+                .await
+                {
+                    Ok(h) => h,
+                    Err(e) => {
+                        eprintln!("dd-web: bootstrap ingress lookup failed for {name}: {e}");
+                        continue;
+                    }
+                };
+                if hostnames.is_empty() {
+                    continue;
+                }
+                if hostnames.iter().any(|h| h == &web_state.config.hostname) {
+                    continue; // our own tunnel
+                }
+                let Some(hostname) = hostnames.into_iter().next() else {
+                    continue;
+                };
+                let agent_id = name
+                    .strip_prefix(&tunnel_prefix)
+                    .unwrap_or(name)
+                    .to_string();
+                store.insert(
+                    agent_id.clone(),
+                    state::AgentSnapshot {
+                        agent_id,
+                        hostname,
+                        vm_name: "unknown".to_string(),
+                        attestation_type: "unknown".to_string(),
+                        status: "stale".to_string(),
+                        last_seen: now,
+                        deployment_count: 0,
+                        deployment_names: Vec::new(),
+                        cpu_percent: 0,
+                        memory_used_mb: 0,
+                        memory_total_mb: 0,
+                    },
+                );
+                count += 1;
             }
             eprintln!("dd-web: bootstrapped {count} agents from CF tunnels");
         }


### PR DESCRIPTION
## Summary
- Prod has been 530 since ~22:08 UTC: every new prod VM self-STONITH'd ~6-7 min after deploy. Root cause was **not** the dd-register watchdog (PR #101's 3-consecutive-gone fix was in the running build).
- The dd-web collector was deleting the CP's OWN Cloudflare tunnel. `list_agent_tunnels` and the bootstrap loop both synthesised each tunnel's hostname as `{name}.{domain}`. That's right for agent tunnels but wrong for the CP: it's named `dd-{env}-{vm}` but its real ingress is `app.{domain}`. The synth'd hostname had no DNS CNAME, every scrape connect-failed, age > 300 s → orphan push → `delete_tunnel_by_name`. dd-register's watchdog then correctly poweroff'd on tunnel-gone.
- This patch calls the existing `tunnel_ingress_hostnames` helper in both sites, uses the tunnel's *real* ingress hostname, and skips any tunnel whose ingress matches `state.config.hostname` (the CP itself). Fails closed on CF API error or empty ingress so a flake can't resurrect the bug.

## Test plan
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo build --workspace --release` clean
- [ ] CI green
- [ ] After squash-merge, new prod VM stays RUNNING and `/health`→200 past the 15-min mark (previous failures hit at ~6-7 min)
- [ ] Collector log line shows `orphans cleaned=0` when the only tunnel is the CP's own

🤖 Generated with [Claude Code](https://claude.com/claude-code)