### PR TITLE
fix: prefer healthy agent in /api/agents, evict stale on re-register

### DIFF
--- a/scripts/ollama-deploy.sh
+++ b/scripts/ollama-deploy.sh
@@ -35,16 +35,19 @@ AUTH=(-H "Authorization: Bearer $DD_PAT")
 
 echo "== ollama-deploy $VM_NAME (model=$MODEL, cp=$CP_URL) =="
 
-# 1. Discover agent hostname via CP's /api/agents.
+# 1. Discover agent hostname via CP's /api/agents. Prefer healthy
+# entries; the store can briefly hold stale duplicates from a prior
+# relaunch whose tunnel is already gone.
 agent_host=""
 for i in $(seq 1 60); do
   agent_host=$(curl -fsS "${AUTH[@]}" "$CP_URL/api/agents" 2>/dev/null \
-    | jq -r --arg vm "$VM_NAME" '.[] | select(.vm_name==$vm) | .hostname' 2>/dev/null \
-    | head -1 || true)
+    | jq -r --arg vm "$VM_NAME" '
+        [.[] | select(.vm_name==$vm and .status=="healthy")]
+        | sort_by(.agent_id) | reverse | .[0].hostname // empty' 2>/dev/null || true)
   if [ -n "$agent_host" ] && [ "$agent_host" != "null" ]; then
     break
   fi
-  echo "  waiting for $VM_NAME in CP fleet... ($i/60)"
+  echo "  waiting for healthy $VM_NAME in CP fleet... ($i/60)"
   sleep 10
 done
 if [ -z "$agent_host" ] || [ "$agent_host" = "null" ]; then

--- a/src/cp.rs
+++ b/src/cp.rs
@@ -298,25 +298,40 @@ async fn register(
     let tunnel = cf::create(&http, &s.cfg.cf, &name, &agent_hostname).await?;
 
     // Seed the store so the dashboard shows the agent before the first
-    // collector tick.
+    // collector tick. Also evict any prior entries with the same
+    // vm_name — a relaunched VM registers a new agent_id/hostname, but
+    // the stale old one hangs around until the collector's dead
+    // threshold (5 min). During that window `/api/agents` returns
+    // duplicates and host-side scripts can pick the dead hostname.
     let now = chrono::Utc::now();
-    s.store.lock().await.insert(
-        name.clone(),
-        collector::Agent {
-            agent_id: name.clone(),
-            hostname: tunnel.hostname.clone(),
-            vm_name: req.vm_name.clone(),
-            attestation_type: "tdx".into(),
-            status: "registered".into(),
-            last_seen: now,
-            deployment_count: 0,
-            deployment_names: Vec::new(),
-            cpu_percent: 0,
-            memory_used_mb: 0,
-            memory_total_mb: 0,
-            ita: ita_claims,
-        },
-    );
+    {
+        let mut store = s.store.lock().await;
+        let stale: Vec<String> = store
+            .iter()
+            .filter(|(id, a)| a.vm_name == req.vm_name && id.as_str() != name)
+            .map(|(id, _)| id.clone())
+            .collect();
+        for id in stale {
+            store.remove(&id);
+        }
+        store.insert(
+            name.clone(),
+            collector::Agent {
+                agent_id: name.clone(),
+                hostname: tunnel.hostname.clone(),
+                vm_name: req.vm_name.clone(),
+                attestation_type: "tdx".into(),
+                status: "healthy".into(),
+                last_seen: now,
+                deployment_count: 0,
+                deployment_names: Vec::new(),
+                cpu_percent: 0,
+                memory_used_mb: 0,
+                memory_total_mb: 0,
+                ita: ita_claims,
+            },
+        );
+    }
 
     eprintln!(
         "cp: registered {} as {} (login={login})",


### PR DESCRIPTION
Two fixes surfaced by the first ollama-deploy run:

1. `scripts/ollama-deploy.sh` — filter `/api/agents` to `status==healthy`, deterministic tie-break. No more picking a dead hostname.
2. `src/cp.rs::register` — evict prior entries with the same `vm_name`; flip seeded status to `healthy` so the filter catches the new entry immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)