### PR TITLE
feat(bastion+ee): wire workload capture end-to-end + unblock preview deploy

### DIFF
--- a/.github/workflows/deploy-cp.yml
+++ b/.github/workflows/deploy-cp.yml
@@ -138,9 +138,13 @@ jobs:
             bake apps/bastion/workload.json.tmpl
           } | jq -cs '.')
 
+          # EE_CAPTURE_SOCKET tells EE (post-capture-socket patch) to tee
+          # every spawned workload's stdio to this unix socket. Bastion
+          # binds and reads it. Unpatched EE images ignore the variable,
+          # so landing this is safe before the EE image catches up.
           jq -c -n \
             --arg workloads "$EE_BOOT_WORKLOADS" \
-            '{ "EE_BOOT_WORKLOADS": $workloads, "EE_OWNER": "devopsdefender" }' \
+            '{ "EE_BOOT_WORKLOADS": $workloads, "EE_OWNER": "devopsdefender", "EE_CAPTURE_SOCKET": "/run/ee/capture.sock" }' \
             > /tmp/ee-config.json
 
           gcloud compute instances create "$VM_NAME" \

--- a/apps/_infra/local-agents.sh
+++ b/apps/_infra/local-agents.sh
@@ -155,6 +155,12 @@ build_config_iso() {
   {
     echo "EE_OWNER=devopsdefender"
     echo "EE_BOOT_WORKLOADS=$workloads"
+    # Tells EE (>= capture-socket patch) to tee every spawned workload's
+    # stdio to this unix socket. Bastion binds + listens on it; unpatched
+    # EE images ignore the variable. Keeps the boot-of-the-listener ≠
+    # boot-of-the-writer race non-fatal: EE falls back to running without
+    # capture when the socket isn't there yet.
+    echo "EE_CAPTURE_SOCKET=/run/ee/capture.sock"
   } > "$tmp/agent.env"
 
   # ext4 — EE rootfs has no iso9660 module.

--- a/crates/bastion/src/bin/bastion.rs
+++ b/crates/bastion/src/bin/bastion.rs
@@ -39,8 +39,10 @@ async fn main() -> std::io::Result<()> {
         }
     }
 
+    let mgr = bastion::Manager::new();
+
     if let Some(path) = capture_socket {
-        if let Err(e) = bastion::capture::spawn_listener(&path).await {
+        if let Err(e) = bastion::capture::spawn_listener(&path, mgr.clone()).await {
             // Non-fatal: if EE isn't configured to emit yet, the socket
             // just stays quiet. But if bind itself fails (e.g. bad
             // path, permissions), surface it.
@@ -50,7 +52,6 @@ async fn main() -> std::io::Result<()> {
 
     let addr = format!("{bind}:{port}");
     eprintln!("bastion: listening on http://{addr}/");
-    let mgr = bastion::Manager::new();
     let app: Router = bastion::router(mgr);
     let listener = tokio::net::TcpListener::bind(&addr).await?;
     axum::serve(listener, app)

--- a/crates/bastion/src/capture.rs
+++ b/crates/bastion/src/capture.rs
@@ -1,31 +1,34 @@
-//! EE capture listener (scaffold).
+//! EE capture listener.
 //!
 //! Listens on a unix-domain socket for line-delimited JSON records
 //! emitted by a patched easyenclave on each spawned workload's stdout
 //! and stderr. Records look like:
 //!
 //! ```json
-//! {"type":"spawn","id":"cloudflared-1735...","argv":[...],"cwd":"/"}
+//! {"type":"spawn","id":"cloudflared-1735...","argv":[...],"cwd":null}
 //! {"type":"out","id":"cloudflared-1735...","s":"stdout","b":"INF ..."}
 //! {"type":"out","id":"cloudflared-1735...","s":"stderr","b":"..."}
 //! {"type":"exit","id":"cloudflared-1735...","code":0}
 //! ```
 //!
-//! **Status**: this file is a scaffold. It binds the socket, accepts
-//! connections, and parses each record into [`CaptureRecord`] — but
-//! it does not yet create [`crate::SessionInfo`]-shaped workload
-//! sessions inside the [`crate::Manager`]. That comes in a follow-up
-//! once upstream `easyenclave` is actually emitting these frames and
-//! the SPA sidebar is ready to render the "Workloads" category.
+//! Each connection is one workload lifetime. Records are dispatched
+//! straight into [`crate::Manager`] as workload sessions:
 //!
-//! For now the listener just logs each parsed event to stderr so we
-//! can verify the socket contract end-to-end once EE lands its patch.
+//! - `spawn` → [`crate::Manager::register_workload`]
+//! - `out`   → [`crate::Manager::workload_out`]
+//! - `exit`  → [`crate::Manager::workload_exit`]
+//!
+//! so the SPA sidebar's "Workloads" category populates live. Wire
+//! contract upstream is documented in easyenclave's `capture.rs`
+//! module.
 
 use std::path::{Path, PathBuf};
 
 use serde::Deserialize;
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::net::{UnixListener, UnixStream};
+
+use crate::Manager;
 
 /// One event over the EE capture socket.
 #[derive(Debug, Clone, Deserialize)]
@@ -57,14 +60,21 @@ fn default_stdout() -> String {
 }
 
 /// Remove any stale socket at `path`, bind a fresh one, and spawn a
-/// task that accepts connections and dispatches records.
+/// task that accepts connections and dispatches records into
+/// `manager` as workload sessions.
 ///
 /// Returns an error if the socket path's parent directory doesn't
 /// exist or binding fails. A stale socket from a previous run is
 /// removed automatically (unix sockets aren't self-cleaning on
 /// process crash).
-pub async fn spawn_listener(path: impl AsRef<Path>) -> std::io::Result<()> {
+pub async fn spawn_listener(path: impl AsRef<Path>, manager: Manager) -> std::io::Result<()> {
     let path: PathBuf = path.as_ref().to_path_buf();
+    // `bind(2)` on a unix socket ENOENTs if the parent dir is missing.
+    // On the DD agent VM, `/run/ee/` is the conventional capture-socket
+    // dir but nothing creates it — so we do it ourselves. Idempotent.
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent).await?;
+    }
     // Unix sockets linger after the owning process dies; clean up
     // before rebinding.
     if tokio::fs::metadata(&path).await.is_ok() {
@@ -77,7 +87,7 @@ pub async fn spawn_listener(path: impl AsRef<Path>) -> std::io::Result<()> {
         loop {
             match listener.accept().await {
                 Ok((stream, _)) => {
-                    tokio::spawn(handle_connection(stream));
+                    tokio::spawn(handle_connection(stream, manager.clone()));
                 }
                 Err(e) => {
                     eprintln!("capture: accept error: {e}");
@@ -89,7 +99,7 @@ pub async fn spawn_listener(path: impl AsRef<Path>) -> std::io::Result<()> {
     Ok(())
 }
 
-async fn handle_connection(stream: UnixStream) {
+async fn handle_connection(stream: UnixStream, manager: Manager) {
     let reader = BufReader::new(stream);
     let mut lines = reader.lines();
     loop {
@@ -100,7 +110,7 @@ async fn handle_connection(stream: UnixStream) {
                     continue;
                 }
                 match serde_json::from_str::<CaptureRecord>(line) {
-                    Ok(record) => handle_record(record),
+                    Ok(record) => handle_record(record, &manager).await,
                     Err(e) => eprintln!("capture: parse error ({e}) on line: {line}"),
                 }
             }
@@ -113,23 +123,20 @@ async fn handle_connection(stream: UnixStream) {
     }
 }
 
-fn handle_record(record: CaptureRecord) {
-    // Scaffold: just log. Next PR wires these into `Manager` as
-    // workload-kind sessions with their own ring buffer and block
-    // stream so they render in the SPA sidebar alongside shells.
+async fn handle_record(record: CaptureRecord, manager: &Manager) {
     match record {
         CaptureRecord::Spawn { id, argv, cwd } => {
-            eprintln!(
-                "capture: spawn id={id} argv={:?} cwd={:?}",
-                argv,
-                cwd.as_deref()
-            );
+            manager.register_workload(id, argv, cwd).await;
         }
-        CaptureRecord::Out { id, s, b } => {
-            eprintln!("capture: out id={id} stream={s} bytes_len={}", b.len());
+        CaptureRecord::Out { id, s: _, b } => {
+            // EE sends lines without the trailing newline; replace it
+            // so the rolling ring produces readable replay in xterm.js.
+            let mut bytes = b.into_bytes();
+            bytes.push(b'\n');
+            manager.workload_out(&id, &bytes).await;
         }
         CaptureRecord::Exit { id, code } => {
-            eprintln!("capture: exit id={id} code={code}");
+            manager.workload_exit(&id, code).await;
         }
     }
 }

--- a/crates/bastion/src/lib.rs
+++ b/crates/bastion/src/lib.rs
@@ -149,17 +149,34 @@ struct Session {
     kind: String,
     title: String,
     created_at_ms: u64,
-    master: Arc<Mutex<Box<dyn MasterPty + Send>>>,
-    writer: Arc<Mutex<Box<dyn Write + Send>>>,
+    /// Present for shell sessions; `None` for workloads (no PTY).
+    master: Option<Arc<Mutex<Box<dyn MasterPty + Send>>>>,
+    /// Present for shell sessions; `None` for workloads (stdin is
+    /// silently dropped, since the workload is already running with
+    /// its own stdin from EE).
+    writer: Option<Arc<Mutex<Box<dyn Write + Send>>>>,
     ring: Arc<Mutex<VecDeque<u8>>>,
     blocks: Arc<RwLock<VecDeque<BlockRecord>>>,
     next_seq: Arc<Mutex<u64>>,
     tx: broadcast::Sender<Event>,
+    /// Per-lifetime accumulator for workload sessions. Holds the
+    /// `argv`, `started_at_ms`, and raw stdout/stderr bytes until
+    /// `exit`, when they're finalized into a single `BlockRecord`.
+    workload_ctx: Option<Arc<Mutex<WorkloadCtx>>>,
     /// PID of the spawned shell so `Manager::remove` can SIGHUP it.
     /// The waiter thread owns the `Child` handle; we track the PID
     /// separately to avoid a lock contest with `wait()`. `None` for
     /// workload sessions.
     pid: Option<u32>,
+}
+
+/// State that a workload session accumulates between `spawn` and
+/// `exit` on the EE capture socket. On `exit` this becomes a single
+/// `BlockRecord` whose `output_b64` covers the whole lifetime.
+struct WorkloadCtx {
+    argv: Vec<String>,
+    started_at_ms: u64,
+    output: Vec<u8>,
 }
 
 impl Session {
@@ -278,6 +295,134 @@ impl Manager {
             false
         }
     }
+
+    /// Register a workload session for EE-captured process output.
+    ///
+    /// Called from [`crate::capture`] on each `spawn` record. The
+    /// returned session has no PTY, no writer, and no pid — WebSocket
+    /// subscribers get replay + live `Raw` bytes + a final
+    /// `BlockRecord` once [`Self::workload_exit`] fires.
+    ///
+    /// Idempotent on duplicate ids: the existing session is returned
+    /// unchanged so a reconnecting capture socket doesn't orphan
+    /// state. (The EE side gives each spawn a unique `<app>-<ms>` id
+    /// so collisions only happen when something reruns the record.)
+    pub async fn register_workload(&self, id: String, argv: Vec<String>, _cwd: Option<String>) {
+        {
+            let g = self.inner.read().await;
+            if g.contains_key(&id) {
+                return;
+            }
+        }
+        let (tx, _rx) = broadcast::channel(BROADCAST_CAP);
+        let started_at_ms = now_ms();
+        let title = argv.first().cloned().unwrap_or_else(|| id.clone());
+        let session = Arc::new(Session {
+            id: id.clone(),
+            kind: "workload".into(),
+            title,
+            created_at_ms: started_at_ms,
+            master: None,
+            writer: None,
+            ring: Arc::new(Mutex::new(VecDeque::with_capacity(RING_CAP))),
+            blocks: Arc::new(RwLock::new(VecDeque::with_capacity(BLOCKS_CAP))),
+            next_seq: Arc::new(Mutex::new(0)),
+            tx,
+            workload_ctx: Some(Arc::new(Mutex::new(WorkloadCtx {
+                argv,
+                started_at_ms,
+                output: Vec::new(),
+            }))),
+            pid: None,
+        });
+        self.inner.write().await.insert(id, session);
+    }
+
+    /// Append a chunk of captured stdout/stderr bytes to a workload
+    /// session: updates the rolling ring so reconnects replay it,
+    /// appends to the per-lifetime accumulator (capped at `RING_CAP`
+    /// — older bytes drop from the front), and broadcasts raw bytes
+    /// to live WS subscribers.
+    ///
+    /// Silent no-op for unknown ids or shell sessions.
+    pub async fn workload_out(&self, id: &str, bytes: &[u8]) {
+        let Some(session) = self.get(id).await else {
+            return;
+        };
+        let Some(ctx) = session.workload_ctx.as_ref() else {
+            return;
+        };
+        {
+            let mut ring = session.ring.lock().await;
+            let n = bytes.len();
+            if ring.len() + n > RING_CAP {
+                let drop_n = ring.len() + n - RING_CAP;
+                for _ in 0..drop_n.min(ring.len()) {
+                    ring.pop_front();
+                }
+            }
+            ring.extend(bytes.iter().copied());
+        }
+        {
+            let mut g = ctx.lock().await;
+            g.output.extend_from_slice(bytes);
+            if g.output.len() > RING_CAP {
+                let drop_n = g.output.len() - RING_CAP;
+                g.output.drain(..drop_n);
+            }
+        }
+        let _ = session.tx.send(Event::Raw(Arc::new(bytes.to_vec())));
+    }
+
+    /// Finalize a workload session: commit one `BlockRecord`
+    /// (`kind = "workload"`, `command = argv.join(" ")`) covering the
+    /// process lifetime, then broadcast a terminal `Exit`.
+    ///
+    /// The session remains in the manager so later reconnects can
+    /// replay its block; process exit is end-of-writes, not
+    /// end-of-readers. Silent no-op for unknown or non-workload ids.
+    pub async fn workload_exit(&self, id: &str, code: i32) {
+        let Some(session) = self.get(id).await else {
+            return;
+        };
+        let Some(ctx) = session.workload_ctx.as_ref() else {
+            return;
+        };
+        let (command, started_at_ms, output) = {
+            let mut g = ctx.lock().await;
+            (
+                g.argv.join(" "),
+                g.started_at_ms,
+                std::mem::take(&mut g.output),
+            )
+        };
+        let output_b64 = base64::engine::general_purpose::STANDARD.encode(&output);
+        let seq = {
+            let mut g = session.next_seq.lock().await;
+            let s = *g;
+            *g += 1;
+            s
+        };
+        let block = BlockRecord {
+            session_id: session.id.clone(),
+            kind: "workload".into(),
+            seq,
+            started_at_ms,
+            ended_at_ms: now_ms(),
+            command,
+            output_b64,
+            exit_code: code,
+        };
+        {
+            let mut blocks = session.blocks.write().await;
+            while blocks.len() >= BLOCKS_CAP {
+                blocks.pop_front();
+            }
+            blocks.push_back(block.clone());
+        }
+        let _ = session.tx.send(Event::Block(Arc::new(block)));
+        let _ = session.tx.send(Event::Exit(code));
+    }
 }
 
 fn short_id() -> String {
@@ -339,12 +484,13 @@ async fn spawn_session(
         kind: "shell".into(),
         title,
         created_at_ms,
-        master: Arc::new(Mutex::new(pair.master)),
-        writer: Arc::new(Mutex::new(writer)),
+        master: Some(Arc::new(Mutex::new(pair.master))),
+        writer: Some(Arc::new(Mutex::new(writer))),
         ring: Arc::new(Mutex::new(VecDeque::with_capacity(RING_CAP))),
         blocks: Arc::new(RwLock::new(VecDeque::with_capacity(BLOCKS_CAP))),
         next_seq: Arc::new(Mutex::new(0)),
         tx,
+        workload_ctx: None,
         pid,
     });
 
@@ -695,12 +841,15 @@ async fn ws_loop(mut socket: WebSocket, id: String, m: Manager) {
     let writer = session.writer.clone();
     let master = session.master.clone();
 
-    // Inbound: stdin bytes and control JSON.
+    // Inbound: stdin bytes and control JSON. For workload sessions,
+    // `writer` and `master` are `None`: stdin bytes from the browser
+    // are silently dropped, and resize is a no-op. Workloads don't
+    // have a PTY; they're view-only.
     let inbound = async move {
         while let Some(Ok(msg)) = stream.next().await {
             match msg {
                 Message::Binary(bytes) => {
-                    let w = writer.clone();
+                    let Some(w) = writer.clone() else { continue };
                     let _ = tokio::task::spawn_blocking(move || {
                         let mut g = w.blocking_lock();
                         let _ = g.write_all(&bytes);
@@ -713,7 +862,8 @@ async fn ws_loop(mut socket: WebSocket, id: String, m: Manager) {
                     };
                     match msg {
                         ClientMsg::Resize(r) => {
-                            let g = master.lock().await;
+                            let Some(m) = master.as_ref() else { continue };
+                            let g = m.lock().await;
                             let _ = g.resize(PtySize {
                                 rows: r.rows.max(4),
                                 cols: r.cols.max(8),
@@ -839,14 +989,15 @@ mod tests {
             kind: "shell".into(),
             title: "t".into(),
             created_at_ms: 0,
-            master: Arc::new(Mutex::new(make_fake_master())),
-            writer: Arc::new(Mutex::new(
+            master: Some(Arc::new(Mutex::new(make_fake_master()))),
+            writer: Some(Arc::new(Mutex::new(
                 Box::new(std::io::sink()) as Box<dyn Write + Send>
-            )),
+            ))),
             ring: Arc::new(Mutex::new(VecDeque::new())),
             blocks: Arc::new(RwLock::new(VecDeque::new())),
             next_seq: Arc::new(Mutex::new(0)),
             tx: broadcast::channel::<Event>(8).0,
+            workload_ctx: None,
             pid: None,
         });
         let mut parser = Parser::new();
@@ -866,6 +1017,44 @@ mod tests {
         let b = &blocks[0];
         assert_eq!(b.command, "echo hi");
         assert_eq!(b.exit_code, 0);
+    }
+
+    #[tokio::test]
+    async fn workload_lifecycle_commits_one_block() {
+        let m = Manager::new();
+        m.register_workload(
+            "cloudflared-1".into(),
+            vec!["cloudflared".into(), "tunnel".into()],
+            None,
+        )
+        .await;
+        m.workload_out("cloudflared-1", b"INF starting\n").await;
+        m.workload_out("cloudflared-1", b"INF connected\n").await;
+        m.workload_exit("cloudflared-1", 0).await;
+
+        let sessions = m.list().await;
+        let w = sessions
+            .iter()
+            .find(|s| s.id == "cloudflared-1")
+            .expect("workload session registered");
+        assert_eq!(w.kind, "workload");
+        assert_eq!(w.title, "cloudflared");
+        assert_eq!(w.next_seq, 1);
+
+        let session = m.get("cloudflared-1").await.expect("session");
+        let blocks = session.blocks.read().await;
+        assert_eq!(blocks.len(), 1);
+        let b = &blocks[0];
+        assert_eq!(b.kind, "workload");
+        assert_eq!(b.command, "cloudflared tunnel");
+        assert_eq!(b.exit_code, 0);
+        let output = base64::engine::general_purpose::STANDARD
+            .decode(&b.output_b64)
+            .unwrap();
+        assert_eq!(
+            String::from_utf8(output).unwrap(),
+            "INF starting\nINF connected\n"
+        );
     }
 
     fn make_fake_master() -> Box<dyn MasterPty + Send> {

--- a/crates/dd/src/agent.rs
+++ b/crates/dd/src/agent.rs
@@ -131,6 +131,7 @@ pub async fn run() -> Result<()> {
         .route("/deploy", post(deploy))
         .route("/exec", post(exec))
         .route("/logs/{app}", get(logs))
+        .fallback(log_unmatched)
         .with_state(state);
 
     let addr = format!("0.0.0.0:{}", cfg.common.port);
@@ -217,6 +218,23 @@ fn spawn_cloudflared(token: String) {
             }
         }
     });
+}
+
+/// 404 with a log line. Without this, a request to a path nobody
+/// registered (e.g. caused by a proxy rewrite, or a typo'd CI URL)
+/// would silently get axum's default 404 — and on the dd-deploy
+/// side, curl doesn't see a body, so the symptom looks like "empty
+/// 200". Logging the unmatched method+path gives us ground truth
+/// for whether a request reached dd-agent at all.
+async fn log_unmatched(
+    method: axum::http::Method,
+    uri: axum::http::Uri,
+) -> (axum::http::StatusCode, Json<serde_json::Value>) {
+    eprintln!("agent: 404 {} {}", method, uri.path());
+    (
+        axum::http::StatusCode::NOT_FOUND,
+        Json(serde_json::json!({"code":"NOT_FOUND","message":"unmatched route"})),
+    )
 }
 
 // ── Routes ──────────────────────────────────────────────────────────────
@@ -438,6 +456,13 @@ async fn deploy(
     headers: HeaderMap,
     Json(spec): Json<serde_json::Value>,
 ) -> Result<Json<serde_json::Value>> {
+    // Log entry *before* auth so we can tell CF-Access-intercepts
+    // (no handler entry at all) from OIDC failures (entry + reject).
+    eprintln!(
+        "agent: /deploy entered (has_auth={}, app={})",
+        headers.contains_key(axum::http::header::AUTHORIZATION),
+        spec.get("app_name").and_then(|v| v.as_str()).unwrap_or("?")
+    );
     let claims = require_gh_oidc(&s, &headers).await?;
     eprintln!(
         "agent: /deploy by {} (repo={}, ref={})",

--- a/crates/dd/src/cf.rs
+++ b/crates/dd/src/cf.rs
@@ -93,12 +93,23 @@ pub async fn create(
     delete_by_name(http, cf, name).await;
 
     let secret = base64::engine::general_purpose::STANDARD.encode(uuid::Uuid::new_v4().as_bytes());
+    // `config_src: "cloudflare"` marks the tunnel as dashboard/API-managed
+    // so cloudflared won't try to push its (empty) local config at connect
+    // time. Without this, cloudflared 2026.3.0 logs
+    // `ERR unable to send local configuration … Invalid ConfigurationSource
+    // change` and the tunnel never registers a connection — the CP's
+    // /health endpoint stays unreachable and `Wait for agent health`
+    // times out.
     let resp = call(
         http,
         cf,
         Method::POST,
         &format!("/accounts/{}/cfd_tunnel", cf.account_id),
-        Some(serde_json::json!({"name": name, "tunnel_secret": secret})),
+        Some(serde_json::json!({
+            "name": name,
+            "tunnel_secret": secret,
+            "config_src": "cloudflare",
+        })),
     )
     .await?;
 


### PR DESCRIPTION
## Summary

Lands the full consumer + producer wiring so bastion's "Workloads" sidebar populates when upstream easyenclave/easyenclave#79 (merged 22:39Z) rolls a new EE image. Also fixes three preview-deploy bugs that were blocking PR #165's CI. Replaces #165, #166, #168.

## Four changes

### 1. EE capture → Manager (was #165)

`capture::spawn_listener` now takes a `Manager` handle. Each incoming LDJSON record drives state:

- `spawn` → `register_workload` — new `kind = "workload"` Session, no PTY
- `out` → `workload_out` — appends to ring + per-lifetime accumulator, broadcasts `Raw` to live WS subscribers
- `exit` → `workload_exit` — commits one `BlockRecord` over the entire lifetime, broadcasts `Block` + `Exit`

`Session` grows `Option<master>/Option<writer>/Option<workload_ctx>`. Shells keep their PTY; workload sessions have none, so `ws_loop` silently drops inbound stdin + Resize — workloads are view-only.

### 2. /run/ee/ created before bind (preview fix)

`spawn_listener` `create_dir_all`s the socket parent before `UnixListener::bind`. Fixes `capture listener failed to bind /run/ee/capture.sock: No such file or directory` — the listener never bound at all.

### 3. CF tunnel config_src=cloudflare (preview fix)

Without this, cloudflared 2026.3.0 logs `ERR unable to send local configuration … Invalid ConfigurationSource change` on connect because the tunnel default source is `local`. Tunnel never registers; CP /health unreachable; `Wait for agent health` times out. Fixes two symptoms at once: CP boot + the agent's empty-body /deploy.

### 4. EE_CAPTURE_SOCKET env wiring (was #168)

easyenclave/easyenclave#79 is merged and EE honours the env var. Plumbed through both boot paths:

- `apps/_infra/local-agents.sh` — `agent.env` for local libvirt VMs.
- `.github/workflows/deploy-cp.yml` — GCE-metadata `ee-config` for CP VMs.

Unpatched EE images ignore unknown env vars, so safe to land before the EE image family rolls.

## Test plan

- [x] `cargo build --workspace` + `cargo test --workspace` clean. New `workload_lifecycle_commits_one_block` covers spawn+out+exit → one BlockRecord.
- [x] Previous CI run: bastion binds capture socket, CP tunnel healthy, /deploy returns `{"id":"…","ok":true,"status":"deploying"}`, hello-world visible in /health within 70ms.
- [ ] Post-merge: once the EE image family rolls post-#79, next preview's `dd-deploy hello-world` populates bastion "Workloads" sidebar. Boot workloads intentionally skipped.

## Scope

Boot workloads (cloudflared, podman-static, nv, bastion itself, dd-agent) stay out of the sidebar for v1 — known and agreed.