### PR TITLE
ci(release): publish a signed attestation for every devopsdefender binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,11 @@ concurrency:
 
 permissions:
   contents: write
+  # GitHub release attestations (actions/attest-build-provenance).
+  # We sign every published `devopsdefender` binary so the CP can later
+  # verify a registering agent's artifact came from this workflow.
+  id-token: write
+  attestations: write
 
 env:
   DD_DOMAIN: ${{ vars.DD_CF_DOMAIN || 'devopsdefender.com' }}
@@ -68,6 +73,22 @@ jobs:
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
           echo "prerelease=${PRERELEASE}" >> "$GITHUB_OUTPUT"
           echo "sha12=${SHA12}" >> "$GITHUB_OUTPUT"
+
+      # Attest the binary's SHA256 against this workflow's identity
+      # (GitHub's Sigstore-backed signing OIDC'd as
+      #  `https://github.com/devopsdefender/dd/.github/workflows/release.yml@<ref>`).
+      # The attestation is stored on the repo's /attestations endpoint
+      # and retrievable via `gh attestation verify` or the REST API.
+      #
+      # For now we're tracking (not enforcing) — the CP will eventually
+      # use this to verify that a registering agent's artifact came
+      # from this workflow. Skipped on fork PRs (they lack id-token).
+      - name: Attest devopsdefender binary
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: target/x86_64-unknown-linux-musl/release/devopsdefender
+          subject-name: devopsdefender
 
       - name: Publish release
         env:


### PR DESCRIPTION
## Summary

First step in moving agent registration off a 1-hour GitHub App installation token (the current `secrets.GITHUB_TOKEN` baked as `DD_PAT` into the guest's config.iso via `scripts/local-agents.sh`). Eventually the CP will verify a registering agent's measurement against a signed attestation on the repo; for now this PR **only publishes attestations** — no verification yet, no auth change. Tracking side only so we build up a body of signed artifacts before flipping any switch.

`actions/attest-build-provenance@v2` produces a Sigstore-backed SLSA provenance statement over the built musl binary. GitHub's workflow OIDC signs on behalf of this repo, so the cert chain identifies the exact workflow + ref + commit that built it. Attestations land on `/repos/devopsdefender/dd/attestations`.

Skipped for PRs from forks (no `id-token: write`) — we only need signatures on push-to-main + tagged releases.

## Test plan

- [ ] Merging triggers Release. Workflow log shows an `Attest devopsdefender binary` step succeeding.
- [ ] `gh attestation list --repo devopsdefender/dd` returns at least one entry with `subject: devopsdefender` and a sha256 matching the `latest` release asset.
- [ ] `gh attestation verify target/.../devopsdefender --repo devopsdefender/dd` passes (once the binary is downloaded locally).

## Plan file

`~/.claude/plans/fuzzy-hopping-marshmallow.md` — the end state is "drop PAT; CP verifies attestations; agent carries only its ITA key; register to any CP you want". This PR is the ground-floor enabling step. No user-visible behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)