### PR TITLE
feat(ollama-deploy): run ollama + OpenClaw as podman containers

### DIFF
--- a/scripts/local-agents.sh
+++ b/scripts/local-agents.sh
@@ -165,6 +165,27 @@ render_domain_xml() {
   # sharing the same path collide with "Device or resource busy".
   sed -i "s|/var/log/ee-local\\.log|/var/log/ee-local-$name.log|g" "$out"
 
+  # Size the VM for the workload. Base easyenclave-local is 4 GiB /
+  # 2 vCPU — fine for a bare agent, undersized for podman + ollama
+  # + the openclaw gateway on a 900 MB container image. Host has
+  # 243 GiB / 64 cores, so we can be generous.
+  #
+  #   prod:    32 GiB / 16 vCPU  (GPU handles the model; host RAM
+  #                               for podman, openclaw, image pull
+  #                               scratch, model load spill)
+  #   preview: 16 GiB / 8 vCPU   (CPU-only inference needs cores;
+  #                               qwen2.5:0.5b + 64k ctx + gateway)
+  if [ "$with_gpu" = "yes" ]; then
+    local mem_kib=33554432  # 32 GiB
+    local vcpus=16
+  else
+    local mem_kib=16777216  # 16 GiB
+    local vcpus=8
+  fi
+  sed -i -E "s|<memory unit='KiB'>[0-9]+</memory>|<memory unit='KiB'>$mem_kib</memory>|" "$out"
+  sed -i -E "s|<currentMemory unit='KiB'>[0-9]+</currentMemory>|<currentMemory unit='KiB'>$mem_kib</currentMemory>|" "$out"
+  sed -i -E "s|<vcpu placement='static'>[0-9]+</vcpu>|<vcpu placement='static'>$vcpus</vcpu>|" "$out"
+
   # Wire QEMU's tdx-guest to the host's QGS unix socket so the guest's
   # TDVMCALL for a quote actually reaches Intel's quote-generation
   # service. Without this, configfs-tsm `outblob` returns 0 bytes →

--- a/scripts/local-agents.sh
+++ b/scripts/local-agents.sh
@@ -165,28 +165,6 @@ render_domain_xml() {
   # sharing the same path collide with "Device or resource busy".
   sed -i "s|/var/log/ee-local\\.log|/var/log/ee-local-$name.log|g" "$out"
 
-  # Size the VM for the workload. Base easyenclave-local is 4 GiB / 2
-  # vCPUs — fine for a bare agent, undersized for podman + ollama +
-  # the openclaw gateway. OpenClaw's own docs recommend a 64k-token
-  # context window for local models, and qwen3.5 / gemma4 want
-  # 11–16 GB VRAM; our preview runs on CPU so it needs that headroom
-  # as host RAM instead.
-  #
-  #   prod:    16 GiB / 8 vCPU  (GPU carries the model; host RAM is
-  #                              for podman + openclaw + scratch)
-  #   preview: 8 GiB / 4 vCPU   (CPU-only inference; qwen2.5:0.5b
-  #                              + 64k ctx + gateway fits)
-  if [ "$with_gpu" = "yes" ]; then
-    local mem_kib=16777216  # 16 GiB
-    local vcpus=8
-  else
-    local mem_kib=8388608   # 8 GiB
-    local vcpus=4
-  fi
-  sed -i -E "s|<memory unit='KiB'>[0-9]+</memory>|<memory unit='KiB'>$mem_kib</memory>|" "$out"
-  sed -i -E "s|<currentMemory unit='KiB'>[0-9]+</currentMemory>|<currentMemory unit='KiB'>$mem_kib</currentMemory>|" "$out"
-  sed -i -E "s|<vcpu placement='static'>[0-9]+</vcpu>|<vcpu placement='static'>$vcpus</vcpu>|" "$out"
-
   # Wire QEMU's tdx-guest to the host's QGS unix socket so the guest's
   # TDVMCALL for a quote actually reaches Intel's quote-generation
   # service. Without this, configfs-tsm `outblob` returns 0 bytes →

--- a/scripts/local-agents.sh
+++ b/scripts/local-agents.sh
@@ -165,6 +165,27 @@ render_domain_xml() {
   # sharing the same path collide with "Device or resource busy".
   sed -i "s|/var/log/ee-local\\.log|/var/log/ee-local-$name.log|g" "$out"
 
+  # Size the VM for the workload. Base easyenclave-local is 4 GiB /
+  # 2 vCPU — fine for a bare agent, undersized for podman + ollama
+  # + the openclaw gateway on a 900 MB container image. Host has
+  # 243 GiB / 64 cores, so we can be generous.
+  #
+  #   prod:    32 GiB / 16 vCPU  (GPU handles the model; host RAM
+  #                               for podman, openclaw, image pull
+  #                               scratch, model load spill)
+  #   preview: 16 GiB / 8 vCPU   (CPU-only inference; qwen2.5:0.5b
+  #                               + 64k ctx + gateway)
+  if [ "$with_gpu" = "yes" ]; then
+    local mem_kib=33554432  # 32 GiB
+    local vcpus=16
+  else
+    local mem_kib=16777216  # 16 GiB
+    local vcpus=8
+  fi
+  sed -i -E "s|<memory unit='KiB'>[0-9]+</memory>|<memory unit='KiB'>$mem_kib</memory>|" "$out"
+  sed -i -E "s|<currentMemory unit='KiB'>[0-9]+</currentMemory>|<currentMemory unit='KiB'>$mem_kib</currentMemory>|" "$out"
+  sed -i -E "s|<vcpu placement='static'>[0-9]+</vcpu>|<vcpu placement='static'>$vcpus</vcpu>|" "$out"
+
   # Wire QEMU's tdx-guest to the host's QGS unix socket so the guest's
   # TDVMCALL for a quote actually reaches Intel's quote-generation
   # service. Without this, configfs-tsm `outblob` returns 0 bytes →

--- a/scripts/local-agents.sh
+++ b/scripts/local-agents.sh
@@ -165,27 +165,6 @@ render_domain_xml() {
   # sharing the same path collide with "Device or resource busy".
   sed -i "s|/var/log/ee-local\\.log|/var/log/ee-local-$name.log|g" "$out"
 
-  # Size the VM for the workload. Base easyenclave-local is 4 GiB /
-  # 2 vCPU — fine for a bare agent, undersized for podman + ollama
-  # + the openclaw gateway on a 900 MB container image. Host has
-  # 243 GiB / 64 cores, so we can be generous.
-  #
-  #   prod:    32 GiB / 16 vCPU  (GPU handles the model; host RAM
-  #                               for podman, openclaw, image pull
-  #                               scratch, model load spill)
-  #   preview: 16 GiB / 8 vCPU   (CPU-only inference needs cores;
-  #                               qwen2.5:0.5b + 64k ctx + gateway)
-  if [ "$with_gpu" = "yes" ]; then
-    local mem_kib=33554432  # 32 GiB
-    local vcpus=16
-  else
-    local mem_kib=16777216  # 16 GiB
-    local vcpus=8
-  fi
-  sed -i -E "s|<memory unit='KiB'>[0-9]+</memory>|<memory unit='KiB'>$mem_kib</memory>|" "$out"
-  sed -i -E "s|<currentMemory unit='KiB'>[0-9]+</currentMemory>|<currentMemory unit='KiB'>$mem_kib</currentMemory>|" "$out"
-  sed -i -E "s|<vcpu placement='static'>[0-9]+</vcpu>|<vcpu placement='static'>$vcpus</vcpu>|" "$out"
-
   # Wire QEMU's tdx-guest to the host's QGS unix socket so the guest's
   # TDVMCALL for a quote actually reaches Intel's quote-generation
   # service. Without this, configfs-tsm `outblob` returns 0 bytes →

--- a/scripts/local-agents.sh
+++ b/scripts/local-agents.sh
@@ -165,6 +165,28 @@ render_domain_xml() {
   # sharing the same path collide with "Device or resource busy".
   sed -i "s|/var/log/ee-local\\.log|/var/log/ee-local-$name.log|g" "$out"
 
+  # Size the VM for the workload. Base easyenclave-local is 4 GiB / 2
+  # vCPUs — fine for a bare agent, undersized for podman + ollama +
+  # the openclaw gateway. OpenClaw's own docs recommend a 64k-token
+  # context window for local models, and qwen3.5 / gemma4 want
+  # 11–16 GB VRAM; our preview runs on CPU so it needs that headroom
+  # as host RAM instead.
+  #
+  #   prod:    16 GiB / 8 vCPU  (GPU carries the model; host RAM is
+  #                              for podman + openclaw + scratch)
+  #   preview: 8 GiB / 4 vCPU   (CPU-only inference; qwen2.5:0.5b
+  #                              + 64k ctx + gateway fits)
+  if [ "$with_gpu" = "yes" ]; then
+    local mem_kib=16777216  # 16 GiB
+    local vcpus=8
+  else
+    local mem_kib=8388608   # 8 GiB
+    local vcpus=4
+  fi
+  sed -i -E "s|<memory unit='KiB'>[0-9]+</memory>|<memory unit='KiB'>$mem_kib</memory>|" "$out"
+  sed -i -E "s|<currentMemory unit='KiB'>[0-9]+</currentMemory>|<currentMemory unit='KiB'>$mem_kib</currentMemory>|" "$out"
+  sed -i -E "s|<vcpu placement='static'>[0-9]+</vcpu>|<vcpu placement='static'>$vcpus</vcpu>|" "$out"
+
   # Wire QEMU's tdx-guest to the host's QGS unix socket so the guest's
   # TDVMCALL for a quote actually reaches Intel's quote-generation
   # service. Without this, configfs-tsm `outblob` returns 0 bytes →

--- a/scripts/ollama-deploy.sh
+++ b/scripts/ollama-deploy.sh
@@ -87,13 +87,16 @@ agent() { curl -fsS --max-time 300 "${AUTH[@]}" "https://$agent_host$1" "${@:2}"
 # ── 3. Fetch podman-static (fetch-only DD workload) ────────────────
 # Tarball unpacks to /var/lib/easyenclave/bin/podman-linux-amd64/
 # with usr/local/bin/{podman,crun,conmon,netavark,...}.
+# NOTE: omit `tag` — EE treats `tag: null` as "GET /releases/latest"
+# (the real newest release), while `tag: "latest"` is a literal tag
+# lookup and 404s on repos like mgoltzsche/podman-static that version
+# their tags as v5.7.1 rather than with a rolling "latest" ref.
 echo "  POST /deploy podman-static..."
 A_SPEC=$(jq -c -n '{
   app_name: "podman-static",
   github_release: {
     repo: "mgoltzsche/podman-static",
-    asset: "podman-linux-amd64.tar.gz",
-    tag: "latest"
+    asset: "podman-linux-amd64.tar.gz"
   }
 }')
 agent /deploy -H 'Content-Type: application/json' -d "$A_SPEC" | jq -c '.' || true

--- a/scripts/ollama-deploy.sh
+++ b/scripts/ollama-deploy.sh
@@ -114,19 +114,37 @@ for i in $(seq 1 60); do
   sleep 5
 done
 
-# ── 4. Bootstrap: flatten bin dir + write containers.conf ──────────
-# Rootful podman defaults to the systemd cgroup manager, which we
-# don't have. Override to cgroupfs. crun is the default runtime in
-# the mgoltzsche tarball; naming it explicitly is belt-and-braces.
-echo "  bootstrapping /etc/containers/containers.conf + flattening /var/lib/easyenclave/bin..."
+# ── 4. Bootstrap: stage podman's helper binaries + containers.conf ─
+# mgoltzsche's tarball layout:
+#   usr/local/bin/                podman, crun, runc, fuse-overlayfs,
+#                                 fusermount3, pasta, pasta.avx2
+#   usr/local/lib/podman/         conmon, netavark, aardvark-dns,
+#                                 rootlessport, catatonit
+#   usr/local/libexec/podman/     quadlet
+#   etc/containers/               containers.conf, policy.json,
+#                                 registries.conf, seccomp.json,
+#                                 storage.conf (tarball defaults)
+# Podman's hardcoded conmon search list includes /usr/libexec/podman/
+# but not /var/lib/easyenclave/bin/, so we symlink conmon to the
+# former. Rootful podman defaults to the systemd cgroup manager,
+# which this guest doesn't have — override to cgroupfs in
+# containers.conf. Use printf (not a heredoc) because busybox sh's
+# `<<EOF` is fragile when piped as a single -c string through jq.
+echo "  bootstrapping podman (conmon + containers.conf)..."
 bootstrap_sh='set -e
-cp -f /var/lib/easyenclave/bin/podman-linux-amd64/usr/local/bin/* /var/lib/easyenclave/bin/
+SRC=/var/lib/easyenclave/bin/podman-linux-amd64
+cp -f $SRC/usr/local/bin/* /var/lib/easyenclave/bin/
+mkdir -p /usr/libexec/podman
+cp -f $SRC/usr/local/lib/podman/conmon /usr/libexec/podman/conmon
+# netavark + aardvark-dns: CNI plugins. We run --net=host so these
+# should be unused, but podman still probes for them during setup.
+cp -f $SRC/usr/local/lib/podman/netavark /var/lib/easyenclave/bin/ 2>/dev/null || true
+cp -f $SRC/usr/local/lib/podman/aardvark-dns /var/lib/easyenclave/bin/ 2>/dev/null || true
 mkdir -p /etc/containers
-cat > /etc/containers/containers.conf <<EOF
-[engine]
-cgroup_manager = "cgroupfs"
-runtime = "crun"
-EOF
+printf "[engine]\ncgroup_manager = \"cgroupfs\"\nruntime = \"crun\"\n" > /etc/containers/containers.conf
+cp -f $SRC/etc/containers/policy.json /etc/containers/ 2>/dev/null || true
+cp -f $SRC/etc/containers/registries.conf /etc/containers/ 2>/dev/null || true
+cp -f $SRC/etc/containers/storage.conf /etc/containers/ 2>/dev/null || true
 echo podman-bootstrap: ok'
 boot_resp=$(agent /exec -H 'Content-Type: application/json' \
   -d "$(jq -c -n --arg s "$bootstrap_sh" '{cmd:["/bin/busybox","sh","-c",$s],timeout_secs:30}')")

--- a/scripts/ollama-deploy.sh
+++ b/scripts/ollama-deploy.sh
@@ -197,21 +197,52 @@ OPENCLAW_SPEC=$(jq -c -n --arg m "$MODEL" '{
 }')
 agent /deploy -H 'Content-Type: application/json' -d "$OPENCLAW_SPEC" | jq -c '.' || true
 
-# ── 9. Confirm openclaw is in the agent's deployment list ──────────
+# ── 9. Confirm openclaw is registered and talking to us ────────────
+# Two probes:
+#   a) EE lists `openclaw` in /health — proves the workload was
+#      accepted (weak — flips on fork, before npm install finishes).
+#   b) `openclaw plugins list` inside the container exits 0 — proves
+#      the gateway daemon is actually responsive. That subcommand
+#      goes through the running gateway, so an unresponsive or
+#      still-installing openclaw fails it. Strongest documented probe
+#      short of an HTTP port (which the docs don't publish).
 echo "  confirming openclaw workload is registered..."
 for i in $(seq 1 30); do
   list=$(agent /health 2>/dev/null || true)
   if echo "$list" | jq -e '.deployments // [] | index("openclaw")' >/dev/null 2>&1; then
-    echo "  openclaw: deployed"
+    echo "  openclaw: registered"
     break
   fi
   sleep 5
 done
 
+# First launch can take a while because of the npm install of
+# @ollama/openclaw + the web-search/fetch plugin. 5 min ceiling.
+echo "  waiting for openclaw gateway to respond to CLI..."
+openclaw_ok=0
+for i in $(seq 1 60); do
+  resp=$(agent /exec -H 'Content-Type: application/json' \
+    -d '{"cmd":["/var/lib/easyenclave/bin/podman","exec","ollama","openclaw","plugins","list"],"timeout_secs":15}' \
+    2>/dev/null || true)
+  if echo "$resp" | jq -e '.exit_code == 0' >/dev/null 2>&1; then
+    echo "  openclaw: responding"
+    echo "  plugins:"
+    echo "$resp" | jq -r '.stdout // ""' | sed 's/^/    /'
+    openclaw_ok=1
+    break
+  fi
+  sleep 5
+done
+if [ "$openclaw_ok" = "0" ]; then
+  echo "  WARNING: openclaw plugins list never returned — gateway may still be installing"
+  echo "  last /exec response:"
+  echo "$resp" | jq -c '.' | head -c 500
+fi
+
 echo
 echo "=== agent fleet summary ==="
 echo "  agent:    https://$agent_host"
 echo "  model:    $MODEL"
-echo "  ollama:   podman container 'ollama' on host net"
-echo "  openclaw: ollama launch openclaw (subcommand)"
+echo "  ollama:   podman container 'ollama' on host net, :11434"
+echo "  openclaw: ollama launch openclaw — plugins listing responded"
 echo "==========================="

--- a/scripts/ollama-deploy.sh
+++ b/scripts/ollama-deploy.sh
@@ -1,23 +1,28 @@
 #!/usr/bin/env bash
-# ollama-deploy.sh — deploy ollama into one local agent VM, pull a
-# model, and run a sample query to confirm inference works.
+# ollama-deploy.sh — run ollama + OpenClaw inside a DD agent VM as
+# podman containers. No ollama binary on the guest rootfs (that's
+# dynamically linked and fails on EE's busybox rootfs with
+# `libstdc++.so.6: cannot open shared object file`). Instead:
 #
-# Invoked by dd-relaunch.sh after `virsh start` succeeds. Requires
-# DD_PAT and DD_ITA_API_KEY in env (same ones the relaunch uses).
+#   1. Fetch static podman (mgoltzsche/podman-static tarball) as a
+#      fetch-only DD workload.
+#   2. One-shot bootstrap via /exec — flatten the tarball's nested
+#      bin dir into /var/lib/easyenclave/bin and write a minimal
+#      /etc/containers/containers.conf (cgroup_manager=cgroupfs so
+#      we don't need systemd).
+#   3. Deploy the ollama container as a long-running workload
+#      (podman run --net=host ...). Prod also passes the three
+#      nvidia device nodes for H100 access.
+#   4. Pull the right-sized model via `podman exec ollama ollama pull`.
+#   5. Launch OpenClaw (a bridge from messaging apps to coding
+#      agents; subcommand of ollama, npm-installed on first run) as
+#      a second long-running workload using the same container.
 #
-#   ollama-deploy.sh <kind>
-#     kind: prod | preview
+#   ollama-deploy.sh <kind> <cp_url>
+#     kind:    prod | preview
+#     cp_url:  https://app.devopsdefender.com | https://pr-N.devopsdefender.com
 #
-# Model selection:
-#   prod    — llama3.1:8b (~4.7 GB) runs on the H100.
-#   preview — qwen2.5:0.5b (~400 MB) runs on CPU.
-#
-# End-to-end:
-#   1. Poll the CP's /api/agents for our vm_name; pick up its hostname.
-#   2. POST ollama workload spec to https://{hostname}/deploy.
-#   3. Wait until ollama listens on 127.0.0.1:11434 (polled via /exec).
-#   4. ollama pull <model> via /exec.
-#   5. ollama query via /exec; echo the response.
+# Requires DD_PAT in the environment (the workflow's GITHUB_TOKEN).
 
 set -euo pipefail
 
@@ -26,8 +31,17 @@ CP_URL="${2?cp_url required}"
 : "${DD_PAT?}"
 
 case "$KIND" in
-  prod)    MODEL="llama3.1:8b" ;;
-  preview) MODEL="qwen2.5:0.5b" ;;
+  prod)
+    MODEL="llama3.1:8b"
+    # GPU passthrough. /dev/nvidia-uvm appears once CUDA is touched;
+    # the nv-insmod boot workload in scripts/local-agents.sh loads
+    # the kernel module, so the device nodes exist by this point.
+    GPU_FLAGS='["--device=/dev/nvidia0","--device=/dev/nvidiactl","--device=/dev/nvidia-uvm"]'
+    ;;
+  preview)
+    MODEL="qwen2.5:0.5b"
+    GPU_FLAGS='[]'
+    ;;
   *) echo "unknown kind: $KIND" >&2; exit 2 ;;
 esac
 
@@ -36,10 +50,9 @@ AUTH=(-H "Authorization: Bearer $DD_PAT")
 
 echo "== ollama-deploy $VM_NAME (model=$MODEL, cp=$CP_URL) =="
 
-# 1. Discover agent hostname via CP's /api/agents. Require an entry
-# whose last_seen is AFTER this script started — otherwise we'll
-# pick up a stale entry from a prior VM generation whose tunnel we
-# just killed by destroying the VM.
+# ── 1. Discover the fresh agent registration on the CP ─────────────
+# last_seen > started_at_iso filters out stale entries from the VM
+# generation we just destroyed during `virsh destroy`.
 started_at_iso="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 echo "  waiting for a fresh ${VM_NAME} registration (last_seen > ${started_at_iso})"
 agent_host=""
@@ -59,10 +72,7 @@ if [ -z "$agent_host" ] || [ "$agent_host" = "null" ]; then
 fi
 echo "  agent: https://$agent_host"
 
-# Wait for Cloudflare's DNS record for this tunnel hostname to
-# propagate to the runner's resolver. The CP's /api/agents returns
-# the hostname as soon as CF's API accepts the CNAME, but global DNS
-# can lag 30–120 s behind. curl (6) here = host not yet resolvable.
+# ── 2. Wait for Cloudflare DNS to propagate ────────────────────────
 echo "  waiting for DNS on $agent_host..."
 for i in $(seq 1 30); do
   if getent hosts "$agent_host" >/dev/null 2>&1; then
@@ -72,66 +82,136 @@ for i in $(seq 1 30); do
   sleep 5
 done
 
-agent() { curl -fsS --max-time 120 "${AUTH[@]}" "https://$agent_host$1" "${@:2}"; }
+agent() { curl -fsS --max-time 300 "${AUTH[@]}" "https://$agent_host$1" "${@:2}"; }
 
-# 2. Deploy ollama workload. EE returns a workload id. Pin to v0.2.8 —
-# last release with a bare-binary asset (later versions ship tar.zst
-# which EE's github_release source doesn't decompress).
-SPEC=$(jq -c -n '{
-  app_name:"ollama",
-  github_release:{repo:"ollama/ollama",asset:"ollama-linux-amd64",rename:"ollama",tag:"v0.2.8"},
-  cmd:["ollama","serve"],
-  env:[
-    "OLLAMA_HOST=127.0.0.1:11434",
-    "OLLAMA_MODELS=/var/lib/easyenclave/ollama"
-  ]
+# ── 3. Fetch podman-static (fetch-only DD workload) ────────────────
+# Tarball unpacks to /var/lib/easyenclave/bin/podman-linux-amd64/
+# with usr/local/bin/{podman,crun,conmon,netavark,...}.
+echo "  POST /deploy podman-static..."
+A_SPEC=$(jq -c -n '{
+  app_name: "podman-static",
+  github_release: {
+    repo: "mgoltzsche/podman-static",
+    asset: "podman-linux-amd64.tar.gz",
+    tag: "latest"
+  }
 }')
-echo "  POST /deploy..."
-deploy_resp=$(agent /deploy -H 'Content-Type: application/json' -d "$SPEC")
-echo "  deploy: $deploy_resp"
+agent /deploy -H 'Content-Type: application/json' -d "$A_SPEC" | jq -c '.' || true
 
-# 3. Wait for ollama to be ready. `ollama list` talks to the local
-# server over 127.0.0.1:11434 and exits 0 once it's up — no need for
-# a separate HTTP client in the guest (EE's busybox has no curl).
-echo "  waiting for ollama to be ready..."
+echo "  waiting for podman binary to appear..."
+podman_path="/var/lib/easyenclave/bin/podman-linux-amd64/usr/local/bin/podman"
 for i in $(seq 1 60); do
   resp=$(agent /exec -H 'Content-Type: application/json' \
-    -d '{"cmd":["/var/lib/easyenclave/bin/ollama","list"],"timeout_secs":10}' \
+    -d "$(jq -c -n --arg p "$podman_path" '{cmd:["/bin/busybox","sh","-c",("test -x " + $p + " && echo found")],timeout_secs:5}')" \
     2>/dev/null || true)
-  if echo "$resp" | jq -e '.exit_code == 0' >/dev/null 2>&1; then
-    echo "  ollama responding"
+  if echo "$resp" | grep -q found; then
+    echo "  podman unpacked"
     break
   fi
   sleep 5
 done
 
-# 4. Pull the model. Ollama streams progress; we just wait for completion.
+# ── 4. Bootstrap: flatten bin dir + write containers.conf ──────────
+# Rootful podman defaults to the systemd cgroup manager, which we
+# don't have. Override to cgroupfs. crun is the default runtime in
+# the mgoltzsche tarball; naming it explicitly is belt-and-braces.
+echo "  bootstrapping /etc/containers/containers.conf + flattening /var/lib/easyenclave/bin..."
+bootstrap_sh='set -e
+cp -f /var/lib/easyenclave/bin/podman-linux-amd64/usr/local/bin/* /var/lib/easyenclave/bin/
+mkdir -p /etc/containers
+cat > /etc/containers/containers.conf <<EOF
+[engine]
+cgroup_manager = "cgroupfs"
+runtime = "crun"
+EOF
+echo podman-bootstrap: ok'
+boot_resp=$(agent /exec -H 'Content-Type: application/json' \
+  -d "$(jq -c -n --arg s "$bootstrap_sh" '{cmd:["/bin/busybox","sh","-c",$s],timeout_secs:30}')")
+echo "  bootstrap: $(echo "$boot_resp" | jq -r '.stdout // .stderr // ""' | tail -3)"
+
+# ── 5. Launch the ollama container (long-running workload) ─────────
+# --net=host  : ollama listens on guest's 127.0.0.1:11434.
+# --name      : so we can `podman exec ollama ...` by name.
+# --cgroup-manager=cgroupfs: matches containers.conf, still required
+#               on the command line because podman doesn't always
+#               pick it up from the engine section when invoked
+#               outside systemd.
+# Volume      : /var/lib/easyenclave/ollama is the persistent vdc
+#               ext4 disk (mounted by the mount-models boot workload
+#               in local-agents.sh); doubles as ollama's model cache
+#               and openclaw's npm prefix.
+echo "  POST /deploy ollama container..."
+OLLAMA_SPEC=$(jq -c -n --argjson gpu "$GPU_FLAGS" '{
+  app_name: "ollama",
+  cmd: ([
+    "/var/lib/easyenclave/bin/podman", "run",
+    "--rm", "--name", "ollama",
+    "--net=host",
+    "--cgroup-manager=cgroupfs"
+  ] + $gpu + [
+    "-v", "/var/lib/easyenclave/ollama:/root/.ollama",
+    "-e", "OLLAMA_HOST=127.0.0.1:11434",
+    "docker.io/ollama/ollama:latest",
+    "serve"
+  ])
+}')
+agent /deploy -H 'Content-Type: application/json' -d "$OLLAMA_SPEC" | jq -c '.' || true
+
+# ── 6. Wait for ollama HTTP to come up inside the container ────────
+# `podman exec ollama ollama list` exits 0 once the server is ready.
+# First run has to pull ~900 MB of container image, so allow plenty.
+echo "  waiting for ollama to be ready (first run pulls the image)..."
+for i in $(seq 1 120); do
+  resp=$(agent /exec -H 'Content-Type: application/json' \
+    -d '{"cmd":["/var/lib/easyenclave/bin/podman","exec","ollama","ollama","list"],"timeout_secs":15}' \
+    2>/dev/null || true)
+  if echo "$resp" | jq -e '.exit_code == 0' >/dev/null 2>&1; then
+    echo "  ollama responding"
+    break
+  fi
+  sleep 10
+done
+
+# ── 7. Pull the model ──────────────────────────────────────────────
 echo "  pulling $MODEL (this can take a few minutes)..."
 pull_resp=$(agent /exec -H 'Content-Type: application/json' \
   -d "$(jq -c -n --arg m "$MODEL" '{
-    cmd:["/var/lib/easyenclave/bin/ollama","pull",$m],
-    timeout_secs:900
+    cmd:["/var/lib/easyenclave/bin/podman","exec","ollama","ollama","pull",$m],
+    timeout_secs:1800
   }')")
-echo "  pull: $(echo "$pull_resp" | jq -r '.stdout // "(no stdout)"' | tail -5)"
+echo "  pull: $(echo "$pull_resp" | jq -r '.stdout // "(no stdout)"' | tail -3)"
 
-# 5. Sample query via `ollama run` — pipes the prompt to the CLI,
-# which talks to the local server and streams the completion to
-# stdout. Keeps the whole pipeline self-contained in the ollama
-# binary (no curl in the EE guest).
-echo "  querying $MODEL..."
-query_resp=$(agent /exec -H 'Content-Type: application/json' \
-  -d "$(jq -c -n --arg m "$MODEL" '{
-    cmd:["/var/lib/easyenclave/bin/ollama","run",$m,
-         "write one sentence about trusted execution environments"],
-    timeout_secs:120
-  }')")
-response=$(echo "$query_resp" | jq -r '.stdout // ""')
-if [ -z "$response" ]; then
-  echo "ERROR: empty inference response"
-  echo "raw: $query_resp" | head -c 500
-  exit 1
-fi
+# ── 8. Launch OpenClaw ─────────────────────────────────────────────
+# `ollama launch openclaw` installs via npm on first run if missing
+# and then stays foreground, so we register it as a second long-
+# running workload. --yes accepts the install prompt non-interactively.
+echo "  POST /deploy openclaw..."
+OPENCLAW_SPEC=$(jq -c -n --arg m "$MODEL" '{
+  app_name: "openclaw",
+  cmd: [
+    "/var/lib/easyenclave/bin/podman", "exec", "ollama",
+    "ollama", "launch", "openclaw",
+    "--model", $m,
+    "--yes"
+  ]
+}')
+agent /deploy -H 'Content-Type: application/json' -d "$OPENCLAW_SPEC" | jq -c '.' || true
+
+# ── 9. Confirm openclaw is in the agent's deployment list ──────────
+echo "  confirming openclaw workload is registered..."
+for i in $(seq 1 30); do
+  list=$(agent /health 2>/dev/null || true)
+  if echo "$list" | jq -e '.deployments // [] | index("openclaw")' >/dev/null 2>&1; then
+    echo "  openclaw: deployed"
+    break
+  fi
+  sleep 5
+done
+
 echo
-echo "=== $MODEL says ==="
-echo "$response"
-echo "==================="
+echo "=== agent fleet summary ==="
+echo "  agent:    https://$agent_host"
+echo "  model:    $MODEL"
+echo "  ollama:   podman container 'ollama' on host net"
+echo "  openclaw: ollama launch openclaw (subcommand)"
+echo "==========================="

--- a/scripts/ollama-deploy.sh
+++ b/scripts/ollama-deploy.sh
@@ -197,16 +197,23 @@ OPENCLAW_SPEC=$(jq -c -n --arg m "$MODEL" '{
 }')
 agent /deploy -H 'Content-Type: application/json' -d "$OPENCLAW_SPEC" | jq -c '.' || true
 
-# ── 9. Confirm openclaw is registered and talking to us ────────────
-# Two probes:
-#   a) EE lists `openclaw` in /health — proves the workload was
-#      accepted (weak — flips on fork, before npm install finishes).
-#   b) `openclaw plugins list` inside the container exits 0 — proves
-#      the gateway daemon is actually responsive. That subcommand
-#      goes through the running gateway, so an unresponsive or
-#      still-installing openclaw fails it. Strongest documented probe
-#      short of an HTTP port (which the docs don't publish).
-echo "  confirming openclaw workload is registered..."
+# ── 9. Confirm openclaw is up ─ three probes, weakest → strongest ──
+# (a) EE lists `openclaw` in /health — proves the workload was
+#     accepted by the in-VM runtime. Flips green on fork, before
+#     npm-install finishes, so on its own it's weak.
+# (b) GET http://127.0.0.1:18789/healthz (the OpenClaw gateway HTTP
+#     endpoint). Docs: https://docs.openclaw.ai/gateway/health.
+#     200 with valid JSON = gateway has bound its port and is
+#     serving. The ollama container runs with --net=host so the
+#     loopback is the VM's loopback; we curl through `podman exec`
+#     so we hit the in-container curl (EE's busybox lacks one).
+# (c) `openclaw agent --message "ping"` — the documented one-shot
+#     CLI. Goes through the running gateway, hands the prompt to
+#     the loaded model, returns the assistant reply. Exit 0 AND
+#     non-empty stdout = the full ollama → openclaw → model path
+#     works end-to-end. The reply gets echoed into the workflow
+#     log as proof of life.
+echo "  confirming openclaw workload is registered with EE..."
 for i in $(seq 1 30); do
   list=$(agent /health 2>/dev/null || true)
   if echo "$list" | jq -e '.deployments // [] | index("openclaw")' >/dev/null 2>&1; then
@@ -216,25 +223,39 @@ for i in $(seq 1 30); do
   sleep 5
 done
 
-# First launch can take a while because of the npm install of
-# @ollama/openclaw + the web-search/fetch plugin. 5 min ceiling.
-echo "  waiting for openclaw gateway to respond to CLI..."
-openclaw_ok=0
+echo "  waiting for openclaw gateway on http://127.0.0.1:18789/healthz..."
+openclaw_live=0
 for i in $(seq 1 60); do
   resp=$(agent /exec -H 'Content-Type: application/json' \
-    -d '{"cmd":["/var/lib/easyenclave/bin/podman","exec","ollama","openclaw","plugins","list"],"timeout_secs":15}' \
+    -d '{"cmd":["/var/lib/easyenclave/bin/podman","exec","ollama","curl","-fsS","http://127.0.0.1:18789/healthz"],"timeout_secs":10}' \
     2>/dev/null || true)
   if echo "$resp" | jq -e '.exit_code == 0' >/dev/null 2>&1; then
-    echo "  openclaw: responding"
-    echo "  plugins:"
-    echo "$resp" | jq -r '.stdout // ""' | sed 's/^/    /'
-    openclaw_ok=1
+    echo "  openclaw: /healthz 200"
+    echo "$resp" | jq -r '.stdout // ""' | head -c 200 | sed 's/^/    /'
+    echo
+    openclaw_live=1
     break
   fi
   sleep 5
 done
-if [ "$openclaw_ok" = "0" ]; then
-  echo "  WARNING: openclaw plugins list never returned — gateway may still be installing"
+
+if [ "$openclaw_live" = "1" ]; then
+  echo "  sending a round-trip prompt: 'ping'"
+  chat=$(agent /exec -H 'Content-Type: application/json' \
+    -d '{"cmd":["/var/lib/easyenclave/bin/podman","exec","ollama","openclaw","agent","--message","ping","--thinking","low"],"timeout_secs":120}' \
+    2>/dev/null || true)
+  reply=$(echo "$chat" | jq -r '.stdout // ""')
+  if [ -n "$reply" ] && echo "$chat" | jq -e '.exit_code == 0' >/dev/null 2>&1; then
+    echo
+    echo "=== openclaw replied ==="
+    echo "$reply"
+    echo "========================"
+  else
+    echo "  WARNING: openclaw agent --message didn't return a reply"
+    echo "  raw: $(echo "$chat" | jq -c '.' | head -c 500)"
+  fi
+else
+  echo "  WARNING: openclaw /healthz never returned 200 — gateway may still be installing (first-run npm)"
   echo "  last /exec response:"
   echo "$resp" | jq -c '.' | head -c 500
 fi
@@ -244,5 +265,5 @@ echo "=== agent fleet summary ==="
 echo "  agent:    https://$agent_host"
 echo "  model:    $MODEL"
 echo "  ollama:   podman container 'ollama' on host net, :11434"
-echo "  openclaw: ollama launch openclaw — plugins listing responded"
+echo "  openclaw: http://127.0.0.1:18789 (gateway), replied to round-trip ping"
 echo "==========================="

--- a/scripts/ollama-deploy.sh
+++ b/scripts/ollama-deploy.sh
@@ -124,31 +124,43 @@ done
 #   etc/containers/               containers.conf, policy.json,
 #                                 registries.conf, seccomp.json,
 #                                 storage.conf (tarball defaults)
-# Podman's hardcoded conmon search list includes /usr/libexec/podman/
-# but not /var/lib/easyenclave/bin/, so we symlink conmon to the
-# former. Rootful podman defaults to the systemd cgroup manager,
-# which this guest doesn't have — override to cgroupfs in
-# containers.conf. Use printf (not a heredoc) because busybox sh's
-# `<<EOF` is fragile when piped as a single -c string through jq.
+# EE's guest rootfs has /usr mounted read-only, so we can't drop
+# conmon into podman's default search paths (/usr/libexec/podman/ …).
+# Instead we stage conmon and the podman helpers under our writable
+# /var/lib/easyenclave/bin and point podman there via containers.conf
+# (conmon_path, helper_binaries_dir, [engine.runtimes]).
+#
+# Rootful podman also defaults to the systemd cgroup manager; this
+# guest doesn't have systemd so we override to cgroupfs.
+#
+# Use printf (not a heredoc) because busybox sh's `<<EOF` is fragile
+# when the whole script is passed as a single `-c` string through
+# jq's string encoding.
 echo "  bootstrapping podman (conmon + containers.conf)..."
 bootstrap_sh='set -e
-SRC=/var/lib/easyenclave/bin/podman-linux-amd64
-cp -f $SRC/usr/local/bin/* /var/lib/easyenclave/bin/
-mkdir -p /usr/libexec/podman
-cp -f $SRC/usr/local/lib/podman/conmon /usr/libexec/podman/conmon
-# netavark + aardvark-dns: CNI plugins. We run --net=host so these
-# should be unused, but podman still probes for them during setup.
-cp -f $SRC/usr/local/lib/podman/netavark /var/lib/easyenclave/bin/ 2>/dev/null || true
-cp -f $SRC/usr/local/lib/podman/aardvark-dns /var/lib/easyenclave/bin/ 2>/dev/null || true
+BIN=/var/lib/easyenclave/bin
+SRC=$BIN/podman-linux-amd64
+cp -f $SRC/usr/local/bin/* $BIN/
+cp -f $SRC/usr/local/lib/podman/conmon $BIN/
+cp -f $SRC/usr/local/lib/podman/netavark $BIN/ 2>/dev/null || true
+cp -f $SRC/usr/local/lib/podman/aardvark-dns $BIN/ 2>/dev/null || true
+cp -f $SRC/usr/local/lib/podman/rootlessport $BIN/ 2>/dev/null || true
 mkdir -p /etc/containers
-printf "[engine]\ncgroup_manager = \"cgroupfs\"\nruntime = \"crun\"\n" > /etc/containers/containers.conf
+# /etc is tmpfs-writable on EE; /usr is read-only, hence the
+# explicit conmon_path / helper_binaries_dir pinning below.
+printf "[engine]\nconmon_path = [\"%s/conmon\"]\nhelper_binaries_dir = [\"%s\"]\ncgroup_manager = \"cgroupfs\"\nruntime = \"crun\"\n[engine.runtimes]\ncrun = [\"%s/crun\"]\nrunc = [\"%s/runc\"]\n" $BIN $BIN $BIN $BIN > /etc/containers/containers.conf
 cp -f $SRC/etc/containers/policy.json /etc/containers/ 2>/dev/null || true
 cp -f $SRC/etc/containers/registries.conf /etc/containers/ 2>/dev/null || true
 cp -f $SRC/etc/containers/storage.conf /etc/containers/ 2>/dev/null || true
 echo podman-bootstrap: ok'
 boot_resp=$(agent /exec -H 'Content-Type: application/json' \
   -d "$(jq -c -n --arg s "$bootstrap_sh" '{cmd:["/bin/busybox","sh","-c",$s],timeout_secs:30}')")
-echo "  bootstrap: $(echo "$boot_resp" | jq -r '.stdout // .stderr // ""' | tail -3)"
+if ! echo "$boot_resp" | jq -e '.exit_code == 0' >/dev/null 2>&1; then
+  echo "ERROR: podman bootstrap failed"
+  echo "$boot_resp" | jq .
+  exit 1
+fi
+echo "  bootstrap: $(echo "$boot_resp" | jq -r '.stdout // ""' | tail -1)"
 
 # ── 5. Launch the ollama container (long-running workload) ─────────
 # --net=host  : ollama listens on guest's 127.0.0.1:11434.
@@ -182,16 +194,29 @@ agent /deploy -H 'Content-Type: application/json' -d "$OLLAMA_SPEC" | jq -c '.' 
 # `podman exec ollama ollama list` exits 0 once the server is ready.
 # First run has to pull ~900 MB of container image, so allow plenty.
 echo "  waiting for ollama to be ready (first run pulls the image)..."
+ollama_ready=0
 for i in $(seq 1 120); do
   resp=$(agent /exec -H 'Content-Type: application/json' \
     -d '{"cmd":["/var/lib/easyenclave/bin/podman","exec","ollama","ollama","list"],"timeout_secs":15}' \
     2>/dev/null || true)
   if echo "$resp" | jq -e '.exit_code == 0' >/dev/null 2>&1; then
     echo "  ollama responding"
+    ollama_ready=1
     break
   fi
   sleep 10
 done
+if [ "$ollama_ready" = "0" ]; then
+  echo "ERROR: ollama container never became ready (20 min timeout)"
+  echo "  most recent /exec response:"
+  echo "$resp" | jq .
+  echo "  last 30 lines of 'podman ps -a' + 'podman logs ollama':"
+  agent /exec -H 'Content-Type: application/json' \
+    -d '{"cmd":["/var/lib/easyenclave/bin/podman","ps","-a"],"timeout_secs":10}' | jq -r '.stdout // .stderr // ""'
+  agent /exec -H 'Content-Type: application/json' \
+    -d '{"cmd":["/var/lib/easyenclave/bin/podman","logs","ollama"],"timeout_secs":10}' 2>&1 | jq -r '.stdout // .stderr // ""' | tail -30
+  exit 1
+fi
 
 # ── 7. Pull the model ──────────────────────────────────────────────
 echo "  pulling $MODEL (this can take a few minutes)..."
@@ -200,6 +225,11 @@ pull_resp=$(agent /exec -H 'Content-Type: application/json' \
     cmd:["/var/lib/easyenclave/bin/podman","exec","ollama","ollama","pull",$m],
     timeout_secs:1800
   }')")
+if ! echo "$pull_resp" | jq -e '.exit_code == 0' >/dev/null 2>&1; then
+  echo "ERROR: ollama pull $MODEL failed"
+  echo "$pull_resp" | jq .
+  exit 1
+fi
 echo "  pull: $(echo "$pull_resp" | jq -r '.stdout // "(no stdout)"' | tail -3)"
 
 # ── 8. Launch OpenClaw ─────────────────────────────────────────────
@@ -260,26 +290,27 @@ for i in $(seq 1 60); do
   sleep 5
 done
 
-if [ "$openclaw_live" = "1" ]; then
-  echo "  sending a round-trip prompt: 'ping'"
-  chat=$(agent /exec -H 'Content-Type: application/json' \
-    -d '{"cmd":["/var/lib/easyenclave/bin/podman","exec","ollama","openclaw","agent","--message","ping","--thinking","low"],"timeout_secs":120}' \
-    2>/dev/null || true)
-  reply=$(echo "$chat" | jq -r '.stdout // ""')
-  if [ -n "$reply" ] && echo "$chat" | jq -e '.exit_code == 0' >/dev/null 2>&1; then
-    echo
-    echo "=== openclaw replied ==="
-    echo "$reply"
-    echo "========================"
-  else
-    echo "  WARNING: openclaw agent --message didn't return a reply"
-    echo "  raw: $(echo "$chat" | jq -c '.' | head -c 500)"
-  fi
-else
-  echo "  WARNING: openclaw /healthz never returned 200 — gateway may still be installing (first-run npm)"
+if [ "$openclaw_live" != "1" ]; then
+  echo "ERROR: openclaw /healthz never returned 200 (gateway didn't come up within 5 min)"
   echo "  last /exec response:"
   echo "$resp" | jq -c '.' | head -c 500
+  exit 1
 fi
+
+echo "  sending a round-trip prompt: 'ping'"
+chat=$(agent /exec -H 'Content-Type: application/json' \
+  -d '{"cmd":["/var/lib/easyenclave/bin/podman","exec","ollama","openclaw","agent","--message","ping","--thinking","low"],"timeout_secs":120}' \
+  2>/dev/null || true)
+reply=$(echo "$chat" | jq -r '.stdout // ""')
+if [ -z "$reply" ] || ! echo "$chat" | jq -e '.exit_code == 0' >/dev/null 2>&1; then
+  echo "ERROR: openclaw agent --message didn't return a reply"
+  echo "  raw: $(echo "$chat" | jq -c '.' | head -c 500)"
+  exit 1
+fi
+echo
+echo "=== openclaw replied ==="
+echo "$reply"
+echo "========================"
 
 echo
 echo "=== agent fleet summary ==="

--- a/scripts/ollama-deploy.sh
+++ b/scripts/ollama-deploy.sh
@@ -114,29 +114,24 @@ for i in $(seq 1 60); do
   sleep 5
 done
 
-# ── 4. Bootstrap: stage podman's helper binaries + containers.conf ─
+# ── 4. Bootstrap: stage podman's helper binaries ───────────────────
 # mgoltzsche's tarball layout:
 #   usr/local/bin/                podman, crun, runc, fuse-overlayfs,
 #                                 fusermount3, pasta, pasta.avx2
 #   usr/local/lib/podman/         conmon, netavark, aardvark-dns,
 #                                 rootlessport, catatonit
-#   usr/local/libexec/podman/     quadlet
-#   etc/containers/               containers.conf, policy.json,
-#                                 registries.conf, seccomp.json,
-#                                 storage.conf (tarball defaults)
-# EE's guest rootfs has /usr mounted read-only, so we can't drop
-# conmon into podman's default search paths (/usr/libexec/podman/ …).
-# Instead we stage conmon and the podman helpers under our writable
-# /var/lib/easyenclave/bin and point podman there via containers.conf
-# (conmon_path, helper_binaries_dir, [engine.runtimes]).
+# EE's guest rootfs has BOTH /usr AND /etc mounted read-only. The
+# only writable paths are under /var/lib/easyenclave (on the
+# persistent vdc ext4 disk) and /run/tmp-style tmpfs locations. So
+# we cannot write a containers.conf anywhere podman looks for one,
+# and we cannot cp conmon into any of podman's hardcoded search
+# dirs. Every path has to be on the podman CLI directly.
 #
-# Rootful podman also defaults to the systemd cgroup manager; this
-# guest doesn't have systemd so we override to cgroupfs.
-#
-# Use printf (not a heredoc) because busybox sh's `<<EOF` is fragile
-# when the whole script is passed as a single `-c` string through
-# jq's string encoding.
-echo "  bootstrapping podman (conmon + containers.conf)..."
+# We DO stage the helpers into /var/lib/easyenclave/bin so the
+# container workload's `cmd[0]` can reach `podman`, and the
+# --conmon / --runtime / --root / --runroot flags on the `podman`
+# command (see step 5) point podman at the rest.
+echo "  bootstrapping podman (staging binaries to writable dirs)..."
 bootstrap_sh='set -e
 BIN=/var/lib/easyenclave/bin
 SRC=$BIN/podman-linux-amd64
@@ -145,13 +140,7 @@ cp -f $SRC/usr/local/lib/podman/conmon $BIN/
 cp -f $SRC/usr/local/lib/podman/netavark $BIN/ 2>/dev/null || true
 cp -f $SRC/usr/local/lib/podman/aardvark-dns $BIN/ 2>/dev/null || true
 cp -f $SRC/usr/local/lib/podman/rootlessport $BIN/ 2>/dev/null || true
-mkdir -p /etc/containers
-# /etc is tmpfs-writable on EE; /usr is read-only, hence the
-# explicit conmon_path / helper_binaries_dir pinning below.
-printf "[engine]\nconmon_path = [\"%s/conmon\"]\nhelper_binaries_dir = [\"%s\"]\ncgroup_manager = \"cgroupfs\"\nruntime = \"crun\"\n[engine.runtimes]\ncrun = [\"%s/crun\"]\nrunc = [\"%s/runc\"]\n" $BIN $BIN $BIN $BIN > /etc/containers/containers.conf
-cp -f $SRC/etc/containers/policy.json /etc/containers/ 2>/dev/null || true
-cp -f $SRC/etc/containers/registries.conf /etc/containers/ 2>/dev/null || true
-cp -f $SRC/etc/containers/storage.conf /etc/containers/ 2>/dev/null || true
+mkdir -p /var/lib/easyenclave/containers/storage /var/lib/easyenclave/containers/runroot
 echo podman-bootstrap: ok'
 boot_resp=$(agent /exec -H 'Content-Type: application/json' \
   -d "$(jq -c -n --arg s "$bootstrap_sh" '{cmd:["/bin/busybox","sh","-c",$s],timeout_secs:30}')")
@@ -174,13 +163,26 @@ echo "  bootstrap: $(echo "$boot_resp" | jq -r '.stdout // ""' | tail -1)"
 #               in local-agents.sh); doubles as ollama's model cache
 #               and openclaw's npm prefix.
 echo "  POST /deploy ollama container..."
+# Every writable path (--root, --runroot, --conmon, --runtime) is
+# on the CLI because EE's /etc and /usr are read-only — podman
+# can't fall back on /etc/containers/containers.conf the way it
+# normally does. Storage lives on the persistent vdc disk so the
+# 900 MB ollama image pull survives VM relaunches.
+# --cgroup-manager=cgroupfs because there's no systemd in the guest.
+# --network=host so ollama's :11434 binds on the VM's loopback,
+# reachable from other EE workloads (like openclaw) and via /exec.
 OLLAMA_SPEC=$(jq -c -n --argjson gpu "$GPU_FLAGS" '{
   app_name: "ollama",
   cmd: ([
-    "/var/lib/easyenclave/bin/podman", "run",
+    "/var/lib/easyenclave/bin/podman",
+    "--conmon=/var/lib/easyenclave/bin/conmon",
+    "--runtime=/var/lib/easyenclave/bin/crun",
+    "--root=/var/lib/easyenclave/containers/storage",
+    "--runroot=/var/lib/easyenclave/containers/runroot",
+    "--cgroup-manager=cgroupfs",
+    "run",
     "--rm", "--name", "ollama",
-    "--net=host",
-    "--cgroup-manager=cgroupfs"
+    "--network=host"
   ] + $gpu + [
     "-v", "/var/lib/easyenclave/ollama:/root/.ollama",
     "-e", "OLLAMA_HOST=127.0.0.1:11434",
@@ -197,7 +199,7 @@ echo "  waiting for ollama to be ready (first run pulls the image)..."
 ollama_ready=0
 for i in $(seq 1 120); do
   resp=$(agent /exec -H 'Content-Type: application/json' \
-    -d '{"cmd":["/var/lib/easyenclave/bin/podman","exec","ollama","ollama","list"],"timeout_secs":15}' \
+    -d '{"cmd":["/var/lib/easyenclave/bin/podman","--root=/var/lib/easyenclave/containers/storage","--runroot=/var/lib/easyenclave/containers/runroot","--cgroup-manager=cgroupfs","exec","ollama","ollama","list"],"timeout_secs":15}' \
     2>/dev/null || true)
   if echo "$resp" | jq -e '.exit_code == 0' >/dev/null 2>&1; then
     echo "  ollama responding"
@@ -212,9 +214,9 @@ if [ "$ollama_ready" = "0" ]; then
   echo "$resp" | jq .
   echo "  last 30 lines of 'podman ps -a' + 'podman logs ollama':"
   agent /exec -H 'Content-Type: application/json' \
-    -d '{"cmd":["/var/lib/easyenclave/bin/podman","ps","-a"],"timeout_secs":10}' | jq -r '.stdout // .stderr // ""'
+    -d '{"cmd":["/var/lib/easyenclave/bin/podman","--root=/var/lib/easyenclave/containers/storage","--runroot=/var/lib/easyenclave/containers/runroot","ps","-a"],"timeout_secs":10}' | jq -r '.stdout // .stderr // ""'
   agent /exec -H 'Content-Type: application/json' \
-    -d '{"cmd":["/var/lib/easyenclave/bin/podman","logs","ollama"],"timeout_secs":10}' 2>&1 | jq -r '.stdout // .stderr // ""' | tail -30
+    -d '{"cmd":["/var/lib/easyenclave/bin/podman","--root=/var/lib/easyenclave/containers/storage","--runroot=/var/lib/easyenclave/containers/runroot","logs","ollama"],"timeout_secs":10}' 2>&1 | jq -r '.stdout // .stderr // ""' | tail -30
   exit 1
 fi
 
@@ -222,7 +224,7 @@ fi
 echo "  pulling $MODEL (this can take a few minutes)..."
 pull_resp=$(agent /exec -H 'Content-Type: application/json' \
   -d "$(jq -c -n --arg m "$MODEL" '{
-    cmd:["/var/lib/easyenclave/bin/podman","exec","ollama","ollama","pull",$m],
+    cmd:["/var/lib/easyenclave/bin/podman","--root=/var/lib/easyenclave/containers/storage","--runroot=/var/lib/easyenclave/containers/runroot","--cgroup-manager=cgroupfs","exec","ollama","ollama","pull",$m],
     timeout_secs:1800
   }')")
 if ! echo "$pull_resp" | jq -e '.exit_code == 0' >/dev/null 2>&1; then
@@ -240,7 +242,11 @@ echo "  POST /deploy openclaw..."
 OPENCLAW_SPEC=$(jq -c -n --arg m "$MODEL" '{
   app_name: "openclaw",
   cmd: [
-    "/var/lib/easyenclave/bin/podman", "exec", "ollama",
+    "/var/lib/easyenclave/bin/podman",
+    "--root=/var/lib/easyenclave/containers/storage",
+    "--runroot=/var/lib/easyenclave/containers/runroot",
+    "--cgroup-manager=cgroupfs",
+    "exec", "ollama",
     "ollama", "launch", "openclaw",
     "--model", $m,
     "--yes"
@@ -278,7 +284,7 @@ echo "  waiting for openclaw gateway on http://127.0.0.1:18789/healthz..."
 openclaw_live=0
 for i in $(seq 1 60); do
   resp=$(agent /exec -H 'Content-Type: application/json' \
-    -d '{"cmd":["/var/lib/easyenclave/bin/podman","exec","ollama","curl","-fsS","http://127.0.0.1:18789/healthz"],"timeout_secs":10}' \
+    -d '{"cmd":["/var/lib/easyenclave/bin/podman","--root=/var/lib/easyenclave/containers/storage","--runroot=/var/lib/easyenclave/containers/runroot","--cgroup-manager=cgroupfs","exec","ollama","curl","-fsS","http://127.0.0.1:18789/healthz"],"timeout_secs":10}' \
     2>/dev/null || true)
   if echo "$resp" | jq -e '.exit_code == 0' >/dev/null 2>&1; then
     echo "  openclaw: /healthz 200"
@@ -299,7 +305,7 @@ fi
 
 echo "  sending a round-trip prompt: 'ping'"
 chat=$(agent /exec -H 'Content-Type: application/json' \
-  -d '{"cmd":["/var/lib/easyenclave/bin/podman","exec","ollama","openclaw","agent","--message","ping","--thinking","low"],"timeout_secs":120}' \
+  -d '{"cmd":["/var/lib/easyenclave/bin/podman","--root=/var/lib/easyenclave/containers/storage","--runroot=/var/lib/easyenclave/containers/runroot","--cgroup-manager=cgroupfs","exec","ollama","openclaw","agent","--message","ping","--thinking","low"],"timeout_secs":120}' \
   2>/dev/null || true)
 reply=$(echo "$chat" | jq -r '.stdout // ""')
 if [ -z "$reply" ] || ! echo "$chat" | jq -e '.exit_code == 0' >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

Ollama's dynamically-linked binary can't run on EE's busybox guest rootfs (`libstdc++.so.6: cannot open shared object file` — run `24575935391`). Containerize everything via **static podman** (mgoltzsche/podman-static) so the image brings its own userspace. **No new Rust code** — everything fits the existing `/deploy` workload spec.

Plan file: `~/.claude/plans/fuzzy-hopping-marshmallow.md`.

## Flow (new `scripts/ollama-deploy.sh`)

1. **Fetch podman-static** (fetch-only DD workload). mgoltzsche tarball bundles podman + crun + conmon + netavark, all static.
2. **Bootstrap config** via `/exec` — write `/etc/containers/containers.conf` with `cgroup_manager=cgroupfs` (no systemd) + flatten the nested `podman-linux-amd64/usr/local/bin` into `/var/lib/easyenclave/bin`.
3. **Deploy ollama container** (long-running): `podman run --net=host --name ollama docker.io/ollama/ollama:latest serve`. Prod adds `/dev/nvidia{0,ctl,-uvm}` for H100 passthrough; preview doesn't.
4. **Pull model** via `podman exec ollama ollama pull` — llama3.1:8b (prod) / qwen2.5:0.5b (preview).
5. **Launch OpenClaw** (messaging-bridge ollama subcommand, auto-npm-installs) as a second long-running workload.

Persistent vdc ext4 (`/var/lib/easyenclave/ollama`) doubles as podman's bind for `/root/.ollama` → first VM relaunch pays the ~900 MB image pull + model download, then reused forever (same disk survives `virsh destroy`+recreate).

## Test plan

- [ ] Merge fires Local Agents (push trigger on main, post-PR #118/#121).
- [ ] Step 1 (SSH + relaunch) unchanged ~10 s.
- [ ] Step 2 log shows, in order: `podman unpacked` → `podman-bootstrap: ok` → `ollama responding` → `pull: success` → `openclaw: deployed`.
- [ ] Fleet dashboard shows `dd-local-prod` with `openclaw` in its deployment list.
- [ ] Preview run on a future src/ PR exercises the CPU path (no GPU flags).

## Hazards (documented in plan)

- Tarball nested layout — bootstrap flattens it before Workload B runs.
- `containers.conf` needed for cgroupfs — written in bootstrap step.
- `ollama/ollama` image may lack npm for OpenClaw install — fall-back is a thin wrapper image pinned in our GHCR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)