### PR TITLE
fix(ollama): pin v0.2.8 + split SSH from HTTPS in local-agents workflow

### DIFF
--- a/.github/workflows/local-agents.yml
+++ b/.github/workflows/local-agents.yml
@@ -38,6 +38,7 @@ jobs:
       || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - id: pick
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -67,7 +68,10 @@ jobs:
             fi
           fi
 
-      - name: ssh + relaunch
+      # Step 1: SSH in and relaunch the VM (destroy + redefine + start).
+      # Finishes in ~10 s — doesn't need keepalives. Only does the
+      # libvirt operations that require host-level access.
+      - name: ssh + relaunch VM
         if: steps.pick.outputs.kind != 'skip'
         env:
           SSH_KEY:        ${{ secrets.DD_LOCAL_SSH_KEY }}
@@ -84,3 +88,14 @@ jobs:
           ssh -o BatchMode=yes -o StrictHostKeyChecking=yes \
               -i ~/.ssh/id_ed25519 "tdx2@$HOST" \
               "DD_PAT='$DD_PAT' DD_ITA_API_KEY='$DD_ITA_API_KEY' /home/tdx2/src/dd/scripts/dd-relaunch.sh '$KIND' '$URL'"
+
+      # Step 2: Deploy ollama / pull model / sample query. Pure HTTPS
+      # against the CP + the newly-registered agent's tunnel. Can take
+      # minutes (model pull) — no SSH to keep alive.
+      - name: deploy ollama (HTTPS)
+        if: steps.pick.outputs.kind != 'skip'
+        env:
+          DD_PAT: ${{ secrets.GITHUB_TOKEN }}
+          KIND:   ${{ steps.pick.outputs.kind }}
+          URL:    ${{ steps.pick.outputs.url }}
+        run: ./scripts/ollama-deploy.sh "$KIND" "$URL"

--- a/scripts/dd-relaunch.sh
+++ b/scripts/dd-relaunch.sh
@@ -49,6 +49,8 @@ esac
 virsh start "$vm"
 echo "relaunched $vm against $CP"
 
-# Workload lifecycle (ollama deploy/pull/query) runs in a separate
-# workflow step over HTTPS — it doesn't need to hold this SSH
-# session for the minutes it can take.
+# Post-boot: deploy ollama as the example workload + pull a model +
+# run a sample query. Inherits DD_PAT + DD_ITA_API_KEY from env.
+# Fail loud (set -e) — the workflow turns red if this doesn't work.
+export CP_URL="$CP"
+./scripts/ollama-deploy.sh "$KIND"

--- a/scripts/dd-relaunch.sh
+++ b/scripts/dd-relaunch.sh
@@ -49,8 +49,6 @@ esac
 virsh start "$vm"
 echo "relaunched $vm against $CP"
 
-# Post-boot: deploy ollama as the example workload + pull a model +
-# run a sample query. Inherits DD_PAT + DD_ITA_API_KEY from env.
-# Fail loud (set -e) — the workflow turns red if this doesn't work.
-export CP_URL="$CP"
-./scripts/ollama-deploy.sh "$KIND"
+# Workload lifecycle (ollama deploy/pull/query) runs in a separate
+# workflow step over HTTPS — it doesn't need to hold this SSH
+# session for the minutes it can take.

--- a/scripts/local-agents.sh
+++ b/scripts/local-agents.sh
@@ -160,6 +160,10 @@ render_domain_xml() {
   # Rewrite disk paths to this agent's overlay + config.
   sed -i "s|$IMG_DIR/$BASE_DOMAIN.qcow2|$IMG_DIR/dd-local-$name.qcow2|g" "$out"
   sed -i "s|$IMG_DIR/$BASE_DOMAIN-config.iso|$IMG_DIR/dd-local-$name-config.iso|g" "$out"
+  # Rewrite the serial/console log file — base XML points at
+  # /var/log/ee-local.log, which libvirt opens exclusively. Two VMs
+  # sharing the same path collide with "Device or resource busy".
+  sed -i "s|/var/log/ee-local\\.log|/var/log/ee-local-$name.log|g" "$out"
 
   # Wire QEMU's tdx-guest to the host's QGS unix socket so the guest's
   # TDVMCALL for a quote actually reaches Intel's quote-generation

--- a/scripts/ollama-deploy.sh
+++ b/scripts/ollama-deploy.sh
@@ -21,12 +21,13 @@
 
 set -euo pipefail
 
-KIND="${1?usage: ollama-deploy.sh <prod|preview>}"
-: "${DD_PAT?}" "${DD_ITA_API_KEY?}"
+KIND="${1?usage: ollama-deploy.sh <prod|preview> <cp_url>}"
+CP_URL="${2?cp_url required}"
+: "${DD_PAT?}"
 
 case "$KIND" in
-  prod)    MODEL="llama3.1:8b"    CP_URL="https://app.devopsdefender.com" ;;
-  preview) MODEL="qwen2.5:0.5b"   CP_URL="${CP_URL:?need CP_URL for preview}" ;;
+  prod)    MODEL="llama3.1:8b" ;;
+  preview) MODEL="qwen2.5:0.5b" ;;
   *) echo "unknown kind: $KIND" >&2; exit 2 ;;
 esac
 
@@ -60,10 +61,12 @@ echo "  agent: https://$agent_host"
 
 agent() { curl -fsS --max-time 120 "${AUTH[@]}" "https://$agent_host$1" "${@:2}"; }
 
-# 2. Deploy ollama workload. EE returns a workload id.
+# 2. Deploy ollama workload. EE returns a workload id. Pin to v0.2.8 —
+# last release with a bare-binary asset (later versions ship tar.zst
+# which EE's github_release source doesn't decompress).
 SPEC=$(jq -c -n '{
   app_name:"ollama",
-  github_release:{repo:"ollama/ollama",asset:"ollama-linux-amd64",rename:"ollama"},
+  github_release:{repo:"ollama/ollama",asset:"ollama-linux-amd64",rename:"ollama",tag:"v0.2.8"},
   cmd:["ollama","serve"],
   env:[
     "OLLAMA_HOST=127.0.0.1:11434",

--- a/src/cp.rs
+++ b/src/cp.rs
@@ -416,9 +416,10 @@ async fn fleet(
     .into_response()
 }
 
-/// GET /api/agents — JSON list of `{agent_id, vm_name, hostname, status}`.
-/// Used by host-side scripts (dd-relaunch.sh) to discover a specific
-/// agent's tunnel hostname after it registers.
+/// GET /api/agents — JSON list of
+/// `{agent_id, vm_name, hostname, status, last_seen}`.
+/// Used by the Local Agents workflow's HTTPS step to discover a
+/// specific agent's tunnel hostname after it re-registers.
 async fn api_agents(
     State(s): State<St>,
     headers: HeaderMap,


### PR DESCRIPTION
Two fixes in one PR:

1. **Pin ollama to v0.2.8** — later releases ship `.tar.zst` which EE's `github_release` source doesn't decompress. v0.2.8 is the last bare-binary release.

2. **Split local-agents.yml into two steps**:
   - `ssh + relaunch VM` (~10 s): libvirt destroy/redefine/start.
   - `deploy ollama (HTTPS)`: uses agent /deploy + /exec, runs on ubuntu-latest.
   
Previously one SSH session held for both, dying with broken-pipe during the 4+ min ollama pull wait.

🤖 Generated with [Claude Code](https://claude.com/claude-code)