### PR TITLE
chore(ci): drop workflow path filters except README

### DIFF
--- a/.github/workflows/local-agents.yml
+++ b/.github/workflows/local-agents.yml
@@ -12,17 +12,13 @@ on:
   workflow_run:
     workflows: ["Release", "Production Deploy"]
     types: [completed]
-  # Script-only changes to the local-agent pipeline don't rebuild dd or
-  # redeploy the CP, so they don't cascade through Release → Production
-  # Deploy. Trigger here directly against prod so fixes to the relaunch
-  # / deploy scripts actually get exercised.
+  # Every non-README push to main also fires a prod relaunch directly,
+  # so fixes to the relaunch / deploy scripts get exercised even when
+  # they don't cascade through Release → Production Deploy.
   push:
     branches: [main]
-    paths:
-      - "scripts/dd-relaunch.sh"
-      - "scripts/local-agents.sh"
-      - "scripts/ollama-deploy.sh"
-      - ".github/workflows/local-agents.yml"
+    paths-ignore:
+      - "README.md"
   workflow_dispatch:
     inputs:
       kind:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,19 +13,11 @@ on:
   push:
     branches: [main]
     tags: ['v*']
-    paths:
-      - "src/**"
-      - "Cargo.toml"
-      - "Cargo.lock"
-      - "scripts/gcp-deploy.sh"
-      - ".github/workflows/release.yml"
+    paths-ignore:
+      - "README.md"
   pull_request:
-    paths:
-      - "src/**"
-      - "Cargo.toml"
-      - "Cargo.lock"
-      - "scripts/gcp-deploy.sh"
-      - ".github/workflows/release.yml"
+    paths-ignore:
+      - "README.md"
 
 concurrency:
   group: dd-release-${{ github.ref }}


### PR DESCRIPTION
## Summary

Replace narrow allowlists with `paths-ignore: [README.md]` in:
- `.github/workflows/release.yml` (push + pull_request)
- `.github/workflows/local-agents.yml` (push)

Every allowlist extension I did in the last hour was whack-a-mole against some file being invisible to `Release → Production Deploy → Local Agents`. Pure-docs README is the only thing we don't want to rebuild for.

## Side effect

On a main push that changes scripts, Local Agents will now fire twice:
1. Its own `push` trigger (kind=prod, immediate).
2. The cascade: Release → Production Deploy → Local Agents `workflow_run` (kind=prod).

Both converge on the same end state. We can collapse later if the duplication becomes annoying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)