### PR TITLE
fix(ci): trigger Local Agents on script-only changes

### DIFF
--- a/.github/workflows/local-agents.yml
+++ b/.github/workflows/local-agents.yml
@@ -12,6 +12,17 @@ on:
   workflow_run:
     workflows: ["Release", "Production Deploy"]
     types: [completed]
+  # Script-only changes to the local-agent pipeline don't rebuild dd or
+  # redeploy the CP, so they don't cascade through Release → Production
+  # Deploy. Trigger here directly against prod so fixes to the relaunch
+  # / deploy scripts actually get exercised.
+  push:
+    branches: [main]
+    paths:
+      - "scripts/dd-relaunch.sh"
+      - "scripts/local-agents.sh"
+      - "scripts/ollama-deploy.sh"
+      - ".github/workflows/local-agents.yml"
   workflow_dispatch:
     inputs:
       kind:
@@ -35,6 +46,7 @@ jobs:
   relaunch:
     if: |
       github.event_name == 'workflow_dispatch'
+      || github.event_name == 'push'
       || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
@@ -51,7 +63,9 @@ jobs:
           if [ "$EVENT" = "workflow_dispatch" ]; then
             echo "kind=$DISPATCH_KIND" >> "$GITHUB_OUTPUT"
             echo "url=$DISPATCH_URL"   >> "$GITHUB_OUTPUT"
-          elif [ "$WF" = "Production Deploy" ]; then
+          elif [ "$EVENT" = "push" ] || [ "$WF" = "Production Deploy" ]; then
+            # push-to-main on local-agent scripts, or a prod CP redeploy
+            # → relaunch dd-local-prod against the live prod CP.
             echo "kind=prod" >> "$GITHUB_OUTPUT"
             echo "url=https://app.devopsdefender.com" >> "$GITHUB_OUTPUT"
           else

--- a/scripts/dd-relaunch.sh
+++ b/scripts/dd-relaunch.sh
@@ -49,8 +49,5 @@ esac
 virsh start "$vm"
 echo "relaunched $vm against $CP"
 
-# Post-boot: deploy ollama as the example workload + pull a model +
-# run a sample query. Inherits DD_PAT + DD_ITA_API_KEY from env.
-# Fail loud (set -e) — the workflow turns red if this doesn't work.
-export CP_URL="$CP"
-./scripts/ollama-deploy.sh "$KIND"
+# ollama deploy + pull + query is driven from the workflow's HTTPS step
+# on ubuntu-latest, not here — see .github/workflows/local-agents.yml.


### PR DESCRIPTION
## Summary

- Script-only changes to `scripts/{dd-relaunch,local-agents,ollama-deploy}.sh` don't rebuild dd or redeploy the CP, so they don't cascade through Release → Production Deploy → Local Agents.
- Add a `push` trigger on main for those scripts + this workflow file, and handle `push` in the `pick` step as `kind=prod` (same as Production Deploy).
- After this merges, the next edit to any local-agent script will auto-exercise end-to-end against prod.

## Test plan

- [ ] Merging this PR itself should fire Local Agents on main with kind=prod → relaunch dd-local-prod → ollama-deploy HTTPS step → llama3.1:8b sample response in log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)