### PR TITLE
feat(ollama): deploy+pull+query via the agent API as example workload

### DIFF
--- a/scripts/dd-relaunch.sh
+++ b/scripts/dd-relaunch.sh
@@ -48,3 +48,9 @@ esac
 
 virsh start "$vm"
 echo "relaunched $vm against $CP"
+
+# Post-boot: deploy ollama as the example workload + pull a model +
+# run a sample query. Inherits DD_PAT + DD_ITA_API_KEY from env.
+# Fail loud (set -e) — the workflow turns red if this doesn't work.
+export CP_URL="$CP"
+./scripts/ollama-deploy.sh "$KIND"

--- a/scripts/local-agents.sh
+++ b/scripts/local-agents.sh
@@ -71,12 +71,23 @@ build_config_iso() {
     }')
   fi
 
+  # Mount the persistent models disk (vdc) at /var/lib/easyenclave/ollama
+  # before ollama might try to use it. Pre-formatted ext4 on the host.
+  local mount_workload
+  mount_workload=$(jq -c -n '{
+    app_name:"mount-models",
+    cmd:["/bin/busybox","sh","-c",
+         "mkdir -p /var/lib/easyenclave/ollama && mount /dev/vdc /var/lib/easyenclave/ollama && echo mount-models: ok; sleep inf"]
+  }')
+
   local workloads
   workloads=$(jq -c -n \
     --argjson nv "$nv_workload" \
+    --argjson mount "$mount_workload" \
     --arg cp "$cp" --arg pat "$DD_PAT" --arg ita "$DD_ITA_API_KEY" \
     --arg env "$env" --arg vm "dd-local-$name" '[
       $nv,
+      $mount,
       {"app_name":"cloudflared",
        "github_release":{"repo":"cloudflare/cloudflared","asset":"cloudflared-linux-amd64","rename":"cloudflared"}},
       {"app_name":"dd-agent",
@@ -116,6 +127,24 @@ build_overlay() {
   echo "  wrote $overlay (backing $BASE)"
 }
 
+# Persistent models disk — survives VM relaunch, so ollama doesn't
+# re-download the model each time. Pre-formatted ext4 on the host;
+# the guest just mounts it.
+build_models_disk() {
+  # $1=name, $2=size_gb
+  local name="$1" size_gb="$2"
+  local models="$IMG_DIR/dd-local-$name-models.qcow2"
+  if [ -f "$models" ]; then
+    echo "  models disk $models already exists (reusing)"
+    return
+  fi
+  qemu-img create -q -f raw "$models.raw" "${size_gb}G"
+  mkfs.ext4 -q -F "$models.raw"
+  qemu-img convert -q -f raw -O qcow2 "$models.raw" "$models"
+  rm -f "$models.raw"
+  echo "  wrote $models (${size_gb}G ext4)"
+}
+
 render_domain_xml() {
   # $1=name, $2=with_gpu (yes/no)
   local name="$1" with_gpu="$2"
@@ -150,6 +179,20 @@ render_domain_xml() {
          /<\/hostdev>/{skip=0}' "$out" > "$out.tmp" && mv "$out.tmp" "$out"
   fi
 
+  # Add a persistent models disk as vdc. EE will mount it at
+  # /var/lib/easyenclave/ollama via the mount-models boot workload.
+  local models="$IMG_DIR/dd-local-$name-models.qcow2"
+  local disk_block="    <disk type='file' device='disk'>
+      <driver name='qemu' type='qcow2'/>
+      <source file='$models'/>
+      <target dev='vdc' bus='virtio'/>
+    </disk>"
+  # Insert before </devices>.
+  awk -v block="$disk_block" '
+    /<\/devices>/ { print block }
+    { print }
+  ' "$out" > "$out.tmp" && mv "$out.tmp" "$out"
+
   echo "$out"
 }
 
@@ -161,6 +204,12 @@ define_agent() {
 
   echo "== dd-local-$name → $cp (env=$env_label, gpu=$with_gpu) =="
   build_overlay "$name"
+  # Models disk: prod holds the GPU model (few GB), preview holds the small CPU one.
+  if [ "$with_gpu" = "yes" ]; then
+    build_models_disk "$name" 40
+  else
+    build_models_disk "$name" 10
+  fi
   build_config_iso "$name" "$cp" "$env_label" "$with_gpu"
   local xml
   xml=$(render_domain_xml "$name" "$with_gpu")

--- a/scripts/ollama-deploy.sh
+++ b/scripts/ollama-deploy.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# ollama-deploy.sh — deploy ollama into one local agent VM, pull a
+# model, and run a sample query to confirm inference works.
+#
+# Invoked by dd-relaunch.sh after `virsh start` succeeds. Requires
+# DD_PAT and DD_ITA_API_KEY in env (same ones the relaunch uses).
+#
+#   ollama-deploy.sh <kind>
+#     kind: prod | preview
+#
+# Model selection:
+#   prod    — llama3.1:8b (~4.7 GB) runs on the H100.
+#   preview — qwen2.5:0.5b (~400 MB) runs on CPU.
+#
+# End-to-end:
+#   1. Poll the CP's /api/agents for our vm_name; pick up its hostname.
+#   2. POST ollama workload spec to https://{hostname}/deploy.
+#   3. Wait until ollama listens on 127.0.0.1:11434 (polled via /exec).
+#   4. ollama pull <model> via /exec.
+#   5. ollama query via /exec; echo the response.
+
+set -euo pipefail
+
+KIND="${1?usage: ollama-deploy.sh <prod|preview>}"
+: "${DD_PAT?}" "${DD_ITA_API_KEY?}"
+
+case "$KIND" in
+  prod)    MODEL="llama3.1:8b"    CP_URL="https://app.devopsdefender.com" ;;
+  preview) MODEL="qwen2.5:0.5b"   CP_URL="${CP_URL:?need CP_URL for preview}" ;;
+  *) echo "unknown kind: $KIND" >&2; exit 2 ;;
+esac
+
+VM_NAME="dd-local-$KIND"
+AUTH=(-H "Authorization: Bearer $DD_PAT")
+
+echo "== ollama-deploy $VM_NAME (model=$MODEL, cp=$CP_URL) =="
+
+# 1. Discover agent hostname via CP's /api/agents.
+agent_host=""
+for i in $(seq 1 60); do
+  agent_host=$(curl -fsS "${AUTH[@]}" "$CP_URL/api/agents" 2>/dev/null \
+    | jq -r --arg vm "$VM_NAME" '.[] | select(.vm_name==$vm) | .hostname' 2>/dev/null \
+    | head -1 || true)
+  if [ -n "$agent_host" ] && [ "$agent_host" != "null" ]; then
+    break
+  fi
+  echo "  waiting for $VM_NAME in CP fleet... ($i/60)"
+  sleep 10
+done
+if [ -z "$agent_host" ] || [ "$agent_host" = "null" ]; then
+  echo "ERROR: $VM_NAME never appeared in CP fleet" >&2
+  exit 1
+fi
+echo "  agent: https://$agent_host"
+
+agent() { curl -fsS --max-time 120 "${AUTH[@]}" "https://$agent_host$1" "${@:2}"; }
+
+# 2. Deploy ollama workload. EE returns a workload id.
+SPEC=$(jq -c -n '{
+  app_name:"ollama",
+  github_release:{repo:"ollama/ollama",asset:"ollama-linux-amd64",rename:"ollama"},
+  cmd:["ollama","serve"],
+  env:[
+    "OLLAMA_HOST=127.0.0.1:11434",
+    "OLLAMA_MODELS=/var/lib/easyenclave/ollama"
+  ]
+}')
+echo "  POST /deploy..."
+deploy_resp=$(agent /deploy -H 'Content-Type: application/json' -d "$SPEC")
+echo "  deploy: $deploy_resp"
+
+# 3. Wait for ollama to listen. Use /exec to probe inside the guest.
+echo "  waiting for ollama on 127.0.0.1:11434..."
+for i in $(seq 1 60); do
+  resp=$(agent /exec -H 'Content-Type: application/json' \
+    -d '{"cmd":["/bin/busybox","sh","-c","curl -fsS http://127.0.0.1:11434/api/tags && echo OK || echo NO"],"timeout_secs":10}' \
+    2>/dev/null || true)
+  if echo "$resp" | grep -q OK; then
+    echo "  ollama responding"
+    break
+  fi
+  sleep 5
+done
+
+# 4. Pull the model. Ollama streams progress; we just wait for completion.
+echo "  pulling $MODEL (this can take a few minutes)..."
+pull_resp=$(agent /exec -H 'Content-Type: application/json' \
+  -d "$(jq -c -n --arg m "$MODEL" '{
+    cmd:["/var/lib/easyenclave/bin/ollama","pull",$m],
+    timeout_secs:900
+  }')")
+echo "  pull: $(echo "$pull_resp" | jq -r '.stdout // "(no stdout)"' | tail -5)"
+
+# 5. Sample query.
+echo "  querying $MODEL..."
+query_resp=$(agent /exec -H 'Content-Type: application/json' \
+  -d "$(jq -c -n --arg m "$MODEL" '{
+    cmd:["/bin/busybox","sh","-c",
+      "curl -fsS http://127.0.0.1:11434/api/generate -H '"'"'Content-Type: application/json'"'"' -d "
+        + ("\"{\\\"model\\\":\\\"" + $m + "\\\",\\\"prompt\\\":\\\"write one sentence about trusted execution environments\\\",\\\"stream\\\":false}\"")
+    ],
+    timeout_secs:120
+  }')")
+response=$(echo "$query_resp" | jq -r '.stdout // "{}"' | jq -r '.response // ""')
+if [ -z "$response" ]; then
+  echo "ERROR: empty inference response"
+  echo "raw: $query_resp" | head -c 500
+  exit 1
+fi
+echo
+echo "=== $MODEL says ==="
+echo "$response"
+echo "==================="

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -15,8 +15,9 @@ use std::time::{Duration, Instant};
 use axum::extract::{Path, State, WebSocketUpgrade};
 use axum::http::HeaderMap;
 use axum::response::{Html, IntoResponse, Response};
-use axum::routing::get;
+use axum::routing::{get, post};
 use axum::{Json, Router};
+use serde::Deserialize;
 use tokio::sync::RwLock;
 
 use crate::auth::{self, Keys};
@@ -105,6 +106,8 @@ pub async fn run() -> Result<()> {
         .route("/workload/{id}", get(workload_page))
         .route("/session/{app}", get(session_page))
         .route("/ws/session/{app}", get(session_ws))
+        .route("/deploy", post(deploy))
+        .route("/exec", post(exec))
         .with_state(state);
 
     let addr = format!("0.0.0.0:{}", cfg.common.port);
@@ -413,6 +416,34 @@ async fn session_page(
     }
     let ws = format!("/ws/session/{}", urlencoding::encode(&app));
     Html(terminal::page(&app, &ws)).into_response()
+}
+
+async fn deploy(
+    State(s): State<St>,
+    headers: HeaderMap,
+    Json(spec): Json<serde_json::Value>,
+) -> Result<Json<serde_json::Value>> {
+    auth::resolve(&s.keys, &s.cfg.common.owner, &headers).await?;
+    Ok(Json(s.ee.deploy(spec).await?))
+}
+
+#[derive(Debug, Deserialize)]
+struct ExecReq {
+    cmd: Vec<String>,
+    #[serde(default = "default_exec_timeout")]
+    timeout_secs: u64,
+}
+fn default_exec_timeout() -> u64 {
+    60
+}
+
+async fn exec(
+    State(s): State<St>,
+    headers: HeaderMap,
+    Json(req): Json<ExecReq>,
+) -> Result<Json<serde_json::Value>> {
+    auth::resolve(&s.keys, &s.cfg.common.owner, &headers).await?;
+    Ok(Json(s.ee.exec(&req.cmd, req.timeout_secs).await?))
 }
 
 async fn session_ws(

--- a/src/cp.rs
+++ b/src/cp.rs
@@ -191,6 +191,7 @@ pub async fn run() -> Result<()> {
         .route("/register", post(register))
         .route("/agent/{id}", get(agent_detail))
         .route("/agent/{id}/logs/{app}", get(agent_logs))
+        .route("/api/agents", get(api_agents))
         .route("/cp/attest", get(cp_attest))
         .route("/cp/ita", get(cp_ita))
         .route("/cp/shell", get(shell_page))
@@ -398,6 +399,33 @@ async fn fleet(
         ),
     ))
     .into_response()
+}
+
+/// GET /api/agents — JSON list of `{agent_id, vm_name, hostname, status}`.
+/// Used by host-side scripts (dd-relaunch.sh) to discover a specific
+/// agent's tunnel hostname after it registers.
+async fn api_agents(
+    State(s): State<St>,
+    headers: HeaderMap,
+    axum::extract::OriginalUri(uri): axum::extract::OriginalUri,
+) -> Result<Json<Vec<serde_json::Value>>> {
+    if require_auth(&s, &headers, &uri).await.is_err() {
+        return Err(Error::Unauthorized);
+    }
+    let agents = s.store.lock().await.clone();
+    Ok(Json(
+        agents
+            .into_values()
+            .map(|a| {
+                serde_json::json!({
+                    "agent_id": a.agent_id,
+                    "vm_name": a.vm_name,
+                    "hostname": a.hostname,
+                    "status": a.status,
+                })
+            })
+            .collect(),
+    ))
 }
 
 async fn agent_detail(

--- a/src/ee.rs
+++ b/src/ee.rs
@@ -51,6 +51,24 @@ impl Ee {
             .await
     }
 
+    /// Deploy a workload at runtime. Spec is a workload object
+    /// (`app_name`, `github_release`/`cmd`, `env`, ...) — we just set
+    /// `method` and forward.
+    pub async fn deploy(&self, mut spec: serde_json::Value) -> Result<serde_json::Value> {
+        spec["method"] = serde_json::json!("deploy");
+        self.call(spec).await
+    }
+
+    /// Run a command inside the enclave and capture stdout/stderr.
+    pub async fn exec(&self, cmd: &[String], timeout_secs: u64) -> Result<serde_json::Value> {
+        self.call(serde_json::json!({
+            "method": "exec",
+            "cmd": cmd,
+            "timeout_secs": timeout_secs,
+        }))
+        .await
+    }
+
     /// Open a PTY shell. Sends the attach request, reads the ack, returns
     /// the raw stream for byte bridging to a WebSocket.
     pub async fn attach(&self, cmd: &[String]) -> Result<UnixStream> {


### PR DESCRIPTION
Ollama as an example workload on both local TDX VMs, pulled + queried at runtime through the EE API. Triggered by the existing GH Actions SSH pipeline.

## What lands
- **Agent**: POST /deploy + POST /exec (auth-gated).
- **CP**: GET /api/agents (JSON list for host-side discovery).
- **EE client**: `deploy()` + `exec()` methods re-added to src/ee.rs.
- **Persistent models disk**: vdc qcow2 per VM, 40G (prod) / 10G (preview), pre-formatted ext4, mounted via a `mount-models` boot workload. Models survive relaunch.
- **scripts/ollama-deploy.sh**: discover agent → deploy ollama → wait for daemon → pull model → sample query → print response.
- **scripts/dd-relaunch.sh**: chain the ollama deploy step after VM boot.

## Models
- prod: llama3.1:8b on H100
- preview: qwen2.5:0.5b on CPU

## Test plan
- [x] cargo clippy + test green
- [ ] CI green
- [ ] Manual `gh workflow run local-agents.yml -f kind=prod -f cp_url=https://app.devopsdefender.com` → VM relaunch → ollama deploy + model pull + sample inference → workflow log shows the `response` text

🤖 Generated with [Claude Code](https://claude.com/claude-code)