### PR TITLE
feat(register): verify TDX quotes via Intel Trust Authority

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -58,6 +58,7 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.DD_CP_CF_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.DD_CP_CF_ACCOUNT_ID }}
           CLOUDFLARE_ZONE_ID: ${{ secrets.DD_CP_CF_ZONE_ID }}
+          DD_ITA_API_KEY: ${{ secrets.DD_ITA_API_KEY }}
           DD_GITHUB_CLIENT_ID: ${{ vars.DD_GITHUB_CLIENT_ID || secrets.DD_GITHUB_CLIENT_ID }}
           DD_GITHUB_CALLBACK_URL: ${{ vars.DD_GITHUB_CALLBACK_URL }}
           DD_GITHUB_CLIENT_SECRET: ${{ secrets.DD_GITHUB_CLIENT_SECRET }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,6 +135,7 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.DD_CP_CF_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.DD_CP_CF_ACCOUNT_ID }}
           CLOUDFLARE_ZONE_ID: ${{ secrets.DD_CP_CF_ZONE_ID }}
+          DD_ITA_API_KEY: ${{ secrets.DD_ITA_API_KEY }}
           # OAuth env vars intentionally omitted — gcp-deploy.sh sees
           # empty DD_GITHUB_CLIENT_ID and skips them in the workload
           # spec. dd-web then disables /auth/github/* and serves

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,11 +351,13 @@ dependencies = [
  "chrono",
  "dd-common",
  "futures-util",
+ "jsonwebtoken",
  "libc",
  "reqwest",
  "serde",
  "serde_json",
  "snow",
+ "thiserror 2.0.18",
  "tokio",
  "uuid",
 ]

--- a/README.md
+++ b/README.md
@@ -41,6 +41,20 @@ The `devopsdefender` binary ships as a **GitHub release asset** — not an OCI i
 
 Per-VM configuration (CF credentials, GitHub OAuth, the workload spec itself) is passed to easyenclave at boot via **GCE instance metadata** (`ee-config` attribute), read by `easyenclave::init::fetch_gce_metadata_config()` and applied as env vars. `scripts/gcp-deploy.sh` builds the spec and invokes `gcloud compute instances create --image-family=easyenclave-staging --metadata-from-file=ee-config=...`.
 
+Intel Trust Authority configuration is passed the same way. Set the
+environment-scoped GitHub Actions secret `DD_ITA_API_KEY` for staging and
+production; `scripts/gcp-deploy.sh` injects it into the management workload as
+`DD_ITA_API_KEY` and sets `DD_ITA_URL` to
+`https://api.trustauthority.intel.com` by default.
+
+`dd-register` fails closed: without `DD_ITA_API_KEY` it refuses to start
+unless `DD_ALLOW_UNVERIFIED_REGISTRATIONS=1` is set (local dev / bring-up
+only). When the key is set, every agent registration must present a TDX
+quote that ITA verifies and whose REPORT_DATA echoes a fresh handshake
+nonce. Measurements (MRTD/RTMR0–3) are logged for each accepted
+registration so we can build a pinned policy once a known-good baseline
+is captured.
+
 ## CI/CD
 
 ```

--- a/crates/dd-client/src/lib.rs
+++ b/crates/dd-client/src/lib.rs
@@ -153,7 +153,14 @@ async fn post_re_register(
         .ok_or_else(|| AppError::InvalidInput("no register URL configured".into()))?;
 
     eprintln!("dd-client: re-registering with {register_url}");
-    match register_with_noise(register_url, &state.config.vm_name, &state.config.owner).await {
+    match register_with_noise(
+        register_url,
+        &state.config.vm_name,
+        &state.config.owner,
+        &state.ee_client,
+    )
+    .await
+    {
         Ok(bootstrap) => {
             eprintln!("dd-client: re-registered — hostname={}", bootstrap.hostname);
 
@@ -181,15 +188,11 @@ async fn register_with_noise(
     register_url: &str,
     vm_name: &str,
     owner: &str,
+    ee_client: &EeClient,
 ) -> Result<dd_common::noise::BootstrapConfig, String> {
     use futures_util::{SinkExt, StreamExt};
 
     let keypair = dd_common::noise::generate_keypair()?;
-    let attestation = dd_common::noise::AttestationPayload {
-        attestation_type: "tdx".into(),
-        vm_name: vm_name.into(),
-        tdx_quote_b64: None,
-    };
 
     // Connect via WebSocket
     let (ws_stream, _) = tokio_tungstenite::connect_async(register_url)
@@ -219,14 +222,40 @@ async fn register_with_noise(
         .await
         .map_err(|e| format!("send msg1: {e}"))?;
 
-    // msg2
+    // msg2 carries a freshness nonce from the register. Embed it in the
+    // TDX quote's REPORT_DATA so ITA can prove the quote was made *for
+    // this handshake* and isn't a replay.
     let msg2 = match ws_rx.next().await {
         Some(Ok(tokio_tungstenite::tungstenite::Message::Binary(data))) => data.to_vec(),
         other => return Err(format!("expected binary msg2, got: {other:?}")),
     };
-    noise
+    let msg2_payload_len = noise
         .read_message(&msg2, &mut buf)
         .map_err(|e| format!("msg2: {e}"))?;
+    let msg2_payload: serde_json::Value = serde_json::from_slice(&buf[..msg2_payload_len])
+        .map_err(|e| format!("parse msg2 payload: {e}"))?;
+    let nonce_b64 = msg2_payload["nonce"]
+        .as_str()
+        .ok_or_else(|| "msg2 missing nonce".to_string())?
+        .to_string();
+
+    // Ask easyenclave for a quote bound to the nonce. REPORT_DATA in
+    // the quote will contain the nonce bytes so the register can bind
+    // verification to this handshake.
+    let attest_resp = ee_client
+        .attest(&nonce_b64)
+        .await
+        .map_err(|e| format!("ee attest: {e}"))?;
+    let tdx_quote_b64 = attest_resp["quote_b64"]
+        .as_str()
+        .ok_or_else(|| format!("ee attest missing quote_b64: {attest_resp}"))?
+        .to_string();
+
+    let attestation = dd_common::noise::AttestationPayload {
+        attestation_type: "tdx".into(),
+        vm_name: vm_name.into(),
+        tdx_quote_b64: Some(tdx_quote_b64),
+    };
 
     // msg3 with attestation
     let attestation_json = serde_json::to_vec(&attestation).unwrap();
@@ -340,7 +369,7 @@ pub async fn run() {
 
     if let Some(ref register_url) = config.register_url {
         eprintln!("dd-client: registering with {register_url}");
-        match register_with_noise(register_url, &config.vm_name, &config.owner).await {
+        match register_with_noise(register_url, &config.vm_name, &config.owner, &ee_client).await {
             Ok(bootstrap) => {
                 eprintln!(
                     "dd-client: registered — owner={} hostname={}",

--- a/crates/dd-register/Cargo.toml
+++ b/crates/dd-register/Cargo.toml
@@ -17,6 +17,7 @@ axum = { version = "0.8", features = ["ws"] }
 base64 = "0.22"
 chrono = { version = "0.4", features = ["serde"] }
 futures-util = "0.3"
+jsonwebtoken = "9"
 # libc: direct reboot(2) syscall for STONITH self-poweroff. Subprocess
 # `poweroff` proved unreliable (busybox tries to signal a systemd-style
 # PID 1, which easyenclave isn't, then no-ops).
@@ -25,5 +26,6 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 snow = "0.9"
+thiserror = "2"
 tokio = { version = "1", features = ["macros", "process", "rt-multi-thread", "signal", "time", "fs", "net"] }
 uuid = { version = "1", features = ["serde", "v4"] }

--- a/crates/dd-register/src/handler.rs
+++ b/crates/dd-register/src/handler.rs
@@ -5,7 +5,9 @@
 //! payload, and dd-register provisions a Cloudflare tunnel + DNS record
 //! for the agent via dd_common::tunnel.
 
+use crate::ita::ItaVerifier;
 use axum::extract::ws::WebSocket;
+use base64::Engine;
 use dd_common::noise;
 use dd_common::tunnel;
 use futures_util::StreamExt;
@@ -54,6 +56,7 @@ pub async fn handle_ws_register(
     cf: tunnel::CfConfig,
     auth_public_key_b64: Option<String>,
     auth_issuer: Option<String>,
+    ita: Option<Arc<ItaVerifier>>,
 ) {
     let (mut ws_tx, mut ws_rx) = socket.split();
 
@@ -65,13 +68,22 @@ pub async fn handle_ws_register(
         }
     };
 
-    // Noise XX handshake — we pass an empty responder payload; the agent
-    // sends its attestation as the initiator payload in msg3.
+    // Fresh 32-byte handshake nonce, sent to the agent in Noise msg2.
+    // The agent embeds it in the TDX quote's REPORT_DATA so ITA can
+    // prove freshness — a stolen valid quote can't be replayed against
+    // a different registration.
+    let mut nonce_bytes = [0u8; 32];
+    nonce_bytes[..16].copy_from_slice(uuid::Uuid::new_v4().as_bytes());
+    nonce_bytes[16..].copy_from_slice(uuid::Uuid::new_v4().as_bytes());
+    let nonce_b64 = base64::engine::general_purpose::STANDARD.encode(nonce_bytes);
+    let msg2_payload = serde_json::to_vec(&serde_json::json!({ "nonce": nonce_b64 }))
+        .expect("nonce json serialization is infallible");
+
     let (mut transport, peer_payload) = match noise::noise_xx_responder_ws(
         &mut ws_tx,
         &mut ws_rx,
         &keypair.private,
-        &[], // register sends no payload in msg2
+        &msg2_payload,
     )
     .await
     {
@@ -94,6 +106,47 @@ pub async fn handle_ws_register(
         "dd-register: agent {} ({})",
         attestation.vm_name, attestation.attestation_type
     );
+
+    // ITA verification (fail closed). If the verifier is configured,
+    // every registration must present a valid TDX quote bound to our
+    // handshake nonce. When the verifier is absent, lib.rs has already
+    // required DD_ALLOW_UNVERIFIED_REGISTRATIONS at startup — so
+    // reaching this branch means the operator opted out explicitly.
+    if let Some(ref verifier) = ita {
+        let Some(quote) = attestation.tdx_quote_b64.as_deref() else {
+            eprintln!(
+                "dd-register: {} rejected — no tdx_quote_b64 in attestation",
+                attestation.vm_name
+            );
+            return;
+        };
+        match verifier.verify(quote, &nonce_b64).await {
+            Ok(claims) => {
+                eprintln!(
+                    "dd-register: {} ITA verified — mrtd={} rtmr0={} rtmr1={} rtmr2={} rtmr3={} tcb={}",
+                    attestation.vm_name,
+                    claims.mrtd.as_deref().unwrap_or("-"),
+                    claims.rtmr0.as_deref().unwrap_or("-"),
+                    claims.rtmr1.as_deref().unwrap_or("-"),
+                    claims.rtmr2.as_deref().unwrap_or("-"),
+                    claims.rtmr3.as_deref().unwrap_or("-"),
+                    claims.tcb_status.as_deref().unwrap_or("-"),
+                );
+            }
+            Err(e) => {
+                eprintln!(
+                    "dd-register: {} rejected — ITA verification failed: {e}",
+                    attestation.vm_name
+                );
+                return;
+            }
+        }
+    } else {
+        eprintln!(
+            "dd-register: WARNING {} registering without ITA verification (DD_ALLOW_UNVERIFIED_REGISTRATIONS set)",
+            attestation.vm_name
+        );
+    }
 
     // Read encrypted registration request
     let req_bytes = match noise::noise_recv_ws(&mut ws_rx, &mut transport).await {

--- a/crates/dd-register/src/ita.rs
+++ b/crates/dd-register/src/ita.rs
@@ -1,0 +1,196 @@
+//! Intel Trust Authority (ITA) TDX quote verifier.
+//!
+//! Flow:
+//!   1. POST the base64-encoded TDX quote to `{base}/appraisal/v1/attest`
+//!      with `x-api-key: {DD_ITA_API_KEY}`. ITA returns a signed JWT
+//!      (`{"token": "..."}`).
+//!   2. Fetch ITA's JWKS at `{base}/certs` and verify the token signature
+//!      against the `kid` named in its header.
+//!   3. Assert the quote's `REPORT_DATA` begins with the handshake nonce
+//!      we sent in Noise msg2. This binds the quote to *this* handshake,
+//!      preventing an attacker from replaying a stolen valid quote.
+//!
+//! What this does NOT enforce yet: a policy_ids list pinning the
+//! expected MRTD/RTMR measurements to our image. Until we have captured
+//! known-good values from a trusted build, verification only confirms
+//! "this is a valid TDX quote per Intel" + nonce freshness, not "this
+//! is our specific easyenclave image." The claims returned here are
+//! logged by handler.rs so ops can capture measurements from prod.
+
+use base64::Engine;
+use jsonwebtoken::{decode, decode_header, DecodingKey, Validation};
+use serde::Deserialize;
+
+#[derive(Debug, thiserror::Error)]
+pub enum ItaError {
+    #[error("ita request failed: {0}")]
+    Request(String),
+    #[error("ita returned {status}: {body}")]
+    Status { status: u16, body: String },
+    #[error("token parse: {0}")]
+    Token(String),
+    #[error("jwks fetch: {0}")]
+    Jwks(String),
+    #[error("key id {0} not found in jwks")]
+    KeyNotFound(String),
+    #[error("report_data does not bind to handshake nonce")]
+    NonceMismatch,
+}
+
+pub struct ItaVerifier {
+    api_key: String,
+    base_url: String,
+    client: reqwest::Client,
+}
+
+#[derive(Debug, Deserialize)]
+struct AttestResponse {
+    token: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct JwksResponse {
+    keys: Vec<Jwk>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Jwk {
+    kid: String,
+    n: String,
+    e: String,
+}
+
+/// Subset of ITA token claims. ITA emits many more fields; we parse the
+/// TDX measurements (for logging + future policy use) and the report
+/// data (for nonce binding).
+#[derive(Debug, Deserialize, Clone)]
+pub struct ItaClaims {
+    /// Hex-encoded 64-byte REPORT_DATA from the quote.
+    #[serde(rename = "attester_tdx_reportdata")]
+    pub report_data: Option<String>,
+    #[serde(rename = "attester_tdx_mrtd")]
+    pub mrtd: Option<String>,
+    #[serde(rename = "attester_tdx_rtmr0")]
+    pub rtmr0: Option<String>,
+    #[serde(rename = "attester_tdx_rtmr1")]
+    pub rtmr1: Option<String>,
+    #[serde(rename = "attester_tdx_rtmr2")]
+    pub rtmr2: Option<String>,
+    #[serde(rename = "attester_tdx_rtmr3")]
+    pub rtmr3: Option<String>,
+    #[serde(rename = "attester_tcb_status")]
+    pub tcb_status: Option<String>,
+}
+
+impl ItaVerifier {
+    pub fn new(api_key: String, base_url: String) -> Self {
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(30))
+            .build()
+            .unwrap_or_else(|_| reqwest::Client::new());
+        Self {
+            api_key,
+            base_url: base_url.trim_end_matches('/').to_string(),
+            client,
+        }
+    }
+
+    /// Verify a TDX quote against ITA and assert its REPORT_DATA begins
+    /// with `handshake_nonce_b64`. Returns the measurement claims for
+    /// logging on success.
+    pub async fn verify(
+        &self,
+        quote_b64: &str,
+        handshake_nonce_b64: &str,
+    ) -> Result<ItaClaims, ItaError> {
+        // 1. POST quote to ITA.
+        let resp = self
+            .client
+            .post(format!("{}/appraisal/v1/attest", self.base_url))
+            .header("x-api-key", &self.api_key)
+            .header("Accept", "application/json")
+            .json(&serde_json::json!({ "quote": quote_b64 }))
+            .send()
+            .await
+            .map_err(|e| ItaError::Request(e.to_string()))?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            return Err(ItaError::Status {
+                status: status.as_u16(),
+                body,
+            });
+        }
+        let attest: AttestResponse = resp
+            .json()
+            .await
+            .map_err(|e| ItaError::Request(format!("decode body: {e}")))?;
+
+        // 2. Verify token signature via JWKS.
+        let header = decode_header(&attest.token).map_err(|e| ItaError::Token(e.to_string()))?;
+        let kid = header
+            .kid
+            .clone()
+            .ok_or_else(|| ItaError::Token("jwt header missing kid".into()))?;
+        let alg = header.alg;
+        let key = self.fetch_jwk(&kid).await?;
+        let decoding_key = DecodingKey::from_rsa_components(&key.n, &key.e)
+            .map_err(|e| ItaError::Token(format!("decoding key: {e}")))?;
+        let mut validation = Validation::new(alg);
+        // ITA's `iss`/`aud` vary by region/tenant; TLS + x-api-key is our
+        // trust root for which ITA instance we're talking to. Default
+        // Validation already skips iss if set_issuer isn't called; turn
+        // off aud checking so we don't reject tokens with an audience
+        // claim the caller hasn't pre-registered.
+        validation.validate_aud = false;
+        let token_data = decode::<ItaClaims>(&attest.token, &decoding_key, &validation)
+            .map_err(|e| ItaError::Token(format!("verify: {e}")))?;
+
+        // 3. Nonce binding. easyenclave places our handshake nonce in
+        //    the leading bytes of REPORT_DATA when requesting the quote;
+        //    ITA returns REPORT_DATA hex-encoded.
+        let report_data = token_data
+            .claims
+            .report_data
+            .as_deref()
+            .ok_or(ItaError::NonceMismatch)?;
+        let nonce_bytes = base64::engine::general_purpose::STANDARD
+            .decode(handshake_nonce_b64)
+            .map_err(|_| ItaError::NonceMismatch)?;
+        let nonce_hex = hex_lower(&nonce_bytes);
+        if !report_data.to_ascii_lowercase().starts_with(&nonce_hex) {
+            return Err(ItaError::NonceMismatch);
+        }
+
+        Ok(token_data.claims)
+    }
+
+    async fn fetch_jwk(&self, kid: &str) -> Result<Jwk, ItaError> {
+        let resp = self
+            .client
+            .get(format!("{}/certs", self.base_url))
+            .send()
+            .await
+            .map_err(|e| ItaError::Jwks(e.to_string()))?;
+        if !resp.status().is_success() {
+            return Err(ItaError::Jwks(format!("status {}", resp.status())));
+        }
+        let jwks: JwksResponse = resp
+            .json()
+            .await
+            .map_err(|e| ItaError::Jwks(format!("decode jwks: {e}")))?;
+        jwks.keys
+            .into_iter()
+            .find(|k| k.kid == kid)
+            .ok_or_else(|| ItaError::KeyNotFound(kid.to_string()))
+    }
+}
+
+fn hex_lower(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        s.push_str(&format!("{b:02x}"));
+    }
+    s
+}

--- a/crates/dd-register/src/lib.rs
+++ b/crates/dd-register/src/lib.rs
@@ -4,6 +4,7 @@
 //! and fleet health. No dashboard, no OAuth, no scraping -- those are dd-web's job.
 
 pub mod handler;
+pub mod ita;
 
 use axum::extract::{State, WebSocketUpgrade};
 use axum::response::IntoResponse;
@@ -11,6 +12,7 @@ use axum::routing::{get, post};
 use axum::{Json, Router};
 use dd_common::tunnel;
 use handler::{AgentRegistry, RegisteredAgent};
+use ita::ItaVerifier;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::Mutex;
@@ -28,6 +30,9 @@ struct AppState {
     auth_public_key_b64: Option<String>,
     /// Auth issuer URL (https://<hostname>).
     auth_issuer: Option<String>,
+    /// Intel Trust Authority verifier. `Some` when DD_ITA_API_KEY is set;
+    /// `None` only when DD_ALLOW_UNVERIFIED_REGISTRATIONS=1 (preview envs).
+    ita: Option<Arc<ItaVerifier>>,
 }
 
 // ── Entry point ─────────────────────────────────────────────────────────
@@ -56,6 +61,34 @@ pub async fn run() {
         eprintln!("dd-register: DD_HOSTNAME not set");
         std::process::exit(1);
     });
+
+    // ITA verification config. Fail closed: without DD_ITA_API_KEY,
+    // refuse to start unless the operator explicitly opted out via
+    // DD_ALLOW_UNVERIFIED_REGISTRATIONS=1 (preview/dev envs only).
+    let ita_api_key = std::env::var("DD_ITA_API_KEY").ok().filter(|s| !s.is_empty());
+    let ita_url = std::env::var("DD_ITA_URL")
+        .unwrap_or_else(|_| "https://api.trustauthority.intel.com".to_string());
+    let allow_unverified = std::env::var("DD_ALLOW_UNVERIFIED_REGISTRATIONS")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false);
+    let ita: Option<Arc<ItaVerifier>> = match (ita_api_key, allow_unverified) {
+        (Some(key), _) => {
+            eprintln!("dd-register: ITA verification enabled — url={ita_url}");
+            Some(Arc::new(ItaVerifier::new(key, ita_url)))
+        }
+        (None, true) => {
+            eprintln!(
+                "dd-register: WARNING ITA verification DISABLED — DD_ALLOW_UNVERIFIED_REGISTRATIONS=1"
+            );
+            None
+        }
+        (None, false) => {
+            eprintln!(
+                "dd-register: refusing to start — DD_ITA_API_KEY unset and DD_ALLOW_UNVERIFIED_REGISTRATIONS not set"
+            );
+            std::process::exit(1);
+        }
+    };
 
     // Self-register: create our own CF tunnel so we're reachable
     let register_id = uuid::Uuid::new_v4().to_string();
@@ -189,6 +222,7 @@ pub async fn run() {
         self_tunnel_id: tunnel_info.tunnel_id.clone(),
         auth_public_key_b64,
         auth_issuer,
+        ita,
     };
 
     // STONITH: signal old register instances to shut down.
@@ -232,8 +266,9 @@ async fn ws_register(State(state): State<AppState>, ws: WebSocketUpgrade) -> imp
     let cf = state.cf.clone();
     let auth_key = state.auth_public_key_b64.clone();
     let auth_issuer = state.auth_issuer.clone();
+    let ita = state.ita.clone();
     ws.on_upgrade(move |socket| {
-        handler::handle_ws_register(socket, registry, cf, auth_key, auth_issuer)
+        handler::handle_ws_register(socket, registry, cf, auth_key, auth_issuer, ita)
     })
 }
 

--- a/scripts/gcp-deploy.sh
+++ b/scripts/gcp-deploy.sh
@@ -30,6 +30,10 @@
 #                             Per-PR envs leave this unset.
 #   DD_GITHUB_CLIENT_SECRET — GitHub OAuth client secret (paired with above)
 #   DD_GITHUB_CALLBACK_URL  — OAuth callback, default https://{hostname}/auth/github/callback
+#   DD_ITA_API_KEY          — Intel Trust Authority API key. If unset,
+#                             ITA-backed registration is disabled.
+#   DD_ITA_URL              — Intel Trust Authority base URL
+#                             (default https://api.trustauthority.intel.com)
 #   EE_IMAGE_FAMILY         — easyenclave GCP image family
 #   EE_IMAGE_PROJECT        — project hosting the image
 #   DD_RELEASE_TAG          — GitHub release tag on devopsdefender/dd
@@ -60,6 +64,8 @@ fi
 DD_GITHUB_CLIENT_ID="${DD_GITHUB_CLIENT_ID:-}"
 DD_GITHUB_CLIENT_SECRET="${DD_GITHUB_CLIENT_SECRET:-}"
 DD_GITHUB_CALLBACK_URL="${DD_GITHUB_CALLBACK_URL:-https://${DD_HOSTNAME}/auth/github/callback}"
+DD_ITA_API_KEY="${DD_ITA_API_KEY:-}"
+DD_ITA_URL="${DD_ITA_URL:-https://api.trustauthority.intel.com}"
 
 # ── Build the workload spec ──────────────────────────────────────────────
 # Two boot workloads:
@@ -81,6 +87,8 @@ EE_BOOT_WORKLOADS=$(jq -c -n \
   --arg gh_client_id   "$DD_GITHUB_CLIENT_ID" \
   --arg gh_client_secret "$DD_GITHUB_CLIENT_SECRET" \
   --arg gh_callback    "$DD_GITHUB_CALLBACK_URL" \
+  --arg ita_api_key    "$DD_ITA_API_KEY" \
+  --arg ita_url        "$DD_ITA_URL" \
   '[
     {
       "github_release": {
@@ -116,6 +124,10 @@ EE_BOOT_WORKLOADS=$(jq -c -n \
           ("DD_GITHUB_CLIENT_ID="     + $gh_client_id),
           ("DD_GITHUB_CLIENT_SECRET=" + $gh_client_secret),
           ("DD_GITHUB_CALLBACK_URL="  + $gh_callback)
+        ] end)
+        + (if $ita_api_key == "" then [] else [
+          ("DD_ITA_API_KEY=" + $ita_api_key),
+          ("DD_ITA_URL="     + $ita_url)
         ] end)
       )
     }


### PR DESCRIPTION
## Summary

- `dd-client` now requests a TDX quote from easyenclave at registration (nonce-bound via Noise msg2) instead of sending `tdx_quote_b64: None`.
- `dd-register` verifies each quote against Intel Trust Authority's `/appraisal/v1/attest` endpoint, validates the returned JWT against ITA's JWKS, and asserts the quote's REPORT_DATA echoes the handshake nonce. Unverified registrations are rejected before any CF tunnel is provisioned.
- Fails closed: `dd-register` refuses to start without `DD_ITA_API_KEY` unless `DD_ALLOW_UNVERIFIED_REGISTRATIONS=1` is set (local dev only).
- Staging + production workflows already pipe `DD_ITA_API_KEY` through `gcp-deploy.sh` into the workload env.

## Known limitation

`policy_ids` is not enforced yet — we don't have captured MRTD/RTMR values for our easyenclave image. The handler logs measurements on every accepted registration so we can capture a known-good baseline from prod and pin a policy in a follow-up PR.

## Test plan

- [ ] CI build passes (`cargo test --workspace` on Linux — I couldn't verify `dd-register` locally because the pre-existing `libc::reboot` call only compiles on Linux)
- [ ] Merge triggers release → production-deploy; confirm `dd-register` startup log shows `ITA verification enabled`
- [ ] Confirm a registering agent logs `ITA verified — mrtd=... rtmr0=...` in `dd-register` serial console
- [ ] Negative test: temporarily point `DD_ITA_URL` at an invalid host → registration should log `ITA verification failed` and refuse to create the tunnel
- [ ] Capture the logged MRTD/RTMR values from a production registration → feeds the follow-up policy PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)