### PR TITLE
feat(ee): wire EE_CAPTURE_SOCKET so workload stdio flows to bastion

### DIFF
--- a/.github/workflows/deploy-cp.yml
+++ b/.github/workflows/deploy-cp.yml
@@ -138,9 +138,13 @@ jobs:
             bake apps/bastion/workload.json.tmpl
           } | jq -cs '.')
 
+          # EE_CAPTURE_SOCKET tells EE (post-capture-socket patch) to tee
+          # every spawned workload's stdio to this unix socket. Bastion
+          # binds and reads it. Unpatched EE images ignore the variable,
+          # so landing this is safe before the EE image catches up.
           jq -c -n \
             --arg workloads "$EE_BOOT_WORKLOADS" \
-            '{ "EE_BOOT_WORKLOADS": $workloads, "EE_OWNER": "devopsdefender" }' \
+            '{ "EE_BOOT_WORKLOADS": $workloads, "EE_OWNER": "devopsdefender", "EE_CAPTURE_SOCKET": "/run/ee/capture.sock" }' \
             > /tmp/ee-config.json
 
           gcloud compute instances create "$VM_NAME" \

--- a/apps/_infra/local-agents.sh
+++ b/apps/_infra/local-agents.sh
@@ -155,6 +155,12 @@ build_config_iso() {
   {
     echo "EE_OWNER=devopsdefender"
     echo "EE_BOOT_WORKLOADS=$workloads"
+    # Tells EE (>= capture-socket patch) to tee every spawned workload's
+    # stdio to this unix socket. Bastion binds + listens on it; unpatched
+    # EE images ignore the variable. Keeps the boot-of-the-listener ≠
+    # boot-of-the-writer race non-fatal: EE falls back to running without
+    # capture when the socket isn't there yet.
+    echo "EE_CAPTURE_SOCKET=/run/ee/capture.sock"
   } > "$tmp/agent.env"
 
   # ext4 — EE rootfs has no iso9660 module.


### PR DESCRIPTION
## Summary

Upstream easyenclave/easyenclave#79 merged (thanks!). EE now honours \`EE_CAPTURE_SOCKET\` and tees every spawned workload's stdout/stderr to that unix socket as LDJSON \`spawn\`/\`out\`/\`exit\` records. Bastion already binds \`/run/ee/capture.sock\` (on #167) and registers workload sessions in its Manager when records arrive.

This PR plumbs the env var from both agent-boot paths:

- **\`apps/_infra/local-agents.sh\`** — writes the \`config.iso\` \`agent.env\` file for \`dd-local-{preview,prod}\` libvirt VMs.
- **\`.github/workflows/deploy-cp.yml\`** — the \`ee-config\` GCE-metadata JSON blob for \`gcloud compute instances create\`.

## Safety

Unpatched EE images ignore unknown env vars, so this is safe to ship before the EE image catches up. Nothing regresses until the next EE image rolls, at which point the bastion sidebar's "Workloads" category starts populating on post-boot deploys.

## Scope note

Boot workloads (cloudflared, podman-static, nv, bastion itself, dd-agent) still won't show — they spawn before bastion binds the listener, and bastion obviously can't capture itself. Only post-boot deploys (what \`dd-deploy\` pushes) will render. Matches the scope we agreed on.

## Depends on

- #167 — bastion-side capture → Manager wiring + preview fixes. Both can merge in either order since the env var is a no-op if bastion isn't listening.

## Test plan

- [x] No Rust changes, no tests to add.
- [ ] Once EE image rolls post-#79 and this merges, next preview's \`dd-deploy hello-world\` populates bastion's "Workloads" sidebar with hello-world's full lifetime block.