### PR TITLE
fix(ci): drop stale ollama-deploy.sh call from dd-relaunch.sh

### DIFF
--- a/scripts/dd-relaunch.sh
+++ b/scripts/dd-relaunch.sh
@@ -49,8 +49,5 @@ esac
 virsh start "$vm"
 echo "relaunched $vm against $CP"
 
-# Post-boot: deploy ollama as the example workload + pull a model +
-# run a sample query. Inherits DD_PAT + DD_ITA_API_KEY from env.
-# Fail loud (set -e) — the workflow turns red if this doesn't work.
-export CP_URL="$CP"
-./scripts/ollama-deploy.sh "$KIND"
+# ollama deploy + pull + query is driven from the workflow's HTTPS step
+# on ubuntu-latest, not here — see .github/workflows/local-agents.yml.


### PR DESCRIPTION
## Summary

- #115 moved ollama deploy+pull+query off SSH onto the workflow's HTTPS step (`.github/workflows/local-agents.yml`, step 2) but forgot to drop the old `./scripts/ollama-deploy.sh "$KIND"` call from `dd-relaunch.sh`.
- After a VM relaunch succeeds, that trailing call now fails with `line 25: 2: cp_url required` (ollama-deploy.sh now needs two args), turning a successful relaunch red.
- Run 24567959425 showed this: `Domain 'dd-local-prod' started` → `relaunched dd-local-prod` → exit 1 from the stale call.

## Test plan

- [ ] Merge → next Production Deploy triggers Local Agents → step 1 ends cleanly (~10 s) with `relaunched dd-local-prod` and no trailing error, step 2 runs ollama-deploy on ubuntu-latest against the fresh agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)