### PR TITLE
ci(dd-deploy): curl --retry on CF-edge blips

### DIFF
--- a/.github/actions/dd-deploy/action.yml
+++ b/.github/actions/dd-deploy/action.yml
@@ -56,8 +56,14 @@ runs:
         fi
 
         # Discover the agent hostname on the CP. /api/agents is
-        # CF-Access-bypassed (public read).
-        agent_host=$(curl -fsS "${CP_URL}/api/agents" \
+        # CF-Access-bypassed (public read). Curl's native --retry
+        # absorbs the transient 5xx (notably CF 530 "origin
+        # unreachable") that reliably hits right after an agent
+        # relaunch — the edge is momentarily between routes. ~30 s
+        # of retries, no bash loop.
+        agent_host=$(curl -fsS \
+          --retry 6 --retry-delay 5 --retry-all-errors \
+          "${CP_URL}/api/agents" \
           | jq -r --arg vm "$VM_NAME" '
               [.[] | select(.vm_name == $vm and .status == "healthy")]
               | sort_by(.last_seen) | reverse | .[0].hostname // empty')
@@ -82,10 +88,12 @@ runs:
         echo "app-name=$app_name" >> "$GITHUB_OUTPUT"
 
         echo "POST /deploy to $agent_host (app=$app_name, repo=$GITHUB_REPOSITORY)"
-        # Capture the body so we can show what EE said — the agent
-        # forwards EE's response verbatim and a non-2xx from the edge
-        # is the only signal curl -f catches.
-        body=$(curl -fsS -X POST "https://${agent_host}/deploy" \
+        # Same CF-edge transient can hit the agent hostname too —
+        # reuse the same retry envelope. Capture the body so we can
+        # show what EE said; the agent forwards it verbatim.
+        body=$(curl -fsS \
+          --retry 6 --retry-delay 5 --retry-all-errors \
+          -X POST "https://${agent_host}/deploy" \
           -H "Authorization: Bearer ${oidc}" \
           -H "Content-Type: application/json" \
           -d "$spec")


### PR DESCRIPTION
## Summary

The \`/api/agents\` lookup and \`/deploy\` POST inside \`dd-deploy\` run through the CF tunnel right after an agent relaunch — the exact moment CF's edge reliably returns a transient 530 \"origin unreachable\" while routing settles. Three main-push prod releases in a row have failed the whole deploy on this same blip despite the CP being healthy.

Add curl's native \`--retry 6 --retry-delay 5 --retry-all-errors\` envelope (~30 s total) to both calls. No bash loops — native curl absorbs the transient 5xx and continues on success. Same pattern we use in \`relaunch-agent\`'s \`Wait for CP healthy\` step.

## Test plan

- [ ] After merge, next push to main goes green end-to-end (no manual rerun needed).
- [ ] \`https://<prod-agent-base>-gpu.devopsdefender.com/\` serves nvidia-smi output.
- [ ] If CF is less flaky than feared, the retry never fires; zero behavior change on happy deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)