### PR TITLE
fix(ollama-deploy): wait for tunnel DNS before POST /deploy

### DIFF
--- a/scripts/ollama-deploy.sh
+++ b/scripts/ollama-deploy.sh
@@ -59,6 +59,19 @@ if [ -z "$agent_host" ] || [ "$agent_host" = "null" ]; then
 fi
 echo "  agent: https://$agent_host"
 
+# Wait for Cloudflare's DNS record for this tunnel hostname to
+# propagate to the runner's resolver. The CP's /api/agents returns
+# the hostname as soon as CF's API accepts the CNAME, but global DNS
+# can lag 30–120 s behind. curl (6) here = host not yet resolvable.
+echo "  waiting for DNS on $agent_host..."
+for i in $(seq 1 30); do
+  if getent hosts "$agent_host" >/dev/null 2>&1; then
+    echo "  DNS resolved"
+    break
+  fi
+  sleep 5
+done
+
 agent() { curl -fsS --max-time 120 "${AUTH[@]}" "https://$agent_host$1" "${@:2}"; }
 
 # 2. Deploy ollama workload. EE returns a workload id. Pin to v0.2.8 —


### PR DESCRIPTION
## Summary

- CP's `/api/agents` returns the hostname as soon as CF's API accepts the tunnel CNAME, but global DNS lags 30–120 s behind.
- `ollama-deploy.sh` POSTed `/deploy` immediately and hit curl (6) "Could not resolve host" → run red even though VM + tunnel are both fine.
- Add a `getent`-based DNS readiness poll (≤ 2.5 min) between agent discovery and the first HTTPS call.

Reproduced on runs `24568308200` (push trigger) and its rerun — both failed at POST `/deploy` because the fresh agent's DNS hadn't propagated yet.

## Test plan

- [ ] Merge → push triggers Local Agents → DNS wait logs `DNS resolved` → `/deploy` succeeds → ollama pull + query.

🤖 Generated with [Claude Code](https://claude.com/claude-code)