### PR TITLE
fix(ita): re-mint tokens periodically

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -10,13 +10,14 @@
 //! with the secret it received at registration.
 
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use axum::extract::{Path, State, WebSocketUpgrade};
 use axum::http::HeaderMap;
 use axum::response::{Html, IntoResponse, Response};
 use axum::routing::get;
 use axum::{Json, Router};
+use tokio::sync::RwLock;
 
 use crate::auth::{self, Keys};
 use crate::config::Agent as Cfg;
@@ -27,6 +28,11 @@ use crate::ita;
 use crate::metrics;
 use crate::terminal;
 
+/// Re-mint interval. Intel ITA tokens typically expire in a few
+/// minutes; refresh well before so `/health` always serves a live
+/// token to the CP's collector.
+const ITA_REFRESH: Duration = Duration::from_secs(180);
+
 #[derive(Clone)]
 struct St {
     cfg: Arc<Cfg>,
@@ -35,9 +41,8 @@ struct St {
     hostname: String,
     cp_hostname: String,
     started: Instant,
-    /// Intel-signed JWT for this VM's TDX measurement, minted at startup.
-    /// Mandatory — the agent fails to start if minting fails.
-    ita_token: String,
+    /// Current Intel-signed JWT. Refreshed by a background task.
+    ita_token: Arc<RwLock<String>>,
 }
 
 pub async fn run() -> Result<()> {
@@ -50,16 +55,40 @@ pub async fn run() -> Result<()> {
         h["attestation_type"].as_str().unwrap_or("?")
     );
 
-    let ita_token = mint_ita(&cfg, &ee).await?;
+    let initial_token = mint_ita(&cfg, &ee).await?;
     eprintln!("agent: ITA token minted");
 
     eprintln!("agent: registering with {}", cfg.cp_url);
-    let b = register(&cfg, &ita_token).await?;
+    let b = register(&cfg, &initial_token).await?;
     eprintln!("agent: registered as {}", b.hostname);
 
     spawn_cloudflared(b.tunnel_token);
 
     let keys = Arc::new(Keys::from_b64(&b.jwt_secret_b64, &b.cp_hostname)?);
+    let ita_token = Arc::new(RwLock::new(initial_token));
+
+    // Background re-mint so /health always serves a non-expired token
+    // for the CP's scrape-and-verify loop.
+    {
+        let cfg = cfg.clone();
+        let ee = ee.clone();
+        let token = ita_token.clone();
+        tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(ITA_REFRESH).await;
+                match mint_ita(&cfg, &ee).await {
+                    Ok(t) => {
+                        *token.write().await = t;
+                        eprintln!("agent: ITA token refreshed");
+                    }
+                    Err(e) => {
+                        eprintln!("agent: ITA refresh failed (keeping stale token): {e}");
+                    }
+                }
+            }
+        });
+    }
+
     let state = St {
         cfg: cfg.clone(),
         ee,
@@ -171,6 +200,7 @@ async fn health(State(s): State<St>) -> Json<serde_json::Value> {
         })
         .unwrap_or_default();
     let m = metrics::collect().await;
+    let ita_token = s.ita_token.read().await.clone();
 
     Json(serde_json::json!({
         "ok": true,
@@ -186,7 +216,7 @@ async fn health(State(s): State<St>) -> Json<serde_json::Value> {
         "memory_used_mb": m.mem_used_mb,
         "memory_total_mb": m.mem_total_mb,
         "uptime_secs": s.started.elapsed().as_secs(),
-        "ita_token": s.ita_token,
+        "ita_token": ita_token,
     }))
 }
 

--- a/src/cp.rs
+++ b/src/cp.rs
@@ -15,7 +15,7 @@ use axum::response::{Html, IntoResponse, Redirect, Response};
 use axum::routing::{get, post};
 use axum::{Form, Json, Router};
 use serde::Deserialize;
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, RwLock};
 
 use crate::auth::{self, Keys};
 use crate::cf;
@@ -28,6 +28,12 @@ use crate::ita;
 use crate::stonith;
 use crate::terminal;
 
+/// Re-mint interval for the CP's own ITA token. The CP isn't scraped
+/// by its own collector (different tunnel prefix), so a background
+/// task is the only thing keeping the `control-plane` entry's claims
+/// fresh on the dashboard.
+const ITA_REFRESH: Duration = Duration::from_secs(180);
+
 #[derive(Clone)]
 struct St {
     cfg: Arc<Cfg>,
@@ -36,8 +42,8 @@ struct St {
     store: Store,
     started: Instant,
     verifier: Arc<ita::Verifier>,
-    /// The CP's own ITA token, minted at startup.
-    cp_ita_token: String,
+    /// The CP's own ITA token. Refreshed by a background task.
+    cp_ita_token: Arc<RwLock<String>>,
 }
 
 pub async fn run() -> Result<()> {
@@ -81,14 +87,14 @@ pub async fn run() -> Result<()> {
 
     // Mint + verify our own ITA token. Any failure is fatal —
     // attestation is mandatory.
-    let cp_ita_token = match mint_cp_ita(&cfg, &ee).await {
+    let initial_token = match mint_cp_ita(&cfg, &ee).await {
         Ok(t) => t,
         Err(e) => {
             eprintln!("cp: ITA mint failed: {e}");
             stonith::poweroff();
         }
     };
-    let cp_claims = match verifier.verify(&cp_ita_token).await {
+    let cp_claims = match verifier.verify(&initial_token).await {
         Ok(c) => c,
         Err(e) => {
             eprintln!("cp: ITA self-verify failed: {e}");
@@ -100,6 +106,7 @@ pub async fn run() -> Result<()> {
         cp_claims.mrtd.as_deref().unwrap_or("?"),
         cp_claims.tcb_status.as_deref().unwrap_or("?")
     );
+    let cp_ita_token = Arc::new(RwLock::new(initial_token));
 
     // Seed the CP into the store before the collector starts ticking.
     store.lock().await.insert(
@@ -119,6 +126,41 @@ pub async fn run() -> Result<()> {
             ita: cp_claims,
         },
     );
+
+    // Background re-mint of the CP's own ITA token. Also re-verifies
+    // and updates the `control-plane` store entry so the fleet card
+    // doesn't show "Expired".
+    {
+        let cfg = cfg.clone();
+        let ee = ee.clone();
+        let verifier = verifier.clone();
+        let token = cp_ita_token.clone();
+        let store = store.clone();
+        tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(ITA_REFRESH).await;
+                let fresh = match mint_cp_ita(&cfg, &ee).await {
+                    Ok(t) => t,
+                    Err(e) => {
+                        eprintln!("cp: own ITA refresh mint failed: {e}");
+                        continue;
+                    }
+                };
+                let claims = match verifier.verify(&fresh).await {
+                    Ok(c) => c,
+                    Err(e) => {
+                        eprintln!("cp: own ITA refresh verify failed: {e}");
+                        continue;
+                    }
+                };
+                *token.write().await = fresh;
+                if let Some(cp) = store.lock().await.get_mut("control-plane") {
+                    cp.ita = claims;
+                }
+                eprintln!("cp: own ITA token refreshed");
+            }
+        });
+    }
 
     // Start the collector with the verifier. It re-verifies each
     // scraped agent's ita_token, so expired / revoked / unsigned
@@ -559,9 +601,10 @@ async fn cp_ita(
     if require_auth(&s, &headers, &uri).await.is_err() {
         return Err(Error::Unauthorized);
     }
-    let claims = s.verifier.verify(&s.cp_ita_token).await?;
+    let token = s.cp_ita_token.read().await.clone();
+    let claims = s.verifier.verify(&token).await?;
     Ok(Json(serde_json::json!({
-        "token": s.cp_ita_token,
+        "token": token,
         "claims": claims,
     })))
 }


### PR DESCRIPTION
Short-lived (~5 min) ITA tokens were minted once at startup and never refreshed. Agent's `/health` eventually served expired tokens (collector dropped them); CP's own `control-plane` entry showed `Expires: Expired` indefinitely.

Background tokio task on both sides re-mints every 180 s. CP task also re-verifies and updates the store entry's claims. Refresh failures are logged + retried, not fatal.

## Test plan
- [x] cargo clippy + tests green locally
- [ ] CI green
- [ ] Preview deploy: watch `cp: own ITA token refreshed` log line; dashboard card stays live past the first 5 min

🤖 Generated with [Claude Code](https://claude.com/claude-code)