### PR TITLE
feat(apps): bake tmuxrs binary on CP + agents

### DIFF
--- a/.github/workflows/deploy-cp.yml
+++ b/.github/workflows/deploy-cp.yml
@@ -136,6 +136,7 @@ jobs:
             bake apps/cloudflared/workload.json
             bake apps/dd-management/workload.json.tmpl
             bake apps/ttyd/workload.json
+            bake apps/tmuxrs/workload.json
           } | jq -cs '.')
 
           jq -c -n \

--- a/apps/_infra/local-agents.sh
+++ b/apps/_infra/local-agents.sh
@@ -135,6 +135,7 @@ build_config_iso() {
     bake "$REPO_ROOT/apps/podman-bootstrap/workload.json"
     bake "$REPO_ROOT/apps/cloudflared/workload.json"
     bake "$REPO_ROOT/apps/ttyd/workload.json"
+    bake "$REPO_ROOT/apps/tmuxrs/workload.json"
   })
 
   local extra_ingress

--- a/apps/tmuxrs/workload.json
+++ b/apps/tmuxrs/workload.json
@@ -1,0 +1,8 @@
+{
+  "app_name": "tmuxrs",
+  "github_release": {
+    "repo": "beijaflor/tmuxrs",
+    "asset": "tmuxrs-linux-amd64",
+    "rename": "tmuxrs"
+  }
+}


### PR DESCRIPTION
## Summary

Add [beijaflor/tmuxrs](https://github.com/beijaflor/tmuxrs) (a Rust tmux session manager, drop-in tmuxinator replacement) as a fetch-only boot workload so the binary lands in \`/var/lib/easyenclave/bin/tmuxrs\` on every VM. Same \`github_release + rename\` pattern cloudflared uses.

Baked on:
- CP (deploy-cp.yml boot set)
- Preview + prod agents (local-agents.sh boot set)

## Heads-up

tmuxrs requires \`tmux\` on \`PATH\` at runtime. EE's rootfs may or may not ship tmux — haven't checked. If it doesn't, the binary will be reachable but will error when it tries to drive tmux. Fixing that is on the EE rootfs side, outside this repo.

## Test plan

- [ ] After merge, the next main push bakes tmuxrs into the prod CP + prod agent config.iso.
- [ ] \`ls /var/lib/easyenclave/bin/tmuxrs\` inside a ttyd session shows the binary.
- [ ] \`tmuxrs list\` → either works (if tmux is present) or errors about tmux (then file an EE rootfs issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)