### PR TITLE
fix(preview): create /run/ee for bastion + diagnose /deploy empty response

### DIFF
--- a/crates/bastion/src/capture.rs
+++ b/crates/bastion/src/capture.rs
@@ -65,6 +65,12 @@ fn default_stdout() -> String {
 /// process crash).
 pub async fn spawn_listener(path: impl AsRef<Path>) -> std::io::Result<()> {
     let path: PathBuf = path.as_ref().to_path_buf();
+    // `bind(2)` on a unix socket ENOENTs if the parent dir is missing.
+    // On the DD agent VM, `/run/ee/` is the conventional capture-socket
+    // dir but nothing creates it — so we do it ourselves. Idempotent.
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent).await?;
+    }
     // Unix sockets linger after the owning process dies; clean up
     // before rebinding.
     if tokio::fs::metadata(&path).await.is_ok() {

--- a/crates/dd/src/agent.rs
+++ b/crates/dd/src/agent.rs
@@ -131,6 +131,7 @@ pub async fn run() -> Result<()> {
         .route("/deploy", post(deploy))
         .route("/exec", post(exec))
         .route("/logs/{app}", get(logs))
+        .fallback(log_unmatched)
         .with_state(state);
 
     let addr = format!("0.0.0.0:{}", cfg.common.port);
@@ -217,6 +218,23 @@ fn spawn_cloudflared(token: String) {
             }
         }
     });
+}
+
+/// 404 with a log line. Without this, a request to a path nobody
+/// registered (e.g. caused by a proxy rewrite, or a typo'd CI URL)
+/// would silently get axum's default 404 — and on the dd-deploy
+/// side, curl doesn't see a body, so the symptom looks like "empty
+/// 200". Logging the unmatched method+path gives us ground truth
+/// for whether a request reached dd-agent at all.
+async fn log_unmatched(
+    method: axum::http::Method,
+    uri: axum::http::Uri,
+) -> (axum::http::StatusCode, Json<serde_json::Value>) {
+    eprintln!("agent: 404 {} {}", method, uri.path());
+    (
+        axum::http::StatusCode::NOT_FOUND,
+        Json(serde_json::json!({"code":"NOT_FOUND","message":"unmatched route"})),
+    )
 }
 
 // ── Routes ──────────────────────────────────────────────────────────────
@@ -438,6 +456,13 @@ async fn deploy(
     headers: HeaderMap,
     Json(spec): Json<serde_json::Value>,
 ) -> Result<Json<serde_json::Value>> {
+    // Log entry *before* auth so we can tell CF-Access-intercepts
+    // (no handler entry at all) from OIDC failures (entry + reject).
+    eprintln!(
+        "agent: /deploy entered (has_auth={}, app={})",
+        headers.contains_key(axum::http::header::AUTHORIZATION),
+        spec.get("app_name").and_then(|v| v.as_str()).unwrap_or("?")
+    );
     let claims = require_gh_oidc(&s, &headers).await?;
     eprintln!(
         "agent: /deploy by {} (repo={}, ref={})",


### PR DESCRIPTION
## Summary

Two fixes for the preview deploy regression showing up in PR #165's CI.

### Fix 1 — bastion creates \`/run/ee/\` before binding

Bastion tried to bind \`/run/ee/capture.sock\` but the parent dir didn't exist on the VM rootfs, so \`bind(2)\` ENOENTed. Non-fatal today (bastion's HTTP server still starts) but meant **no workload capture would ever flow**, even once upstream EE #79 lands.

\`capture::spawn_listener\` now \`create_dir_all\`s the parent first. Idempotent.

### Fix 2 — diagnostic on \`/deploy\`

PR #164's CI regressed the hello-world deploy with an odd symptom: curl prints \`agent response: \` (empty body, 2xx), then \`/health\` never shows the workload. Static analysis rules out code regressions — \`agent.rs\` and \`cf.rs\` are byte-identical across the recombine (just file renames). Empty-body-2xx matches exactly what curl prints on a 3xx redirect without \`-L\`, which points at CF Access intercepting \`/deploy\` instead of letting the path-scoped bypass win.

Shipping two low-risk observability hooks:

- \`eprintln!\` at the top of \`deploy()\` *before* the GH OIDC check — so any request that actually reaches dd-agent shows up in \`/logs/dd-agent\`.
- A \`fallback\` handler that logs method + path of any unmatched request — catches proxy rewrites, typo'd URLs, or CF Access redirect landings.

Once this runs, the next CI log will show either \`agent: /deploy entered\` (confirming auth is the issue) or silence (confirming CF Access is intercepting before dd-agent sees anything).

## Scope

- Fixes the bastion dir bug permanently.
- Adds diagnostics for the /deploy bug, doesn't yet fix it. Next PR will be the targeted fix once we have signal.

## Test plan

- [x] \`cargo build --workspace\` clean.
- [x] \`cargo test --workspace\` green.
- [ ] Preview CI serial log shows \`capture: listening on /run/ee/capture.sock\` (not ENOENT).
- [ ] Preview CI \`/logs/dd-agent\` output shows either \`/deploy entered\` or \`404 POST /deploy\` — either way, we know where to look next.