### PR TITLE
feat(ci): auto-relaunch local TDX agents from GH Actions

### DIFF
--- a/.github/workflows/local-agents.yml
+++ b/.github/workflows/local-agents.yml
@@ -1,0 +1,86 @@
+name: Local Agents
+
+# Relaunches the local TDX agent VM on this user's host whenever the
+# corresponding CP gets new code:
+#   - Production Deploy success → reboot dd-local-prod against app.devopsdefender.com
+#   - Release success on a PR    → reboot dd-local-preview against pr-N.devopsdefender.com
+#
+# SSHs in via key auth to a public-IP host, then invokes
+# scripts/dd-relaunch.sh which handles the destroy/recreate cycle.
+
+on:
+  workflow_run:
+    workflows: ["Release", "Production Deploy"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      kind:
+        description: 'prod | preview'
+        required: true
+        default: 'prod'
+      cp_url:
+        description: 'CP URL (e.g. https://app.devopsdefender.com)'
+        required: true
+        default: 'https://app.devopsdefender.com'
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: local-agents-${{ github.event.workflow_run.name || github.event.inputs.kind }}
+  cancel-in-progress: false
+
+jobs:
+  relaunch:
+    if: |
+      github.event_name == 'workflow_dispatch'
+      || github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - id: pick
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT: ${{ github.event_name }}
+          WF: ${{ github.event.workflow_run.name }}
+          BRANCH: ${{ github.event.workflow_run.head_branch }}
+          DISPATCH_KIND: ${{ github.event.inputs.kind }}
+          DISPATCH_URL: ${{ github.event.inputs.cp_url }}
+        run: |
+          if [ "$EVENT" = "workflow_dispatch" ]; then
+            echo "kind=$DISPATCH_KIND" >> "$GITHUB_OUTPUT"
+            echo "url=$DISPATCH_URL"   >> "$GITHUB_OUTPUT"
+          elif [ "$WF" = "Production Deploy" ]; then
+            echo "kind=prod" >> "$GITHUB_OUTPUT"
+            echo "url=https://app.devopsdefender.com" >> "$GITHUB_OUTPUT"
+          else
+            # Release on a PR: derive pr-N. Released-on-main returns
+            # no open PR → skip (Production Deploy will fire shortly).
+            pr=$(gh pr list --head "$BRANCH" --state open \
+                   --repo "${{ github.repository }}" \
+                   --json number --jq '.[0].number' 2>/dev/null || true)
+            if [ -n "$pr" ]; then
+              echo "kind=preview" >> "$GITHUB_OUTPUT"
+              echo "url=https://pr-$pr.devopsdefender.com" >> "$GITHUB_OUTPUT"
+            else
+              echo "kind=skip" >> "$GITHUB_OUTPUT"
+            fi
+          fi
+
+      - name: ssh + relaunch
+        if: steps.pick.outputs.kind != 'skip'
+        env:
+          SSH_KEY:        ${{ secrets.DD_LOCAL_SSH_KEY }}
+          HOST:           ${{ secrets.DD_LOCAL_HOST }}
+          DD_PAT:         ${{ secrets.GITHUB_TOKEN }}
+          DD_ITA_API_KEY: ${{ secrets.DD_ITA_API_KEY }}
+          KIND:           ${{ steps.pick.outputs.kind }}
+          URL:            ${{ steps.pick.outputs.url }}
+        run: |
+          mkdir -p ~/.ssh
+          printf '%s\n' "$SSH_KEY" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -H "$HOST" >> ~/.ssh/known_hosts 2>/dev/null
+          ssh -o BatchMode=yes -o StrictHostKeyChecking=yes \
+              -i ~/.ssh/id_ed25519 "tdx2@$HOST" \
+              "DD_PAT='$DD_PAT' DD_ITA_API_KEY='$DD_ITA_API_KEY' /home/tdx2/src/dd/scripts/dd-relaunch.sh '$KIND' '$URL'"

--- a/scripts/dd-relaunch.sh
+++ b/scripts/dd-relaunch.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# dd-relaunch.sh — destroy and recreate one local TDX agent VM.
+#
+# Invoked over SSH by .github/workflows/local-agents.yml after a
+# Release / Production Deploy succeeds. Pulls the current main of dd
+# (so this script and local-agents.sh are always the latest), tears
+# down the existing VM + overlay, runs scripts/local-agents.sh to
+# redefine, and starts the VM.
+#
+#   dd-relaunch.sh prod    https://app.devopsdefender.com
+#   dd-relaunch.sh preview https://pr-N.devopsdefender.com
+#
+# DD_PAT and DD_ITA_API_KEY must be set in the environment.
+
+set -euo pipefail
+
+KIND="${1?usage: dd-relaunch.sh <prod|preview> <cp-url>}"
+CP="${2?cp url required}"
+: "${DD_PAT?DD_PAT must be set}"
+: "${DD_ITA_API_KEY?DD_ITA_API_KEY must be set}"
+
+case "$KIND" in
+  prod|preview) ;;
+  *) echo "unknown kind: $KIND (want prod|preview)" >&2; exit 2 ;;
+esac
+
+cd /home/tdx2/src/dd
+
+# Pull the latest scripts. Limit the checkout to the two scripts so a
+# dirty working tree elsewhere doesn't block the deploy. The relaunch
+# script itself has already been read into memory by bash, so the
+# update takes effect on the *next* invocation.
+git fetch --quiet origin main
+git checkout --quiet origin/main -- scripts/local-agents.sh scripts/dd-relaunch.sh
+
+vm="dd-local-$KIND"
+overlay="/var/lib/libvirt/images/$vm.qcow2"
+
+virsh destroy "$vm" 2>/dev/null || true
+virsh undefine "$vm" --managed-save --snapshots-metadata 2>/dev/null || true
+rm -f "$overlay"
+
+# Redefine via local-agents.sh; "" skips the other slot.
+case "$KIND" in
+  prod)    ./scripts/local-agents.sh ""  "$CP" ;;
+  preview) ./scripts/local-agents.sh "$CP" "" ;;
+esac
+
+virsh start "$vm"
+echo "relaunched $vm against $CP"


### PR DESCRIPTION
Workflow + host script that reboots the local TDX VMs on this user's host on every Production Deploy / PR Release success.

## Wiring
- `.github/workflows/local-agents.yml` — `workflow_run` on Release + Production Deploy + a manual `workflow_dispatch` entry. SSHes to `tdx2@$DD_LOCAL_HOST` via `DD_LOCAL_SSH_KEY`.
- `scripts/dd-relaunch.sh` — host-side: pulls latest scripts, destroys the VM + overlay, reruns `local-agents.sh` for the relevant slot, starts.

## Secrets needed (set out-of-band; not in this PR)
- `DD_LOCAL_HOST` — public IP/DNS
- `DD_LOCAL_SSH_KEY` — Ed25519 private key authorized as `tdx2` on the host
- `DD_ITA_API_KEY` — already set

## Auth shortcut
`secrets.GITHUB_TOKEN` doubles as `DD_PAT` — the CP's `verify_pat` falls back to `/repos/{owner}/dd` which `GITHUB_TOKEN` has access to, so no separate user PAT is required.

## Test plan
- [ ] Set the three secrets, generate `DD_LOCAL_SSH_KEY`, append pubkey to host `~tdx2/.ssh/authorized_keys`.
- [ ] `gh workflow run local-agents.yml -f kind=prod -f cp_url=https://app.devopsdefender.com`
- [ ] Watch `virsh list` on the host: dd-local-prod cycles `shut off → running` within ~30s; fleet at `app.devopsdefender.com` shows fresh `last_seen`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)