### PR TITLE
fix(ollama-deploy): drive ollama via its CLI, EE guest has no curl

### DIFF
--- a/scripts/ollama-deploy.sh
+++ b/scripts/ollama-deploy.sh
@@ -90,13 +90,15 @@ echo "  POST /deploy..."
 deploy_resp=$(agent /deploy -H 'Content-Type: application/json' -d "$SPEC")
 echo "  deploy: $deploy_resp"
 
-# 3. Wait for ollama to listen. Use /exec to probe inside the guest.
-echo "  waiting for ollama on 127.0.0.1:11434..."
+# 3. Wait for ollama to be ready. `ollama list` talks to the local
+# server over 127.0.0.1:11434 and exits 0 once it's up — no need for
+# a separate HTTP client in the guest (EE's busybox has no curl).
+echo "  waiting for ollama to be ready..."
 for i in $(seq 1 60); do
   resp=$(agent /exec -H 'Content-Type: application/json' \
-    -d '{"cmd":["/bin/busybox","sh","-c","curl -fsS http://127.0.0.1:11434/api/tags && echo OK || echo NO"],"timeout_secs":10}' \
+    -d '{"cmd":["/var/lib/easyenclave/bin/ollama","list"],"timeout_secs":10}' \
     2>/dev/null || true)
-  if echo "$resp" | grep -q OK; then
+  if echo "$resp" | jq -e '.exit_code == 0' >/dev/null 2>&1; then
     echo "  ollama responding"
     break
   fi
@@ -112,17 +114,18 @@ pull_resp=$(agent /exec -H 'Content-Type: application/json' \
   }')")
 echo "  pull: $(echo "$pull_resp" | jq -r '.stdout // "(no stdout)"' | tail -5)"
 
-# 5. Sample query.
+# 5. Sample query via `ollama run` — pipes the prompt to the CLI,
+# which talks to the local server and streams the completion to
+# stdout. Keeps the whole pipeline self-contained in the ollama
+# binary (no curl in the EE guest).
 echo "  querying $MODEL..."
 query_resp=$(agent /exec -H 'Content-Type: application/json' \
   -d "$(jq -c -n --arg m "$MODEL" '{
-    cmd:["/bin/busybox","sh","-c",
-      "curl -fsS http://127.0.0.1:11434/api/generate -H '"'"'Content-Type: application/json'"'"' -d "
-        + ("\"{\\\"model\\\":\\\"" + $m + "\\\",\\\"prompt\\\":\\\"write one sentence about trusted execution environments\\\",\\\"stream\\\":false}\"")
-    ],
+    cmd:["/var/lib/easyenclave/bin/ollama","run",$m,
+         "write one sentence about trusted execution environments"],
     timeout_secs:120
   }')")
-response=$(echo "$query_resp" | jq -r '.stdout // "{}"' | jq -r '.response // ""')
+response=$(echo "$query_resp" | jq -r '.stdout // ""')
 if [ -z "$response" ]; then
   echo "ERROR: empty inference response"
   echo "raw: $query_resp" | head -c 500


### PR DESCRIPTION
## Summary

EE's busybox sh doesn't ship curl as a standalone binary, so:

- The readiness probe (`curl ... /api/tags && echo OK`) silently failed for the full 5-min loop — we proceeded to pull only because the loop timed out.
- The sample query exited with `sh: curl: not found` (run `24568563608`).

Replace both with ollama CLI calls:
- readiness: `ollama list` (talks to local :11434, exits 0 when ready)
- query: `ollama run $MODEL "<prompt>"` (streams completion to stdout)

Keeps everything inside the single ollama binary — no extra tools in the guest.

## Test plan

- [ ] Merge → push triggers Local Agents → readiness loop exits with `ollama responding` in seconds, not 5 min → query returns a one-sentence TEE description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)