### PR TITLE
chore(cf): gate block.<hostname> with CF Access human policy

### DIFF
--- a/src/cf.rs
+++ b/src/cf.rs
@@ -475,7 +475,13 @@ async fn ensure_bypass_app(http: &Client, cf: &CfCreds, name: &str, domain: &str
 /// log viewer, future metrics panel). These get a human CF Access
 /// app, not a public bypass — otherwise exposing ttyd on a public
 /// subdomain would be a free shell for the internet.
-const ADMIN_LABELS: &[&str] = &["term"];
+///
+/// - `term` — ttyd workload (DD's built-in).
+/// - `block` — [bastion](https://github.com/devopsdefender/bastion)
+///   workload when deployed onto an agent via dd-deploy. Bastion is a
+///   block-aware web terminal; exposing it without auth is the same
+///   "free shell for the internet" risk.
+const ADMIN_LABELS: &[&str] = &["term", "block"];
 
 fn is_admin_label(label: &str) -> bool {
     ADMIN_LABELS.contains(&label)


### PR DESCRIPTION
## Summary
- Adds \`\"block\"\` to \`ADMIN_LABELS\` alongside \`\"term\"\`.
- Lands ahead of [bastion v0.2](https://github.com/devopsdefender/bastion) so that when bastion is deployed as a workload onto existing DD agents via \`dd-deploy\` and publishes on \`hostname_label=\"block\"\`, the resulting subdomain gets a human CF Access app (GitHub org or admin email) — not a public bypass.
- DD's own built-in \`/term\` stays ttyd; bastion deploys alongside at \`block.<hostname>\`, not in place of.

## Test plan
- [x] cargo fmt / clippy / test pass locally
- [ ] Merge → main auto-deploys → \`block.app.devopsdefender.com\` Access app exists (initially with no origin behind it until bastion's release deploys a workload there)
- [ ] Subsequent bastion v0.2 release triggers \`dd-deploy\`, bastion appears at \`block.app.devopsdefender.com\` behind the new Access policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)