### PR TITLE
feat(auth): accept Cloudflare Access JWTs

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -21,7 +21,7 @@ use serde::Deserialize;
 use tokio::sync::RwLock;
 
 use crate::auth::{self, Keys};
-use crate::config::Agent as Cfg;
+use crate::config::{Agent as Cfg, CfAccess};
 use crate::ee::Ee;
 use crate::error::{Error, Result};
 use crate::html::{self, shell};
@@ -39,6 +39,7 @@ struct St {
     cfg: Arc<Cfg>,
     ee: Arc<Ee>,
     keys: Arc<Keys>,
+    access: Option<Arc<auth::AccessValidator>>,
     hostname: String,
     /// Tunnel name returned by the CP at /register — stable for the
     /// life of this agent's tunnel. The /ingress/replace call on the
@@ -76,6 +77,10 @@ pub async fn run() -> Result<()> {
     spawn_cloudflared(b.tunnel_token);
 
     let keys = Arc::new(Keys::from_b64(&b.jwt_secret_b64, &b.cp_hostname)?);
+    let access = b.cf_access.map(auth::AccessValidator::new).map(Arc::new);
+    if access.is_some() {
+        eprintln!("agent: Cloudflare Access auth enabled");
+    }
     let ita_token = Arc::new(RwLock::new(initial_token));
 
     // Background re-mint so /health always serves a non-expired token
@@ -104,6 +109,7 @@ pub async fn run() -> Result<()> {
         cfg: cfg.clone(),
         ee,
         keys,
+        access,
         hostname: b.hostname,
         agent_id: b.agent_id,
         cp_hostname: b.cp_hostname,
@@ -137,6 +143,8 @@ struct Bootstrap {
     agent_id: String,
     jwt_secret_b64: String,
     cp_hostname: String,
+    #[serde(default)]
+    cf_access: Option<CfAccess>,
 }
 
 async fn register(cfg: &Cfg, ita_token: &str) -> Result<Bootstrap> {
@@ -257,7 +265,7 @@ async fn require_auth(
     headers: &HeaderMap,
     uri: &axum::http::Uri,
 ) -> std::result::Result<String, Response> {
-    match auth::resolve(&s.keys, &s.cfg.common.owner, headers).await {
+    match auth::resolve(&s.keys, &s.cfg.common.owner, s.access.as_deref(), headers).await {
         Ok(login) => Ok(login),
         Err(Error::Unauthorized) => Err(auth::login_redirect(&s.cp_hostname, uri)),
         Err(e) => Err(e.into_response()),
@@ -452,7 +460,7 @@ async fn deploy(
     headers: HeaderMap,
     Json(spec): Json<serde_json::Value>,
 ) -> Result<Json<serde_json::Value>> {
-    auth::resolve(&s.keys, &s.cfg.common.owner, &headers).await?;
+    auth::resolve(&s.keys, &s.cfg.common.owner, s.access.as_deref(), &headers).await?;
 
     // Pull `expose` off the spec before forwarding to EE. EE ignores
     // unknown fields today but keeping the payload tidy avoids future
@@ -548,7 +556,7 @@ async fn exec(
     headers: HeaderMap,
     Json(req): Json<ExecReq>,
 ) -> Result<Json<serde_json::Value>> {
-    auth::resolve(&s.keys, &s.cfg.common.owner, &headers).await?;
+    auth::resolve(&s.keys, &s.cfg.common.owner, s.access.as_deref(), &headers).await?;
     Ok(Json(s.ee.exec(&req.cmd, req.timeout_secs).await?))
 }
 
@@ -558,7 +566,7 @@ async fn session_ws(
     headers: HeaderMap,
     ws: WebSocketUpgrade,
 ) -> Result<Response> {
-    auth::resolve(&s.keys, &s.cfg.common.owner, &headers).await?;
+    auth::resolve(&s.keys, &s.cfg.common.owner, s.access.as_deref(), &headers).await?;
     let _ = app;
     let vm = s.cfg.common.vm_name.clone();
     let ee = s.ee.clone();

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,26 +1,35 @@
-//! Single-path auth.
+//! Origin auth.
 //!
-//! One token type: GitHub PAT. Two presentations:
-//!   - `Authorization: Bearer <pat>` — CI, curl. Verified against GitHub.
-//!   - `dd_auth` JWT cookie (HS256, `Domain=.{cf.domain}`) — browsers.
-//!     Issued only by the CP's `/auth/pat` POST; shared across all
-//!     `*.{cf.domain}` hosts, so agents verify it without ever issuing.
+//! During the Cloudflare Access migration we accept three presentations:
+//!   - `Cf-Access-Jwt-Assertion` — preferred browser/service identity,
+//!     signed by Cloudflare Access and validated locally by CP/agents.
+//!   - `dd_auth` JWT cookie (HS256, `Domain=.{cf.domain}`) — legacy
+//!     browser auth issued by the CP's `/auth/pat` POST.
+//!   - `Authorization: Bearer <pat>` — legacy CI/curl path verified
+//!     against GitHub.
 
 use std::time::Duration;
 
 use axum::http::header::{AUTHORIZATION, COOKIE, SET_COOKIE};
-use axum::http::{HeaderMap, HeaderValue, Uri};
+use axum::http::{HeaderMap, HeaderName, HeaderValue, Uri};
 use axum::response::{IntoResponse, Redirect, Response};
 use base64::Engine;
-use jsonwebtoken::{Algorithm, DecodingKey, EncodingKey, Header, Validation};
+use jsonwebtoken::jwk::{Jwk, JwkSet};
+use jsonwebtoken::{
+    decode, decode_header, Algorithm, DecodingKey, EncodingKey, Header, Validation,
+};
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use tokio::sync::RwLock;
 
+use crate::config::CfAccess;
 use crate::error::{Error, Result};
 
 pub const AUTH_COOKIE: &str = "dd_auth";
 pub const COOKIE_TTL: Duration = Duration::from_secs(24 * 60 * 60);
 const JWT_ALG: Algorithm = Algorithm::HS256;
+const CF_ACCESS_JWT_ASSERTION: HeaderName = HeaderName::from_static("cf-access-jwt-assertion");
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Claims {
@@ -42,6 +51,101 @@ pub struct Keys {
     /// Raw secret bytes, base64-encoded. The CP passes this to agents
     /// in their register response so they can verify the same JWTs.
     pub secret_b64: String,
+}
+
+#[derive(Clone)]
+pub struct AccessValidator {
+    cfg: CfAccess,
+    http: Client,
+    jwks: Arc<RwLock<Option<JwkSet>>>,
+}
+
+impl AccessValidator {
+    pub fn new(cfg: CfAccess) -> Self {
+        Self {
+            cfg,
+            http: Client::new(),
+            jwks: Arc::new(RwLock::new(None)),
+        }
+    }
+
+    pub async fn resolve(&self, headers: &HeaderMap) -> Result<Option<String>> {
+        let Some(token) = access_token(headers) else {
+            return Ok(None);
+        };
+        let claims = self.verify_token(token).await?;
+        Ok(Some(access_principal(&claims)))
+    }
+
+    async fn verify_token(&self, token: &str) -> Result<serde_json::Value> {
+        let header = decode_header(token).map_err(|_| Error::Unauthorized)?;
+        if header.alg != Algorithm::RS256 {
+            return Err(Error::Unauthorized);
+        }
+        let kid = header.kid.ok_or(Error::Unauthorized)?;
+
+        let jwk = self.get_jwk(&kid).await?;
+        match self.decode_with_jwk(token, &jwk) {
+            Ok(claims) => Ok(claims),
+            Err(_) => {
+                // Access rotates signing keys; refresh once on failure
+                // in case the cached set is stale but the token is valid.
+                self.refresh_jwks().await?;
+                let jwk = self.get_cached_jwk(&kid).await.ok_or(Error::Unauthorized)?;
+                self.decode_with_jwk(token, &jwk)
+                    .map_err(|_| Error::Unauthorized)
+            }
+        }
+    }
+
+    async fn get_jwk(&self, kid: &str) -> Result<Jwk> {
+        if let Some(jwk) = self.get_cached_jwk(kid).await {
+            return Ok(jwk);
+        }
+        self.refresh_jwks().await?;
+        self.get_cached_jwk(kid).await.ok_or(Error::Unauthorized)
+    }
+
+    async fn get_cached_jwk(&self, kid: &str) -> Option<Jwk> {
+        self.jwks
+            .read()
+            .await
+            .as_ref()
+            .and_then(|set| set.find(kid).cloned())
+    }
+
+    async fn refresh_jwks(&self) -> Result<()> {
+        let resp = self
+            .http
+            .get(&self.cfg.jwks_url)
+            .send()
+            .await
+            .map_err(|e| Error::Upstream(format!("CF Access certs: {e}")))?;
+        let status = resp.status();
+        if !status.is_success() {
+            let text = resp.text().await.unwrap_or_default();
+            return Err(Error::Upstream(format!(
+                "CF Access certs {} -> {status}: {text}",
+                self.cfg.jwks_url
+            )));
+        }
+        let jwks = resp.json::<JwkSet>().await?;
+        *self.jwks.write().await = Some(jwks);
+        Ok(())
+    }
+
+    fn decode_with_jwk(
+        &self,
+        token: &str,
+        jwk: &Jwk,
+    ) -> jsonwebtoken::errors::Result<serde_json::Value> {
+        let key = DecodingKey::from_jwk(jwk)?;
+        let mut validation = Validation::new(Algorithm::RS256);
+        validation.set_required_spec_claims(&["exp", "iss", "aud"]);
+        validation.set_issuer(&[self.cfg.issuer.as_str()]);
+        validation.set_audience(&self.cfg.audiences);
+        decode::<serde_json::Value>(token, &key, &validation).map(|d| d.claims)
+    }
 }
 
 impl Keys {
@@ -181,6 +285,26 @@ pub fn bearer(headers: &HeaderMap) -> Option<String> {
         .filter(|s| !s.is_empty())
 }
 
+fn access_token(headers: &HeaderMap) -> Option<&str> {
+    headers
+        .get(CF_ACCESS_JWT_ASSERTION)?
+        .to_str()
+        .ok()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+}
+
+fn access_principal(claims: &serde_json::Value) -> String {
+    for key in ["email", "common_name", "sub"] {
+        if let Some(v) = claims.get(key).and_then(|v| v.as_str()) {
+            if !v.is_empty() {
+                return v.to_string();
+            }
+        }
+    }
+    "cf-access".into()
+}
+
 pub fn with_cookie(resp: impl IntoResponse, cookie_value: String) -> Response {
     let mut r = resp.into_response();
     if let Ok(hv) = HeaderValue::from_str(&cookie_value) {
@@ -196,7 +320,17 @@ pub fn sanitize_next(next: Option<&str>) -> String {
     }
 }
 
-pub async fn resolve(keys: &Keys, owner: &str, headers: &HeaderMap) -> Result<String> {
+pub async fn resolve(
+    keys: &Keys,
+    owner: &str,
+    access: Option<&AccessValidator>,
+    headers: &HeaderMap,
+) -> Result<String> {
+    if let Some(access) = access {
+        if let Some(principal) = access.resolve(headers).await? {
+            return Ok(principal);
+        }
+    }
     if let Some(jwt) = read_cookie(headers, AUTH_COOKIE) {
         if let Some(c) = keys.verify(&jwt) {
             return Ok(c.login);

--- a/src/cf.rs
+++ b/src/cf.rs
@@ -9,7 +9,7 @@ use base64::Engine;
 use reqwest::{Client, Method};
 use serde::{Deserialize, Serialize};
 
-use crate::config::CfCreds;
+use crate::config::{CfAccess, CfCreds};
 use crate::error::{Error, Result};
 
 const API: &str = "https://api.cloudflare.com/client/v4";
@@ -285,6 +285,124 @@ pub async fn list(http: &Client, cf: &CfCreds) -> Result<Vec<serde_json::Value>>
     Ok(resp["result"].as_array().cloned().unwrap_or_default())
 }
 
+/// Discover Cloudflare Access origin-JWT verifier metadata for a hostname
+/// from the account's configured Access applications. Exact hostname apps
+/// win over wildcard apps. Returns `Ok(None)` when Access is not configured
+/// for the hostname.
+pub async fn discover_access(
+    http: &Client,
+    cf: &CfCreds,
+    hostname: &str,
+) -> Result<Option<CfAccess>> {
+    let org = call(
+        http,
+        cf,
+        Method::GET,
+        &format!("/accounts/{}/access/organizations", cf.account_id),
+        None,
+    )
+    .await?;
+    let auth_domain = org["result"]["auth_domain"]
+        .as_str()
+        .ok_or_else(|| Error::Upstream("CF Access organization: missing auth_domain".into()))?;
+    let issuer = normalize_access_issuer(auth_domain);
+
+    let apps = call(
+        http,
+        cf,
+        Method::GET,
+        &format!("/accounts/{}/access/apps?per_page=200", cf.account_id),
+        None,
+    )
+    .await?;
+    let Some(items) = apps["result"].as_array() else {
+        return Ok(None);
+    };
+
+    let mut best: Option<(u8, String)> = None;
+    for app in items {
+        if app["type"].as_str() != Some("self_hosted") {
+            continue;
+        }
+        let Some(aud) = app["aud"].as_str() else {
+            continue;
+        };
+        let score = access_app_match_score(app, hostname);
+        if score > best.as_ref().map(|(s, _)| *s).unwrap_or(0) {
+            best = Some((score, aud.to_string()));
+        }
+    }
+
+    Ok(best.map(|(_, aud)| CfAccess {
+        jwks_url: format!("{issuer}/cdn-cgi/access/certs"),
+        issuer,
+        audiences: vec![aud],
+    }))
+}
+
+fn normalize_access_issuer(raw: &str) -> String {
+    let raw = raw.trim().trim_end_matches('/');
+    if raw.starts_with("https://") || raw.starts_with("http://") {
+        raw.to_string()
+    } else {
+        format!("https://{raw}")
+    }
+}
+
+fn access_app_match_score(app: &serde_json::Value, hostname: &str) -> u8 {
+    access_app_patterns(app)
+        .into_iter()
+        .filter_map(|pattern| hostname_pattern_score(&pattern, hostname))
+        .max()
+        .unwrap_or(0)
+}
+
+fn access_app_patterns(app: &serde_json::Value) -> Vec<String> {
+    let mut patterns = Vec::new();
+    if let Some(domain) = app["domain"].as_str() {
+        patterns.push(domain.to_string());
+    }
+    if let Some(items) = app["self_hosted_domains"].as_array() {
+        patterns.extend(items.iter().filter_map(|v| v.as_str().map(String::from)));
+    }
+    if let Some(items) = app["destinations"].as_array() {
+        patterns.extend(
+            items
+                .iter()
+                .filter_map(|v| v["uri"].as_str().map(String::from)),
+        );
+    }
+    patterns
+}
+
+fn hostname_pattern_score(pattern: &str, hostname: &str) -> Option<u8> {
+    let pattern = pattern_host(pattern)?;
+    if pattern == hostname {
+        return Some(2);
+    }
+    let suffix = pattern.strip_prefix("*.")?;
+    if hostname != suffix && hostname.ends_with(&format!(".{suffix}")) {
+        Some(1)
+    } else {
+        None
+    }
+}
+
+fn pattern_host(pattern: &str) -> Option<String> {
+    let without_scheme = pattern
+        .trim()
+        .strip_prefix("https://")
+        .or_else(|| pattern.trim().strip_prefix("http://"))
+        .unwrap_or_else(|| pattern.trim());
+    let host = without_scheme
+        .split('/')
+        .next()
+        .unwrap_or_default()
+        .trim()
+        .trim_end_matches('.');
+    (!host.is_empty()).then(|| host.to_ascii_lowercase())
+}
+
 /// `Some(true)` if present, `Some(false)` if confirmed deleted, `None`
 /// on ambiguous transport error — the watchdog uses `None` to mean
 /// "don't count as gone" and avoid flaky kernel_poweroffs.
@@ -305,5 +423,52 @@ pub async fn exists(http: &Client, cf: &CfCreds, tunnel_id: &str) -> Option<bool
             Some(body["result"]["deleted_at"].is_null())
         }
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{access_app_match_score, hostname_pattern_score, normalize_access_issuer};
+
+    #[test]
+    fn issuer_is_normalized_to_https_url() {
+        assert_eq!(
+            normalize_access_issuer("team.cloudflareaccess.com"),
+            "https://team.cloudflareaccess.com"
+        );
+        assert_eq!(
+            normalize_access_issuer("https://team.cloudflareaccess.com/"),
+            "https://team.cloudflareaccess.com"
+        );
+    }
+
+    #[test]
+    fn hostname_patterns_match_exact_and_wildcard() {
+        assert_eq!(
+            hostname_pattern_score("app.example.com", "app.example.com"),
+            Some(2)
+        );
+        assert_eq!(
+            hostname_pattern_score("*.example.com", "agent.example.com"),
+            Some(1)
+        );
+        assert_eq!(hostname_pattern_score("*.example.com", "example.com"), None);
+        assert_eq!(
+            hostname_pattern_score("*.example.com", "badexample.com"),
+            None
+        );
+    }
+
+    #[test]
+    fn access_app_match_score_reads_all_supported_fields() {
+        let app = serde_json::json!({
+            "domain": "old.example.com",
+            "self_hosted_domains": ["*.example.com"],
+            "destinations": [{"type": "public", "uri": "https://exact.example.com/path"}]
+        });
+
+        assert_eq!(access_app_match_score(&app, "agent.example.com"), 1);
+        assert_eq!(access_app_match_score(&app, "exact.example.com"), 2);
+        assert_eq!(access_app_match_score(&app, "other.test"), 0);
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,7 @@
 //! Environment-derived configuration for both modes.
 
 use crate::error::{Error, Result};
+use serde::{Deserialize, Serialize};
 
 #[derive(Clone)]
 pub struct CfCreds {
@@ -55,6 +56,15 @@ impl Common {
             vm_name,
         })
     }
+}
+
+/// Cloudflare Access origin JWT validation metadata discovered from
+/// Cloudflare's Access application config.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct CfAccess {
+    pub issuer: String,
+    pub audiences: Vec<String>,
+    pub jwks_url: String,
 }
 
 /// ITA (Intel Trust Authority) configuration. All fields required —

--- a/src/cp.rs
+++ b/src/cp.rs
@@ -40,6 +40,7 @@ struct St {
     cfg: Arc<Cfg>,
     ee: Arc<Ee>,
     keys: Arc<Keys>,
+    access: Option<Arc<auth::AccessValidator>>,
     store: Store,
     started: Instant,
     verifier: Arc<ita::Verifier>,
@@ -81,6 +82,8 @@ pub async fn run() -> Result<()> {
     let store: Store = Arc::new(Mutex::new(HashMap::new()));
 
     let keys = Arc::new(Keys::fresh(&cfg.hostname));
+    let access_cfg = discover_access_for(&http, &cfg.cf, &cfg.hostname, "cp").await;
+    let access = access_cfg.map(auth::AccessValidator::new).map(Arc::new);
 
     // ITA verifier — required.
     let verifier = ita::Verifier::new(cfg.ita.jwks_url.clone(), cfg.ita.issuer.clone());
@@ -203,6 +206,7 @@ pub async fn run() -> Result<()> {
         cfg: cfg.clone(),
         ee,
         keys,
+        access,
         store,
         started: Instant::now(),
         verifier,
@@ -338,6 +342,7 @@ async fn register(
         .map(|e| (e.hostname_label.clone(), e.port))
         .collect();
     let tunnel = cf::create(&http, &s.cfg.cf, &name, &agent_hostname, &extras).await?;
+    let access_cfg = discover_access_for(&http, &s.cfg.cf, &agent_hostname, &req.vm_name).await;
     if !tunnel.extra_hostnames.is_empty() {
         eprintln!(
             "cp: registered extra ingress for {}: {:?}",
@@ -398,7 +403,34 @@ async fn register(
         "agent_id": name,
         "jwt_secret_b64": s.keys.secret_b64,
         "cp_hostname": s.cfg.hostname,
+        "cf_access": access_cfg,
     })))
+}
+
+async fn discover_access_for(
+    http: &reqwest::Client,
+    cf: &crate::config::CfCreds,
+    hostname: &str,
+    label: &str,
+) -> Option<crate::config::CfAccess> {
+    match crate::cf::discover_access(http, cf, hostname).await {
+        Ok(Some(access)) => {
+            eprintln!(
+                "cp: Cloudflare Access auth enabled for {label} ({hostname}, issuer={}, audiences={})",
+                access.issuer,
+                access.audiences.join(",")
+            );
+            Some(access)
+        }
+        Ok(None) => {
+            eprintln!("cp: no Cloudflare Access app matched {hostname}; using legacy auth only");
+            None
+        }
+        Err(e) => {
+            eprintln!("cp: Cloudflare Access discovery failed for {hostname}: {e}");
+            None
+        }
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -835,7 +867,7 @@ async fn shell_ws(
     headers: HeaderMap,
     ws: WebSocketUpgrade,
 ) -> Result<Response> {
-    auth::resolve(&s.keys, &s.cfg.common.owner, &headers).await?;
+    auth::resolve(&s.keys, &s.cfg.common.owner, s.access.as_deref(), &headers).await?;
     let ee = s.ee.clone();
     let vm = format!("dd-{}-cp", s.cfg.common.env_label);
     Ok(ws.on_upgrade(move |socket| async move {
@@ -850,7 +882,7 @@ async fn require_auth(
     headers: &HeaderMap,
     uri: &axum::http::Uri,
 ) -> std::result::Result<String, Response> {
-    match auth::resolve(&s.keys, &s.cfg.common.owner, headers).await {
+    match auth::resolve(&s.keys, &s.cfg.common.owner, s.access.as_deref(), headers).await {
         Ok(login) => Ok(login),
         Err(Error::Unauthorized) => Err(auth::login_redirect_local(uri)),
         Err(e) => Err(e.into_response()),


### PR DESCRIPTION
## Summary
- discover Cloudflare Access app issuer/AUD metadata from the Cloudflare API instead of requiring verifier env vars
- validate Cf-Access-Jwt-Assertion at the CP and agents when a matching Access app exists
- pass discovered Access verifier config to agents during /register while keeping dd_auth/PAT fallback for migration

## Notes
- Cloudflare still owns the Access signing keys and app AUD generation; DD discovers and validates them.
- If no matching Access app exists or the CF token lacks Access Apps read permission, DD logs and keeps legacy auth behavior.

## Tests
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --target x86_64-unknown-linux-musl -- -D warnings
- cargo test