### PR TITLE
ci(prod): auto-deploy web-nvidia-smi after agent relaunches

### DIFF
--- a/.github/workflows/deploy-cp.yml
+++ b/.github/workflows/deploy-cp.yml
@@ -333,19 +333,35 @@ jobs:
           ita-api-key: ${{ secrets.DD_ITA_API_KEY }}
           release-tag: ${{ inputs.release_tag }}
 
-      # Every env: deploy hello-world to the just-registered agent
-      # via /deploy with a per-job GitHub Actions OIDC token. This
-      # exercises the full GH-OIDC auth path (mint → agent verify
+      # Preview only: deploy hello-world as the end-to-end canary.
+      # Exercises the full GH-OIDC auth path (mint → agent verify
       # against GitHub JWKS → repository_owner check) AND proves
-      # podman bootstrapped correctly on the agent. Also probes the
-      # rejection path: a curl without the OIDC header must 401.
+      # podman bootstrapped correctly on the agent. Prod uses
+      # web-nvidia-smi (below) for the same verification, so running
+      # hello-world there too is just noise.
       - name: Deploy hello-world via GH OIDC
-        if: inputs.relaunch_agent
+        if: inputs.relaunch_agent && inputs.env != 'production'
         uses: ./.github/actions/dd-deploy
         with:
           cp-url: https://${{ inputs.hostname }}
-          vm-name: ${{ inputs.env == 'production' && 'dd-local-prod' || 'dd-local-preview' }}
+          vm-name: dd-local-preview
           workload: apps/hello-world/workload.json
+
+      # Prod only: redeploy the nvidia-smi demo every main-push so
+      # `<agent-base>-gpu.devopsdefender.com` stays live and pinned to
+      # the freshly-booted prod agent. Preview agents have no GPU, so
+      # the workload's podman run with /dev/nvidia* devices would fail.
+      - name: Deploy web-nvidia-smi via GH OIDC
+        if: inputs.relaunch_agent && inputs.env == 'production'
+        uses: ./.github/actions/dd-deploy
+        with:
+          cp-url: https://${{ inputs.hostname }}
+          vm-name: dd-local-prod
+          workload: apps/web-nvidia-smi/workload.json
+          # nvidia-smi's container needs a `podman pull` + apt-get
+          # install of netcat in the first run — give it headroom
+          # past the default 120s so the /health poll catches it.
+          wait-for-deployment-seconds: '300'
 
       # Runs last so the relaunch cascade's own STONITH wave (old agent
       # re-registers → old CP's CF tunnel is deleted → old CP poweroffs)


### PR DESCRIPTION
## Summary

The release pipeline has been deploying \`hello-world\` as the end-to-end canary after agent relaunches, but \`web-nvidia-smi\` — the actual GPU demo published at \`<agent-base>-gpu.devopsdefender.com\` — was never wired into the CI path. After every main-push the URL stayed stale (pinned to a previous agent UUID) or unset.

New step in \`deploy-cp.yml\` posts \`apps/web-nvidia-smi/workload.json\` to the prod agent's \`/deploy\` via the same \`dd-deploy\` composite action. Prod-only guard (\`inputs.env == 'production'\`) — preview agents have no GPU passthrough and the workload's \`podman run --device=/dev/nvidia*\` would fail. Bumps \`wait-for-deployment-seconds\` to 300 because the first run has to \`podman pull docker.io/nvidia/cuda:…\` and \`apt-get install netcat\` before the /health poll can see it.

## Test plan

- [ ] Merge, push, watch release. Expect \`Deploy web-nvidia-smi via GH OIDC\` step to complete within ~4 min.
- [ ] \`curl https://<prod-agent-base>-gpu.devopsdefender.com/\` returns raw \`nvidia-smi\` table output.
- [ ] Prod agent's \`/health\` shows \`web-nvidia-smi\` in \`deployments\` and \`{hostname_label: gpu, port: 8081}\` in \`extra_ingress\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)