### PR TITLE
feat(metrics): per-disk + per-network-interface stats on /health and fleet

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -218,6 +218,8 @@ async fn health(State(s): State<St>) -> Json<serde_json::Value> {
         "cpu_percent": m.cpu_pct,
         "memory_used_mb": m.mem_used_mb,
         "memory_total_mb": m.mem_total_mb,
+        "nets": m.nets,
+        "disks": m.disks,
         "uptime_secs": s.started.elapsed().as_secs(),
         "ita_token": ita_token,
     }))

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -39,6 +39,10 @@ pub struct Agent {
     pub cpu_percent: u64,
     pub memory_used_mb: u64,
     pub memory_total_mb: u64,
+    #[serde(default)]
+    pub nets: Vec<crate::metrics::NetStats>,
+    #[serde(default)]
+    pub disks: Vec<crate::metrics::DiskStats>,
     /// Intel-verified ITA claims. Required — agents without a valid
     /// token don't enter the store.
     pub ita: ita::Claims,
@@ -176,6 +180,8 @@ async fn tick(
                 cpu_percent: h["cpu_percent"].as_u64().unwrap_or(0),
                 memory_used_mb: h["memory_used_mb"].as_u64().unwrap_or(0),
                 memory_total_mb: h["memory_total_mb"].as_u64().unwrap_or(0),
+                nets: serde_json::from_value(h["nets"].clone()).unwrap_or_default(),
+                disks: serde_json::from_value(h["disks"].clone()).unwrap_or_default(),
                 ita: claims,
             },
         );

--- a/src/cp.rs
+++ b/src/cp.rs
@@ -25,6 +25,7 @@ use crate::ee::Ee;
 use crate::error::{Error, Result};
 use crate::html::{self, shell};
 use crate::ita;
+use crate::metrics;
 use crate::stonith;
 use crate::terminal;
 
@@ -123,6 +124,8 @@ pub async fn run() -> Result<()> {
             cpu_percent: 0,
             memory_used_mb: 0,
             memory_total_mb: 0,
+            nets: Vec::new(),
+            disks: Vec::new(),
             ita: cp_claims,
         },
     );
@@ -328,6 +331,8 @@ async fn register(
                 cpu_percent: 0,
                 memory_used_mb: 0,
                 memory_total_mb: 0,
+                nets: Vec::new(),
+                disks: Vec::new(),
                 ita: ita_claims,
             },
         );
@@ -532,6 +537,41 @@ async fn agent_detail(
         )
     };
 
+    let disks_table = if a.disks.is_empty() {
+        String::new()
+    } else {
+        let mut rows = String::new();
+        for d in &a.disks {
+            rows.push_str(&format!(
+                "<tr><td>{m}</td><td class=\"dim\">{fs}</td><td>{u}/{t} GB</td></tr>",
+                m = html::escape(&d.mount),
+                fs = html::escape(&d.fstype),
+                u = d.used_gb,
+                t = d.total_gb,
+            ));
+        }
+        format!(
+            r#"<div class="section">Disks</div><table><tr><th>mount</th><th>fs</th><th>used</th></tr>{rows}</table>"#
+        )
+    };
+
+    let nets_table = if a.nets.is_empty() {
+        String::new()
+    } else {
+        let mut rows = String::new();
+        for n in &a.nets {
+            rows.push_str(&format!(
+                "<tr><td>{i}</td><td>{rx}</td><td>{tx}</td></tr>",
+                i = html::escape(&n.iface),
+                rx = metrics::format_bytes_si(n.rx_bytes),
+                tx = metrics::format_bytes_si(n.tx_bytes),
+            ));
+        }
+        format!(
+            r#"<div class="section">Network</div><table><tr><th>iface</th><th>rx</th><th>tx</th></tr>{rows}</table>"#
+        )
+    };
+
     Html(shell(
         &format!("DD — {}", a.vm_name),
         &html::nav(&[("Fleet", "/", false)]),
@@ -545,6 +585,8 @@ async fn agent_detail(
   <div class="row"><span>CPU</span><span>{cpu}%</span></div>
   <div class="row"><span>Memory</span><span>{mu}/{mt} MB</span></div>
 </div>
+{disks_table}
+{nets_table}
 {ita_card}
 <div class="section">Workloads</div>{wl_table}
 {extra}"#,
@@ -557,6 +599,8 @@ async fn agent_detail(
             cpu = a.cpu_percent,
             mu = a.memory_used_mb,
             mt = a.memory_total_mb,
+            disks_table = disks_table,
+            nets_table = nets_table,
             ita_card = ita_card,
         ),
     ))

--- a/src/cp.rs
+++ b/src/cp.rs
@@ -110,6 +110,10 @@ pub async fn run() -> Result<()> {
     let cp_ita_token = Arc::new(RwLock::new(initial_token));
 
     // Seed the CP into the store before the collector starts ticking.
+    // The refresh loop below will keep these numbers current every
+    // ITA_REFRESH ticks; we fill them once at startup so the first
+    // render isn't all zeros while the refresh loop sleeps.
+    let cp_m = metrics::collect().await;
     store.lock().await.insert(
         "control-plane".into(),
         collector::Agent {
@@ -121,11 +125,11 @@ pub async fn run() -> Result<()> {
             last_seen: chrono::Utc::now(),
             deployment_count: 0,
             deployment_names: Vec::new(),
-            cpu_percent: 0,
-            memory_used_mb: 0,
-            memory_total_mb: 0,
-            nets: Vec::new(),
-            disks: Vec::new(),
+            cpu_percent: cp_m.cpu_pct,
+            memory_used_mb: cp_m.mem_used_mb,
+            memory_total_mb: cp_m.mem_total_mb,
+            nets: cp_m.nets,
+            disks: cp_m.disks,
             ita: cp_claims,
         },
     );
@@ -157,8 +161,19 @@ pub async fn run() -> Result<()> {
                     }
                 };
                 *token.write().await = fresh;
+                // Also refresh live system metrics on the CP's own
+                // store entry — the collector scrapes other tunnels,
+                // not itself, so without this the /agent/control-plane
+                // detail page would show empty disks/nets/cpu forever.
+                let m = crate::metrics::collect().await;
                 if let Some(cp) = store.lock().await.get_mut("control-plane") {
                     cp.ita = claims;
+                    cp.last_seen = chrono::Utc::now();
+                    cp.cpu_percent = m.cpu_pct;
+                    cp.memory_used_mb = m.mem_used_mb;
+                    cp.memory_total_mb = m.mem_total_mb;
+                    cp.nets = m.nets;
+                    cp.disks = m.disks;
                 }
                 eprintln!("cp: own ITA token refreshed");
             }

--- a/src/cp.rs
+++ b/src/cp.rs
@@ -558,11 +558,11 @@ async fn agent_detail(
         let mut rows = String::new();
         for d in &a.disks {
             rows.push_str(&format!(
-                "<tr><td>{m}</td><td class=\"dim\">{fs}</td><td>{u}/{t} GB</td></tr>",
+                "<tr><td>{m}</td><td class=\"dim\">{fs}</td><td>{u} / {t}</td></tr>",
                 m = html::escape(&d.mount),
                 fs = html::escape(&d.fstype),
-                u = d.used_gb,
-                t = d.total_gb,
+                u = metrics::format_bytes_si(d.used_bytes),
+                t = metrics::format_bytes_si(d.total_bytes),
             ));
         }
         format!(

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,7 +1,22 @@
 //! Lightweight /proc-derived system metrics for the agent dashboard
 //! and the /health JSON. No external process dependencies.
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct DiskStats {
+    pub mount: String,
+    pub fstype: String,
+    pub used_gb: u64,
+    pub total_gb: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct NetStats {
+    pub iface: String,
+    pub rx_bytes: u64,
+    pub tx_bytes: u64,
+}
 
 #[derive(Debug, Clone, Serialize, Default)]
 pub struct SysMetrics {
@@ -9,7 +24,39 @@ pub struct SysMetrics {
     pub mem_used_mb: u64,
     pub mem_total_mb: u64,
     pub load_1m: f64,
+    /// Per-interface RX/TX byte counters (excludes `lo`).
+    pub nets: Vec<NetStats>,
+    /// Per-mount capacity stats (excludes pseudo-filesystems).
+    pub disks: Vec<DiskStats>,
 }
+
+/// /proc-filesystem types we don't want in disk stats. Everything else
+/// (ext4, xfs, btrfs, overlay, vfat, …) gets statvfs'd.
+const PSEUDO_FSTYPES: &[&str] = &[
+    "proc",
+    "sysfs",
+    "cgroup",
+    "cgroup2",
+    "tmpfs",
+    "devtmpfs",
+    "ramfs",
+    "devpts",
+    "mqueue",
+    "tracefs",
+    "debugfs",
+    "securityfs",
+    "pstore",
+    "bpf",
+    "configfs",
+    "autofs",
+    "binfmt_misc",
+    "hugetlbfs",
+    "rpc_pipefs",
+    "fusectl",
+    "nsfs",
+    "squashfs",
+    "iso9660",
+];
 
 pub async fn collect() -> SysMetrics {
     let mut m = SysMetrics::default();
@@ -60,6 +107,85 @@ pub async fn collect() -> SysMetrics {
         }
     }
 
+    // /proc/net/dev: one row per interface, space-separated counters.
+    //   Inter-|   Receive                             ...
+    //    face |bytes    packets errs drop fifo frame compressed multicast | bytes ...
+    //       lo:  46340 …
+    //     eth0:  12345 …
+    // Col 0 = RX bytes, col 8 = TX bytes. Skip `lo`.
+    if let Ok(dev) = tokio::fs::read_to_string("/proc/net/dev").await {
+        for line in dev.lines().skip(2) {
+            let Some((iface, rest)) = line.split_once(':') else {
+                continue;
+            };
+            let iface = iface.trim();
+            if iface == "lo" || iface.is_empty() {
+                continue;
+            }
+            let cols: Vec<u64> = rest
+                .split_whitespace()
+                .filter_map(|s| s.parse().ok())
+                .collect();
+            if cols.len() >= 9 {
+                m.nets.push(NetStats {
+                    iface: iface.to_string(),
+                    rx_bytes: cols[0],
+                    tx_bytes: cols[8],
+                });
+            }
+        }
+    }
+
+    // /proc/mounts: one row per mount, space-separated:
+    //   <source> <mount-point> <fstype> <opts> <dump> <pass>
+    // For every mount whose fstype isn't a known pseudo-filesystem, call
+    // statvfs to get capacity. libc is already in the tree; one unsafe
+    // block per statvfs call.
+    if let Ok(mounts) = tokio::fs::read_to_string("/proc/mounts").await {
+        let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+        for line in mounts.lines() {
+            let cols: Vec<&str> = line.split_whitespace().collect();
+            if cols.len() < 3 {
+                continue;
+            }
+            let mount = cols[1];
+            let fstype = cols[2];
+            if PSEUDO_FSTYPES.contains(&fstype) {
+                continue;
+            }
+            // Dedupe — a disk may be bind-mounted multiple times.
+            if !seen.insert(mount.to_string()) {
+                continue;
+            }
+            let Ok(cmount) = std::ffi::CString::new(mount) else {
+                continue;
+            };
+            let mut vfs: libc::statvfs = unsafe { std::mem::zeroed() };
+            // SAFETY: statvfs writes only to its out param; cmount is a valid C string.
+            if unsafe { libc::statvfs(cmount.as_ptr(), &mut vfs) } != 0 {
+                continue;
+            }
+            #[allow(clippy::unnecessary_cast)]
+            let frsize: u64 = vfs.f_frsize as u64;
+            #[allow(clippy::unnecessary_cast)]
+            let blocks: u64 = vfs.f_blocks as u64;
+            #[allow(clippy::unnecessary_cast)]
+            let bavail: u64 = vfs.f_bavail as u64;
+            // Skip 0-sized "filesystems" (often virtual overlays with
+            // no meaningful capacity).
+            if blocks == 0 {
+                continue;
+            }
+            let gib = 1024u64 * 1024 * 1024;
+            m.disks.push(DiskStats {
+                mount: mount.to_string(),
+                fstype: fstype.to_string(),
+                total_gb: frsize.saturating_mul(blocks) / gib,
+                used_gb: frsize.saturating_mul(blocks.saturating_sub(bavail)) / gib,
+            });
+        }
+    }
+
     m
 }
 
@@ -68,6 +194,25 @@ pub fn format_bytes_mb(mb: u64) -> String {
         format!("{:.1}G", mb as f64 / 1024.0)
     } else {
         format!("{mb}M")
+    }
+}
+
+/// Humanise a raw byte count as K/M/G/T. Used for network counters.
+pub fn format_bytes_si(b: u64) -> String {
+    const K: u64 = 1024;
+    const M: u64 = 1024 * K;
+    const G: u64 = 1024 * M;
+    const T: u64 = 1024 * G;
+    if b >= T {
+        format!("{:.1}T", b as f64 / T as f64)
+    } else if b >= G {
+        format!("{:.1}G", b as f64 / G as f64)
+    } else if b >= M {
+        format!("{:.1}M", b as f64 / M as f64)
+    } else if b >= K {
+        format!("{:.1}K", b as f64 / K as f64)
+    } else {
+        format!("{b}B")
     }
 }
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -7,8 +7,8 @@ use serde::{Deserialize, Serialize};
 pub struct DiskStats {
     pub mount: String,
     pub fstype: String,
-    pub used_gb: u64,
-    pub total_gb: u64,
+    pub used_bytes: u64,
+    pub total_bytes: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -176,12 +176,11 @@ pub async fn collect() -> SysMetrics {
             if blocks == 0 {
                 continue;
             }
-            let gib = 1024u64 * 1024 * 1024;
             m.disks.push(DiskStats {
                 mount: mount.to_string(),
                 fstype: fstype.to_string(),
-                total_gb: frsize.saturating_mul(blocks) / gib,
-                used_gb: frsize.saturating_mul(blocks.saturating_sub(bavail)) / gib,
+                total_bytes: frsize.saturating_mul(blocks),
+                used_bytes: frsize.saturating_mul(blocks.saturating_sub(bavail)),
             });
         }
     }


### PR DESCRIPTION
## Summary

Agent `/health` previously reported three aggregate numbers — cpu_percent, memory_used_mb, memory_total_mb. Enough for one fleet card, missing the two things most useful when something's wrong: **which interface is saturating** and **which mount point is filling up**.

Adds two Vecs to `SysMetrics`:

- `NetStats { iface, rx_bytes, tx_bytes }` — one row per non-`lo` interface from `/proc/net/dev`
- `DiskStats { mount, fstype, used_gb, total_gb }` — one row per real filesystem (skips a blocklist of pseudo types: proc, sysfs, tmpfs, cgroup2, …)

Uses `libc::statvfs` for disk (libc was already in the tree — no new deps, one `unsafe` block per mount).

Results flow through `agent /health` JSON → `collector::Agent` → CP dashboard. Agent-detail page now renders two new tables (Disks, Network) between the main card and the ITA card. Fleet table is unchanged (one row per agent, aggregates only).

Bonus: `metrics::format_bytes_si` helper for humanising raw byte counts (K/M/G/T, 1.2G style).

## Test plan

- [ ] Merge triggers Release + Production Deploy. CP restarts.
- [ ] `curl -H "Authorization: Bearer $(gh auth token)" https://app.devopsdefender.com/agent/<id>` — detail page shows Disks + Network tables.
- [ ] `curl /health` on any agent — JSON has `disks: [...]` and `nets: [...]` arrays.
- [ ] dd-local-prod detail page shows vdc ext4 at `/var/lib/easyenclave/ollama` once that's mounted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)