### PR TITLE
feat(agent): send EE_TOKEN on every socket call (Tier-1 seal)

### DIFF
--- a/apps/dd-agent/workload.json.tmpl
+++ b/apps/dd-agent/workload.json.tmpl
@@ -5,6 +5,7 @@
     "asset": "devopsdefender",
     "tag": "${DD_RELEASE_TAG}"
   },
+  "inherit_token": true,
   "cmd": ["devopsdefender", "agent"],
   "env": [
     "DD_MODE=agent",

--- a/apps/dd-management/workload.json.tmpl
+++ b/apps/dd-management/workload.json.tmpl
@@ -5,6 +5,7 @@
     "asset": "devopsdefender",
     "tag": "${DD_RELEASE_TAG}"
   },
+  "inherit_token": true,
   "cmd": ["devopsdefender"],
   "env": [
     "DD_MODE=management",

--- a/crates/dd/src/ee.rs
+++ b/crates/dd/src/ee.rs
@@ -10,14 +10,27 @@ use crate::error::{Error, Result};
 
 pub struct Ee {
     path: String,
+    /// Boot token minted by easyenclave and handed to dd-agent via
+    /// `EE_TOKEN`. When set, every socket request carries
+    /// `"token": "<hex>"` so EE's seal (easyenclave#80) accepts us.
+    /// On unpatched EE images the field is ignored as an unknown key;
+    /// makes this change forward-compatible either direction.
+    token: Option<String>,
 }
 
 impl Ee {
     pub fn new(path: impl Into<String>) -> Self {
-        Self { path: path.into() }
+        Self {
+            path: path.into(),
+            token: std::env::var("EE_TOKEN").ok().filter(|s| !s.is_empty()),
+        }
     }
 
-    async fn call(&self, req: serde_json::Value) -> Result<serde_json::Value> {
+    async fn call(&self, mut req: serde_json::Value) -> Result<serde_json::Value> {
+        if let Some(token) = &self.token {
+            req["token"] = serde_json::Value::String(token.clone());
+        }
+
         let stream = UnixStream::connect(&self.path)
             .await
             .map_err(|e| Error::Upstream(format!("EE connect {}: {e}", self.path)))?;
@@ -76,7 +89,10 @@ impl Ee {
             .await
             .map_err(|e| Error::Upstream(format!("EE attach {}: {e}", self.path)))?;
 
-        let req = serde_json::json!({"method": "attach", "cmd": cmd});
+        let mut req = serde_json::json!({"method": "attach", "cmd": cmd});
+        if let Some(token) = &self.token {
+            req["token"] = serde_json::Value::String(token.clone());
+        }
         let mut buf = serde_json::to_vec(&req)?;
         buf.push(b'\n');
         stream.write_all(&buf).await?;


### PR DESCRIPTION
## Summary

DD half of the Tier-1 EE seal (easyenclave/easyenclave#80). dd-agent + dd-management read \`EE_TOKEN\` from env once at construction and inject \`\"token\": \"<hex>\"\` into every JSON request to EE's unix socket. Forward-compatible both ways:

- **Unpatched EE** (today's prod image): unknown \`token\` field is silently ignored, zero regression.
- **Patched EE** (easyenclave/easyenclave#80 rolled): socket requires the token; unauth'd requests get \`{\"ok\":false,\"error\":\"unauthenticated\"}\`.

\`apps/dd-agent/workload.json.tmpl\` + \`apps/dd-management/workload.json.tmpl\` opt in via \`inherit_token: true\` so EE hands them the token at spawn. Every other workload (cloudflared, podman-*, nv, bastion) runs without the env var and therefore without socket access — that's the whole point of the seal.

## Motivation

Closes the \"local root on the VM ≠ control of the enclave\" gap. A compromised cloudflared or bastion can no longer deploy new workloads, drop into an attach shell, or exfiltrate quotes.

## Rollout order

This PR is safe to merge first (unpatched EE ignores the extra field). Upstream easyenclave#80 can merge either before or after; once its image rolls, the seal kicks in.

## Test plan

- [x] \`cargo build --workspace\` + \`cargo test --workspace\` clean.
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean.
- [ ] Preview CI with new EE image: \`dd-deploy hello-world\` succeeds via authenticated path.
- [ ] A rogue workload's \`echo '{\"method\":\"list\"}' | nc -U /var/lib/easyenclave/agent.sock\` returns \`unauthenticated\` (manual verify post-deploy).