### PR TITLE
marketing: reflect workload-spec + metrics + signed-release model

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
     </div>
     <div class="stats">
       <div class="stat"><span class="value">TDX Attested</span><span class="label">Hardware-sealed memory</span></div>
-      <div class="stat"><span class="value">4 Binaries</span><span class="label">dd-client, dd-register, dd-web, easyenclave</span></div>
+      <div class="stat"><span class="value">1 Binary</span><span class="label">devopsdefender (cp + agent modes)</span></div>
       <div class="stat"><span class="value">Open Source</span><span class="label">MIT license</span></div>
     </div>
   </div>
@@ -105,7 +105,7 @@
   <section id="arch" class="section-center">
     <div class="container">
       <h2>Architecture</h2>
-      <p class="subtitle">4 binaries, 2 repos, zero trust.</p>
+      <p class="subtitle">1 binary, 2 modes, zero trust.</p>
       <div class="arch">
 <pre>
 <span class="hl">Customer</span> (browser)
@@ -115,18 +115,19 @@
                                     |
                             <span class="gr">easyenclave</span> (PID 1)
                             ├── unix socket API
-                            ├── workload: <span class="hl">dd-client</span>
-                            │   ├── web dashboard + terminal
+                            ├── workload: <span class="hl">devopsdefender agent</span>
                             │   ├── /health, /deploy, /exec
-                            │   └── Noise WS ──> <span class="hl">dd-register</span>
-                            └── workload: <span class="hl">openclaw + ollama</span>
-                                └── gemma4:e2b (CPU inference)
+                            │   ├── ITA-signed attestation
+                            │   └── registers with devopsdefender cp
+                            └── workload: <span class="hl">openclaw + ollama</span> (podman)
+                                ├── llama3.1:8b (GPU, prod)
+                                └── qwen2.5:0.5b (CPU, preview)
 
-<span class="hl">dd-web</span> (fleet dashboard, N instances)
+<span class="hl">devopsdefender cp</span> (fleet dashboard + management)
   ├── discovers agents via CF tunnels
   ├── scrapes /health (Prometheus-style)
-  ├── GitHub OAuth + JWT auth
-  └── /federate for horizontal scaling
+  ├── verifies agent ITA tokens at /register
+  └── web UI: fleet, per-agent terminal, logs
 </pre>
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -41,22 +41,22 @@
         <div class="step">
           <div class="step-num">1</div>
           <div class="step-content">
-            <h3>Deploy</h3>
-            <p>Push your container image via GitHub Actions. The <code>deploy-workload</code> action POSTs your deploy spec to dd-agent's API through the Cloudflare tunnel. No SSH keys, no raw IPs.</p>
+            <h3>Declare</h3>
+            <p>Write your app as one JSON spec at <code>apps/&lt;name&gt;/workload.json</code> &mdash; or paste it inline in your GitHub Actions workflow. A workload is <code>{app_name, cmd, env, github_release}</code>: a container, a binary, a shell script, your call.</p>
           </div>
         </div>
         <div class="step">
           <div class="step-num">2</div>
           <div class="step-content">
-            <h3>Attest</h3>
-            <p>The TDX VM generates a cryptographic quote proving the exact code running inside the enclave. EasyEnclave's attestation API lets you verify the measurement against known-good builds.</p>
+            <h3>Deploy</h3>
+            <p>Push via GitHub Actions &mdash; the <code>deploy-workload</code> action POSTs the spec to the agent's <code>/deploy</code> through its Cloudflare tunnel. No SSH, no raw IPs, no port forwards. Or skip the action and bake it as a boot workload.</p>
           </div>
         </div>
         <div class="step">
           <div class="step-num">3</div>
           <div class="step-content">
-            <h3>Run</h3>
-            <p>Your workload runs inside hardware-encrypted memory. The fleet dashboard shows health, metrics, and attestation status across all your agents. Logs stay inside the enclave boundary.</p>
+            <h3>Attest &amp; run</h3>
+            <p>Intel TDX seals the guest memory; the agent mints a quote and the CP verifies it via Intel Trust Authority at <code>/register</code>. Your workload runs inside hardware-encrypted memory while the fleet dashboard streams live CPU, disk, and network metrics.</p>
           </div>
         </div>
       </div>
@@ -75,13 +75,13 @@
         </div>
         <div class="card">
           <div class="icon">&#x1f4ca;</div>
-          <h3>Fleet Management</h3>
-          <p>dd-web dashboard shows all agents across your infrastructure. Prometheus-style collector scrapes /health. Federation for horizontal scaling.</p>
+          <h3>Fleet Metrics</h3>
+          <p>CP dashboard scrapes <code>/health</code> on every agent: CPU, memory, per-disk capacity, per-NIC rx/tx, ITA attestation status. Click an agent for detail; open a per-app terminal in the browser.</p>
         </div>
         <div class="card">
           <div class="icon">&#x1f680;</div>
-          <h3>API-Driven Deploys</h3>
-          <p>GitHub Actions deploy workloads via POST /deploy. No SSH. GITHUB_TOKEN auth works out of the box. Retry logic handles tunnel instability.</p>
+          <h3>Workloads as JSON</h3>
+          <p>Every app &mdash; cloudflared, dd-agent, ollama, openclaw, yours &mdash; is one file at <code>apps/&lt;name&gt;/workload.json</code>. Boot workloads and runtime deploys share the same schema. Drop in a JSON, ship it.</p>
         </div>
         <div class="card">
           <div class="icon">&#x20bf;</div>
@@ -96,7 +96,12 @@
         <div class="card">
           <div class="icon">&#x1f310;</div>
           <h3>Cloudflare Tunnels</h3>
-          <p>Every agent gets a tunnel hostname. No public IPs, no firewall rules, no port forwarding. dd-register provisions tunnels automatically on registration.</p>
+          <p>Every agent gets a tunnel hostname. No public IPs, no firewall rules, no port forwarding. The CP provisions tunnels automatically on registration.</p>
+        </div>
+        <div class="card">
+          <div class="icon">&#x1f4dc;</div>
+          <h3>Signed Releases</h3>
+          <p>Every <code>devopsdefender</code> binary CI publishes carries a Sigstore-backed GitHub build attestation. <code>gh attestation verify</code> proves a binary came from this repo's release workflow &mdash; provable provenance, not trust us.</p>
         </div>
       </div>
     </div>
@@ -105,7 +110,7 @@
   <section id="arch" class="section-center">
     <div class="container">
       <h2>Architecture</h2>
-      <p class="subtitle">1 binary, 2 modes, zero trust.</p>
+      <p class="subtitle">1 binary, 2 modes, workloads as code.</p>
       <div class="arch">
 <pre>
 <span class="hl">Customer</span> (browser)
@@ -114,20 +119,20 @@
 <span class="hl">Cloudflare Edge</span> ──── tunnel ────> <span class="gr">TDX VM</span>
                                     |
                             <span class="gr">easyenclave</span> (PID 1)
-                            ├── unix socket API
-                            ├── workload: <span class="hl">devopsdefender agent</span>
-                            │   ├── /health, /deploy, /exec
-                            │   ├── ITA-signed attestation
-                            │   └── registers with devopsdefender cp
-                            └── workload: <span class="hl">openclaw + ollama</span> (podman)
-                                ├── llama3.1:8b (GPU, prod)
-                                └── qwen2.5:0.5b (CPU, preview)
+                            |
+                            └── spawns workloads from <span class="hl">apps/*/workload.json</span>
+                                ├── <span class="hl">cloudflared</span>           (fetch-only, gives us a tunnel)
+                                ├── <span class="hl">devopsdefender agent</span>  (/health, /deploy, /exec)
+                                ├── <span class="hl">podman</span>                (static, rootful, daemon-less)
+                                └── container: <span class="hl">ollama + openclaw</span>
+                                    ├── llama3.1:8b on H100 (prod)
+                                    └── qwen2.5:0.5b on CPU (preview)
 
 <span class="hl">devopsdefender cp</span> (fleet dashboard + management)
   ├── discovers agents via CF tunnels
-  ├── scrapes /health (Prometheus-style)
-  ├── verifies agent ITA tokens at /register
-  └── web UI: fleet, per-agent terminal, logs
+  ├── scrapes /health (per-disk + per-NIC metrics)
+  ├── verifies each agent's ITA quote at /register
+  └── web UI: fleet table, per-agent detail, in-browser shell
 </pre>
       </div>
     </div>
@@ -136,13 +141,22 @@
   <section class="section-center">
     <div class="container">
       <h2>Deploy with GitHub Actions</h2>
-      <p class="subtitle">One action to deploy. One action to verify.</p>
+      <p class="subtitle">One action to deploy. One action to verify. Inline spec, no extra files.</p>
       <div class="code-block">
         <div class="code-header">.github/workflows/deploy.yml</div>
 <pre><span class="k">- uses:</span> <span class="s">devopsdefender/dd/.github/actions/deploy-workload@main</span>
   <span class="k">with:</span>
     <span class="k">agent-url:</span> <span class="s">https://app.devopsdefender.com</span>
-    <span class="k">deploy-spec:</span> <span class="s">apps/myapp/deploy.json</span>
+    <span class="c"># deploy-spec: apps/myapp/workload.json   # or a file path</span>
+    <span class="k">deploy-spec-inline:</span> <span class="s">|</span>
+      <span class="s">{</span>
+        <span class="s">"app_name": "myapp",</span>
+        <span class="s">"github_release": {</span>
+          <span class="s">"repo": "me/myapp",</span>
+          <span class="s">"asset": "myapp-linux-amd64"</span>
+        <span class="s">},</span>
+        <span class="s">"cmd": ["myapp", "serve"]</span>
+      <span class="s">}</span>
 
 <span class="k">- uses:</span> <span class="s">devopsdefender/dd/.github/actions/verify-deployment@main</span>
   <span class="k">with:</span>
@@ -150,6 +164,7 @@
     <span class="k">deployment:</span> <span class="s">myapp</span>
     <span class="k">timeout:</span> <span class="s">300</span></pre>
       </div>
+      <p style="margin-top:16px;color:var(--text-dim);font-size:14px;">Every workload &mdash; dd-agent, cloudflared, ollama, openclaw, yours &mdash; is one JSON spec at <code>apps/&lt;name&gt;/workload.json</code>. Boot-time, runtime, first-class; same schema everywhere.</p>
     </div>
   </section>
 

--- a/style.css
+++ b/style.css
@@ -76,6 +76,7 @@ section .subtitle { color: var(--text-dim); font-size: 16px; margin-bottom: 40px
 .code-block pre { padding: 20px; font-family: var(--mono); font-size: 13px; line-height: 1.6; overflow-x: auto; }
 .code-block .k { color: var(--mauve); }
 .code-block .s { color: var(--green); }
+.code-block .c { color: var(--text-dim); font-style: italic; }
 
 /* Callout */
 .callout { background: var(--bg-alt); border: 1px solid var(--surface); border-radius: 12px; padding: 40px; text-align: center; max-width: 640px; margin: 0 auto; }


### PR DESCRIPTION
## Summary

Three months of iteration have solidified how DD actually deploys + measures things. Update the landing page to match.

### How It Works — three steps, updated

| step | was | now |
|---|---|---|
| 1 | "Push your container image" | **Declare**: a workload is one JSON spec at `apps/<name>/workload.json` (or inline in the workflow). |
| 2 | "Attest" via EasyEnclave | **Deploy**: `deploy-workload` action POSTs the spec to `/deploy`. Or bake it as a boot workload. |
| 3 | "Run" | **Attest & run**: TDX seals memory; CP verifies the Intel ITA quote at `/register`; fleet streams live CPU + disk + NIC metrics. |

### Deploy example — inline + on-disk convention

`deploy-spec-inline:` heredoc is the active form; `deploy-spec:` file path stays commented out above for copy-paste convenience. Adds a note that on-disk specs live at `apps/<name>/workload.json`.

### Feature cards

- **Fleet Metrics** (was Fleet Management) — mentions per-disk capacity + per-NIC rx/tx (PR #126) and the per-agent in-browser terminal.
- **Workloads as JSON** (was API-Driven Deploys) — leads with the `apps/` tree.
- **Signed Releases** (new) — Sigstore-backed GitHub attestations on every binary CI publishes (PR #125).
- **Cloudflare Tunnels** — drops "dd-register" in favour of "the CP".

### Architecture diagram

- easyenclave now spawns workloads from `apps/*/workload.json`.
- Podman shows up as its own workload; ollama + openclaw run as a container on top of it (reflects PR #127's boot chain).
- Subtitle: "1 binary, 2 modes, workloads as code."

### Plumbing

Adds `.c` class to style.css (dim/italic) for commented lines in code blocks. The `deploy-spec` file-path line in the inline-spec example uses it.

## Test plan

- [ ] gh-pages preview at `pr-preview/pr-N/` — eyeball the hero, steps, features, architecture diagram, and deploy example. Commented line should render dim/italic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)