### PR TITLE
feat(bastion/web): client-side connector store + device identity seed

### DIFF
--- a/crates/bastion/web/src/App.svelte
+++ b/crates/bastion/web/src/App.svelte
@@ -2,9 +2,9 @@
   import { onMount } from "svelte";
   import Sidebar from "./lib/Sidebar.svelte";
   import TerminalPane from "./lib/TerminalPane.svelte";
-  import { ui, loadSessions } from "./ui.svelte";
+  import { ui, bootstrap } from "./ui.svelte";
 
-  onMount(loadSessions);
+  onMount(bootstrap);
 
   // Snapshot the row IDs — iterating the Map directly in `{#each}`
   // creates new [key, value] tuples every render and defeats keyed
@@ -22,7 +22,16 @@
       </div>
     {/each}
     {#if !ui.active}
-      <div class="empty">No session selected.</div>
+      <div class="empty">
+        {#if !ui.ready}
+          Loading…
+        {:else if ui.connectors.length === 0}
+          No connectors yet. Click <kbd>+</kbd> in the sidebar to add
+          one.
+        {:else}
+          No session selected.
+        {/if}
+      </div>
     {/if}
   </main>
 </div>
@@ -74,5 +83,13 @@
     justify-content: center;
     color: #585b70;
     font-size: 13px;
+    text-align: center;
+    padding: 24px;
+  }
+  kbd {
+    background: #313244;
+    padding: 1px 6px;
+    border-radius: 3px;
+    font-size: 11px;
   }
 </style>

--- a/crates/bastion/web/src/connectors.ts
+++ b/crates/bastion/web/src/connectors.ts
@@ -1,0 +1,124 @@
+/**
+ * Client-side connector registry — the source of truth for what
+ * shows up in the sidebar.
+ *
+ * Each entry is one *source* of sessions: a DD enclave, an SSH host,
+ * an Anthropic API key, a GitHub token, a local shell (Tauri only).
+ * The Svelte UI iterates connectors and, per kind, knows how to
+ * populate `ui.rows` with the connector's sessions.
+ *
+ * Persistence: IndexedDB object store `connectors`, keyed by `id`.
+ * Stays on the device. Phase 3 will replicate it across the user's
+ * other devices via an encrypted sync channel keyed by the identity
+ * key (see `identity.ts`).
+ */
+
+import type { Agent } from "./types";
+
+export type ConnectorKind =
+  | "dd-enclave"
+  | "ssh-host"
+  | "anthropic"
+  | "github"
+  | "local-shell";
+
+export interface Connector {
+  id: string; // opaque client-generated uuid
+  kind: ConnectorKind;
+  label: string;
+  config: Record<string, unknown>;
+  created_at_ms: number;
+}
+
+const DB_NAME = "bastion";
+const DB_STORE = "connectors";
+const DB_VERSION = 1;
+
+function openDb(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, DB_VERSION);
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      if (!db.objectStoreNames.contains(DB_STORE)) {
+        db.createObjectStore(DB_STORE, { keyPath: "id" });
+      }
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+export async function listConnectors(): Promise<Connector[]> {
+  const db = await openDb();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(DB_STORE, "readonly");
+    const req = tx.objectStore(DB_STORE).getAll();
+    req.onsuccess = () => resolve(req.result as Connector[]);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+export async function addConnector(c: Connector): Promise<void> {
+  const db = await openDb();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(DB_STORE, "readwrite");
+    tx.objectStore(DB_STORE).put(c);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+export async function removeConnector(id: string): Promise<void> {
+  const db = await openDb();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(DB_STORE, "readwrite");
+    tx.objectStore(DB_STORE).delete(id);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+function newId(): string {
+  // `crypto.randomUUID` is available in every browser Tauri v2
+  // supports; don't bother polyfilling.
+  return crypto.randomUUID();
+}
+
+/// One-shot seed: on first run, convert whatever agents the CP's
+/// page-time fetch already injected into `window.__DD_AGENTS__` into
+/// persistent connector entries. Idempotent — subsequent calls no-op
+/// if the store is non-empty.
+export async function seedFromAgents(agents: Agent[]): Promise<void> {
+  const existing = await listConnectors();
+  if (existing.length > 0) return;
+  const now = Date.now();
+  for (const a of agents) {
+    await addConnector({
+      id: newId(),
+      kind: "dd-enclave",
+      label: a.vm_name,
+      config: { vm_name: a.vm_name, origin: a.origin },
+      created_at_ms: now,
+    });
+  }
+}
+
+/// Add a DD enclave via its public bastion origin
+/// (e.g. `https://dd-prod-agent-abc-block.devopsdefender.com`).
+/// Label defaults to the origin host if not provided.
+export async function addDdEnclave(
+  origin: string,
+  label?: string,
+): Promise<Connector> {
+  const trimmed = origin.trim().replace(/\/+$/, "");
+  const vm = label?.trim() || new URL(trimmed).hostname;
+  const c: Connector = {
+    id: newId(),
+    kind: "dd-enclave",
+    label: vm,
+    config: { vm_name: vm, origin: trimmed },
+    created_at_ms: Date.now(),
+  };
+  await addConnector(c);
+  return c;
+}

--- a/crates/bastion/web/src/identity.ts
+++ b/crates/bastion/web/src/identity.ts
@@ -1,0 +1,58 @@
+/**
+ * Device identity seed.
+ *
+ * Persisted in localStorage as a base64-encoded 32-byte random blob.
+ * Generated once per browser origin; survives reloads. Future Noise_KK
+ * handshake (Phase 2) will derive an X25519 keypair from this seed so
+ * the long-term identity is the same across a refresh / a Tauri build
+ * reading the same Stronghold slot.
+ *
+ * For Phase 1 we only need to prove we persist a stable per-device
+ * secret — nothing yet consumes the derived keypair. Keeps the scaffold
+ * dependency-light.
+ */
+
+const KEY = "dd-bastion-identity-seed";
+
+function b64encode(bytes: Uint8Array): string {
+  let s = "";
+  for (const b of bytes) s += String.fromCharCode(b);
+  return btoa(s);
+}
+
+function b64decode(s: string): Uint8Array {
+  const raw = atob(s);
+  const out = new Uint8Array(raw.length);
+  for (let i = 0; i < raw.length; i++) out[i] = raw.charCodeAt(i);
+  return out;
+}
+
+/// Load the identity seed, minting + persisting a new one on first
+/// call. Idempotent. Synchronous — localStorage is the source of truth.
+export function loadIdentitySeed(): Uint8Array {
+  const cached = localStorage.getItem(KEY);
+  if (cached) {
+    try {
+      const bytes = b64decode(cached);
+      if (bytes.length === 32) return bytes;
+    } catch {
+      // Fall through to regenerate — stored blob was corrupt.
+    }
+  }
+  const seed = new Uint8Array(32);
+  crypto.getRandomValues(seed);
+  localStorage.setItem(KEY, b64encode(seed));
+  return seed;
+}
+
+/// Short visual fingerprint of the seed, for UI. Not cryptographic —
+/// just lets the user eyeball "am I still the same device?" across
+/// reloads. 8 hex chars = 32 bits of collision resistance, enough for
+/// human recognition, not enough for authentication.
+export function fingerprint(seed: Uint8Array): string {
+  let hex = "";
+  for (let i = 0; i < 4; i++) {
+    hex += seed[i].toString(16).padStart(2, "0");
+  }
+  return hex;
+}

--- a/crates/bastion/web/src/lib/Sidebar.svelte
+++ b/crates/bastion/web/src/lib/Sidebar.svelte
@@ -1,7 +1,13 @@
 <script lang="ts">
-  import { ui, createShell, killShell } from "../ui.svelte";
+  import {
+    ui,
+    createShell,
+    killShell,
+    refreshConnectors,
+  } from "../ui.svelte";
   import type { Row } from "../ui.svelte";
-  import type { Agent } from "../types";
+  import type { Connector, ConnectorKind } from "../connectors";
+  import { addDdEnclave } from "../connectors";
 
   // Rendered in this order; unknown kinds fall into "Other".
   const CATEGORIES: { key: string; label: string }[] = [
@@ -9,6 +15,51 @@
     { key: "workload", label: "Workloads" },
     { key: "claude", label: "Claude" },
     { key: "codex", label: "Codex" },
+  ];
+
+  // Placeholder "+" menu items. Each one names the discovery story
+  // so the next PR knows what it's meant to auto-populate:
+  // - ssh-host: read ~/.ssh/known_hosts + ~/.ssh/config on the user's
+  //   side (web: paste/upload; Tauri: file read).
+  // - anthropic: one API key → list conversations via API.
+  // - github: one OAuth token → events feed → blocks.
+  // - local-shell: Tauri-only native PTY.
+  const ADD_OPTIONS: {
+    kind: ConnectorKind | "local-shell";
+    label: string;
+    hint: string;
+    enabled: boolean;
+  }[] = [
+    {
+      kind: "dd-enclave",
+      label: "Add DD enclave…",
+      hint: "By block URL; or let CP discover for you.",
+      enabled: true,
+    },
+    {
+      kind: "ssh-host",
+      label: "Add SSH host",
+      hint: "Discovers from ~/.ssh/known_hosts + ~/.ssh/config.",
+      enabled: false,
+    },
+    {
+      kind: "anthropic",
+      label: "Add Anthropic conversations",
+      hint: "Paste an API key; list conversations via API.",
+      enabled: false,
+    },
+    {
+      kind: "github",
+      label: "Add GitHub activity",
+      hint: "OAuth token → events feed → blocks.",
+      enabled: false,
+    },
+    {
+      kind: "local-shell",
+      label: "Add local shell",
+      hint: "Tauri-only; opens a native PTY on this device.",
+      enabled: false,
+    },
   ];
 
   type Grouped = Map<string, [string, Row][]>;
@@ -28,28 +79,110 @@
     return { by, other };
   }
 
-  /// Label for a row in the sidebar. In unified mode, prefix with
-  /// the agent's `vm_name` so the user sees which node it lives on.
+  /// Label for a row in the sidebar — connector's label (usually
+  /// the agent's vm_name) + the session's title/id. When the user
+  /// only has one connector this is a bit verbose, but it's the
+  /// right default once they add ssh/anthropic/etc. alongside.
   function rowLabel(row: Row): string {
     const t = row.info.title || row.info.id.slice(0, 8);
-    return ui.unified ? `${row.agent.vm_name} · ${t}` : t;
+    if (ui.connectors.length <= 1) return t;
+    return `${row.connector.label} · ${t}`;
   }
 
-  function pickNewShellAgent(): Agent {
-    // Unified mode: create on the CP itself (first entry of __DD_AGENTS__
-    // by convention, since cp.rs puts CP at index 0). Falls back to
-    // location.origin in single-node mode.
-    return ui.agents[0];
+  /// Pick the enclave to create new shells on. Default: first
+  /// `dd-enclave` connector. (Future: a last-used preference.)
+  function pickNewShellConnector(): Connector | null {
+    return ui.connectors.find((c) => c.kind === "dd-enclave") ?? null;
   }
 
   let grouped = $derived(groupRows(ui.rows));
+  let menuOpen = $state(false);
+  let addingEnclave = $state(false);
+  let newEnclaveUrl = $state("");
+
+  async function submitEnclave(e: Event) {
+    e.preventDefault();
+    if (!newEnclaveUrl.trim()) return;
+    try {
+      await addDdEnclave(newEnclaveUrl);
+      newEnclaveUrl = "";
+      addingEnclave = false;
+      menuOpen = false;
+      await refreshConnectors();
+    } catch (err) {
+      console.error("add enclave failed:", err);
+    }
+  }
 </script>
 
 <aside class="sidebar">
   <div class="hdr">
     <span class="grow">Sessions</span>
-    <button class="icon" title="New shell" onclick={() => createShell(pickNewShellAgent())}>+</button>
+    {#if ui.deviceFp}
+      <span class="fp" title="Device identity (first 4 bytes)">
+        {ui.deviceFp}
+      </span>
+    {/if}
+    <div class="menu-wrap">
+      <button
+        class="icon"
+        title="New shell / add connector"
+        onclick={() => {
+          const c = pickNewShellConnector();
+          if (menuOpen) {
+            menuOpen = false;
+          } else if (c) {
+            createShell(c);
+          } else {
+            menuOpen = true;
+          }
+        }}
+        oncontextmenu={(e) => {
+          e.preventDefault();
+          menuOpen = !menuOpen;
+        }}>+</button>
+      {#if menuOpen}
+        <div class="menu" role="menu">
+          <div class="menu-head">Add connector</div>
+          {#each ADD_OPTIONS as opt}
+            <button
+              class="menu-item"
+              class:disabled={!opt.enabled}
+              disabled={!opt.enabled}
+              title={opt.hint}
+              onclick={() => {
+                if (opt.kind === "dd-enclave") {
+                  addingEnclave = true;
+                }
+              }}
+            >
+              {opt.label}
+              {#if !opt.enabled}<span class="todo">TODO</span>{/if}
+            </button>
+          {/each}
+        </div>
+      {/if}
+    </div>
   </div>
+
+  {#if addingEnclave}
+    <form class="add-form" onsubmit={submitEnclave}>
+      <label for="enclave-url">Enclave URL</label>
+      <input
+        id="enclave-url"
+        type="url"
+        placeholder="https://dd-…-block.devopsdefender.com"
+        bind:value={newEnclaveUrl}
+      />
+      <div class="add-actions">
+        <button type="submit">Add</button>
+        <button type="button" onclick={() => { addingEnclave = false; }}>
+          Cancel
+        </button>
+      </div>
+    </form>
+  {/if}
+
   <ul class="list">
     {#each CATEGORIES as cat}
       {@const items = grouped.by.get(cat.key) ?? []}
@@ -65,8 +198,7 @@
               <button
                 class="t"
                 onclick={() => (ui.active = id)}
-                title={rowLabel(row)}
-              >
+                title={rowLabel(row)}>
                 {rowLabel(row)}
               </button>
               {#if row.info.kind === "shell"}
@@ -74,14 +206,15 @@
                   class="x"
                   title="Close"
                   onclick={() => killShell(row)}
-                  aria-label="Close session"
-                >×</button>
+                  aria-label="Close session">×</button>
               {/if}
             </div>
             {#if row.blocks.length > 0}
               <ul class="blocks">
                 {#each row.blocks.slice(-50) as b (b.seq)}
-                  <li class={b.exit_code === 0 ? "ok" : "fail"} title={`exit ${b.exit_code}`}>
+                  <li
+                    class={b.exit_code === 0 ? "ok" : "fail"}
+                    title={`exit ${b.exit_code}`}>
                     {(b.command || "(no command)").slice(0, 80)}
                   </li>
                 {/each}
@@ -99,8 +232,9 @@
             <button
               class="t"
               onclick={() => (ui.active = id)}
-              title={rowLabel(row)}
-            >{rowLabel(row)}</button>
+              title={rowLabel(row)}>
+              {rowLabel(row)}
+            </button>
           </div>
         </li>
       {/each}
@@ -118,6 +252,7 @@
     min-height: 0;
   }
   .hdr {
+    position: relative;
     display: flex;
     align-items: center;
     gap: 8px;
@@ -128,6 +263,15 @@
     text-transform: uppercase;
   }
   .hdr .grow { flex: 1; }
+  .hdr .fp {
+    font-family: ui-monospace, monospace;
+    font-size: 10px;
+    color: #6c7086;
+    padding: 1px 6px;
+    border: 1px solid #313244;
+    border-radius: 3px;
+    letter-spacing: 0.6px;
+  }
   button.icon {
     padding: 2px 10px;
     font-size: 16px;
@@ -139,6 +283,93 @@
     cursor: pointer;
   }
   button.icon:hover { background: #45475a; }
+  .menu-wrap { position: relative; }
+  .menu {
+    position: absolute;
+    top: 28px;
+    right: 0;
+    background: #181825;
+    border: 1px solid #313244;
+    border-radius: 4px;
+    padding: 4px;
+    min-width: 220px;
+    z-index: 10;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  }
+  .menu-head {
+    color: #89b4fa;
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.6px;
+    padding: 6px 8px 4px;
+  }
+  .menu-item {
+    all: unset;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    width: 100%;
+    padding: 6px 8px;
+    border-radius: 3px;
+    color: #cdd6f4;
+    font-size: 12px;
+    cursor: pointer;
+    text-transform: none;
+    box-sizing: border-box;
+  }
+  .menu-item:hover:not(.disabled) { background: #313244; }
+  .menu-item.disabled {
+    color: #585b70;
+    cursor: not-allowed;
+  }
+  .menu-item .todo {
+    margin-left: auto;
+    font-size: 9px;
+    color: #f9e2af;
+    background: #45452344;
+    padding: 1px 4px;
+    border-radius: 2px;
+    letter-spacing: 0.4px;
+  }
+  .add-form {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 12px 14px;
+    background: #1e1e2e;
+    border-bottom: 1px solid #313244;
+  }
+  .add-form label {
+    color: #a6adc8;
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.6px;
+  }
+  .add-form input {
+    background: #11111b;
+    color: #cdd6f4;
+    border: 1px solid #313244;
+    border-radius: 3px;
+    padding: 6px 8px;
+    font-size: 12px;
+    font-family: ui-monospace, monospace;
+  }
+  .add-form input:focus {
+    outline: none;
+    border-color: #89b4fa;
+  }
+  .add-actions { display: flex; gap: 6px; }
+  .add-actions button {
+    flex: 1;
+    padding: 6px 8px;
+    border: 0;
+    border-radius: 3px;
+    background: #313244;
+    color: #cdd6f4;
+    font-size: 11px;
+    cursor: pointer;
+  }
+  .add-actions button[type="submit"] { background: #89b4fa; color: #11111b; }
   .list {
     list-style: none;
     margin: 0;

--- a/crates/bastion/web/src/lib/TerminalPane.svelte
+++ b/crates/bastion/web/src/lib/TerminalPane.svelte
@@ -76,8 +76,8 @@
     const row = ui.rows.get(rowId);
     if (!row) return;
     const term = row.term!;
-    const proto = row.agent.origin.startsWith("https:") ? "wss:" : "ws:";
-    const base = row.agent.origin.replace(/^https?:/, proto);
+    const proto = row.origin.startsWith("https:") ? "wss:" : "ws:";
+    const base = row.origin.replace(/^https?:/, proto);
     const ws = new WebSocket(`${base}/ws/${row.info.id}`);
     ws.binaryType = "arraybuffer";
     row.ws = ws;

--- a/crates/bastion/web/src/ui.svelte.ts
+++ b/crates/bastion/web/src/ui.svelte.ts
@@ -1,87 +1,130 @@
 import type { Agent, BlockRecord, SessionInfo } from "./types";
+import type { Connector } from "./connectors";
+import { listConnectors, seedFromAgents, addConnector } from "./connectors";
+import { loadIdentitySeed, fingerprint } from "./identity";
 
-/// Composite key so session ids from different agents can't collide.
-export type RowId = string; // `${vm_name}/${session_id}`
+/// Composite key so session ids from different connectors can't collide.
+export type RowId = string; // `${connector.label}/${session_id}`
 
 export interface Row {
-  /// Node this session lives on.
-  agent: Agent;
+  /// Connector this session came from. The SPA keeps a direct
+  /// reference (rather than a connector id) so row operations don't
+  /// need to re-look-up the connector.
+  connector: Connector;
+  /// Origin this row's WS/API calls target. For `dd-enclave` this
+  /// comes from `connector.config.origin`; future kinds (SSH,
+  /// Anthropic) compute it differently.
+  origin: string;
   info: SessionInfo;
   blocks: BlockRecord[];
-  /// Live WS to the owning agent. `null` until first activation.
+  /// Live WS to the owning origin. `null` until first activation.
   ws: WebSocket | null;
   /// xterm.js instance. `null` until first activation.
   term: import("@xterm/xterm").Terminal | null;
   fit: import("@xterm/addon-fit").FitAddon | null;
 }
 
-function rowKey(agent: Agent, sessionId: string): RowId {
-  return `${agent.vm_name}/${sessionId}`;
+function rowKey(connector: Connector, sessionId: string): RowId {
+  return `${connector.label}/${sessionId}`;
 }
 
-/// Svelte 5 runes-based reactive ui. One flat Map of rows, keyed by
-/// `${vm_name}/${id}`, populated by fan-out in unified mode or a single
-/// fetch in single-node mode.
-///
-/// Named `ui` (not `state`) to avoid ambiguity with Svelte's `$state`
-/// rune when consumers also use runes locally.
+/// Svelte 5 runes-based reactive UI state. One flat Map of rows plus
+/// the client-held connector list. Named `ui` (not `state`) to avoid
+/// ambiguity with Svelte's `$state` rune when consumers also use
+/// runes locally.
 export const ui = $state<{
   rows: Map<RowId, Row>;
   active: RowId | null;
-  agents: Agent[];
-  unified: boolean;
+  connectors: Connector[];
+  /// Short visual device-id fingerprint — rendered in the sidebar
+  /// header. Derived from the identity seed persisted in
+  /// localStorage (see `identity.ts`).
+  deviceFp: string;
+  /// True once the first `bootstrap()` call finishes. UI can use
+  /// this to show a spinner on initial load.
+  ready: boolean;
 }>({
   rows: new Map(),
   active: null,
-  agents: [],
-  unified: false,
+  connectors: [],
+  deviceFp: "",
+  ready: false,
 });
 
-/// Agents to query. In unified mode comes from `window.__DD_AGENTS__`;
-/// otherwise a single-element list representing the current origin.
-export function resolveAgents(): Agent[] {
+/// One-time setup at app load: mint/load the device identity, pull
+/// the connector list from IndexedDB (seed on first run from the
+/// server-injected `__DD_AGENTS__`), and fan out to each connector
+/// to populate `ui.rows`.
+export async function bootstrap(): Promise<void> {
+  ui.deviceFp = fingerprint(loadIdentitySeed());
   if (window.__DD_AGENTS__ && window.__DD_AGENTS__.length > 0) {
-    ui.unified = true;
-    return window.__DD_AGENTS__;
+    await seedFromAgents(window.__DD_AGENTS__);
   }
-  ui.unified = false;
-  return [{ vm_name: location.hostname, origin: location.origin }];
+  await refreshConnectors();
+  ui.ready = true;
 }
 
-export async function loadSessions(): Promise<void> {
-  ui.agents = resolveAgents();
+/// Reload connectors from IndexedDB and re-fetch sessions from each.
+/// Called after add/remove.
+export async function refreshConnectors(): Promise<void> {
+  ui.connectors = await listConnectors();
+  await reloadSessions();
+}
+
+async function reloadSessions(): Promise<void> {
   const all = await Promise.all(
-    ui.agents.map(async (agent): Promise<Row[]> => {
-      try {
-        const resp = await fetch(`${agent.origin}/api/sessions`, {
-          credentials: "include",
-        });
-        if (!resp.ok) return [];
-        const sessions: SessionInfo[] = await resp.json();
-        return sessions.map((info) => ({
-          agent,
-          info,
-          blocks: [],
-          ws: null,
-          term: null,
-          fit: null,
-        }));
-      } catch {
-        return [];
+    ui.connectors.map(async (c): Promise<Row[]> => {
+      if (c.kind === "dd-enclave") {
+        return fetchDdEnclave(c);
       }
-    })
+      // Every other connector kind is a Phase-3 TODO. Keep the row
+      // for sidebar discoverability but don't try to fetch.
+      return [];
+    }),
   );
   const next = new Map<RowId, Row>();
   for (const bucket of all) {
     for (const row of bucket) {
-      next.set(rowKey(row.agent, row.info.id), row);
+      next.set(rowKey(row.connector, row.info.id), row);
     }
   }
   ui.rows = next;
 }
 
-export async function createShell(agent: Agent): Promise<void> {
-  const resp = await fetch(`${agent.origin}/api/sessions`, {
+/// Fetch an enclave's live sessions. Cross-origin failures
+/// (CF-Access bounce, CORS reject, offline) degrade to "no rows" for
+/// that enclave rather than propagating — the sidebar still shows
+/// every connector the user configured, just empty for unreachable
+/// ones. Phase 2 replaces this with a Noise_KK channel that isn't
+/// subject to the same browser same-origin rules.
+async function fetchDdEnclave(c: Connector): Promise<Row[]> {
+  const origin = (c.config.origin as string | undefined) ?? "";
+  if (!origin) return [];
+  try {
+    const resp = await fetch(`${origin}/api/sessions`, {
+      credentials: "include",
+    });
+    if (!resp.ok) return [];
+    const sessions: SessionInfo[] = await resp.json();
+    return sessions.map((info) => ({
+      connector: c,
+      origin,
+      info,
+      blocks: [],
+      ws: null,
+      term: null,
+      fit: null,
+    }));
+  } catch {
+    return [];
+  }
+}
+
+export async function createShell(c: Connector): Promise<void> {
+  if (c.kind !== "dd-enclave") return;
+  const origin = (c.config.origin as string | undefined) ?? "";
+  if (!origin) return;
+  const resp = await fetch(`${origin}/api/sessions`, {
     method: "POST",
     credentials: "include",
     headers: { "content-type": "application/json" },
@@ -89,10 +132,11 @@ export async function createShell(agent: Agent): Promise<void> {
   });
   if (!resp.ok) return;
   const info: SessionInfo = await resp.json();
-  const id = rowKey(agent, info.id);
+  const id = rowKey(c, info.id);
   const rows = new Map(ui.rows);
   rows.set(id, {
-    agent,
+    connector: c,
+    origin,
     info,
     blocks: [],
     ws: null,
@@ -104,8 +148,12 @@ export async function createShell(agent: Agent): Promise<void> {
 }
 
 export async function killShell(row: Row): Promise<void> {
+  if (row.connector.kind !== "dd-enclave") {
+    destroyRow(rowKey(row.connector, row.info.id));
+    return;
+  }
   try {
-    await fetch(`${row.agent.origin}/api/sessions/${row.info.id}`, {
+    await fetch(`${row.origin}/api/sessions/${row.info.id}`, {
       method: "DELETE",
       credentials: "include",
     });
@@ -113,7 +161,7 @@ export async function killShell(row: Row): Promise<void> {
     // Not fatal — the session might be gone already; the UI cleanup
     // below runs either way.
   }
-  destroyRow(rowKey(row.agent, row.info.id));
+  destroyRow(rowKey(row.connector, row.info.id));
 }
 
 export function destroyRow(id: RowId): void {
@@ -136,3 +184,6 @@ export function destroyRow(id: RowId): void {
     ui.active = null;
   }
 }
+
+/// Re-export for the sidebar's "Add enclave" dialog.
+export { addConnector };


### PR DESCRIPTION
## Summary

Phase 1 of the Signal-style client-as-brain, server-as-blind-store architecture. Scaffolds the client-side connector model every future kind (SSH, Anthropic, GitHub, local shell, cross-device sync) will plug into. Zero behavior change for the default DD-enclave path; stacked on #172.

## What's in

### \`identity.ts\` — device identity seed

32 random bytes minted once per browser origin, persisted in localStorage, idempotent on reload. Phase 2 derives the long-term X25519 Noise static keypair from this seed. The sidebar header shows a 4-byte fingerprint so the user can eyeball device continuity across reloads.

### \`connectors.ts\` — IndexedDB store

Object store \`connectors\` keyed by \`{id, kind, label, config, created_at_ms}\`. CRUD + a one-shot \`seedFromAgents()\` that migrates the current \`window.__DD_AGENTS__\` injection into persistent entries on first load. \`addDdEnclave(origin, label?)\` for the user-typed-URL form.

### \`ui.svelte.ts\` rewired

Session rows now derive from the connector list, not a server-injected agent list. Each connector kind has its own \`fetchX()\` dispatch; only \`dd-enclave\` is implemented here. **Cross-origin fetch failure degrades silently** — no more console spam, the connector just shows no rows. Fixes the CF-Access preflight error on cross-origin \`/api/sessions\`.

### Sidebar

- \`+\` button behavior:
  - **Left-click, primary DD enclave exists** → create a new shell on it (existing shortcut preserved).
  - **Left-click, no DD enclave** → open connector menu.
  - **Right-click** → open connector menu regardless.
- Menu items:
  - **Add DD enclave…** — enabled. Small URL form; adds the connector to IDB, refreshes sessions.
  - **Add SSH host / Add Anthropic conversations / Add GitHub activity / Add local shell** — disabled with \`TODO\` badges. Tooltips carry the discovery hint (\`~/.ssh/known_hosts\` + \`~/.ssh/config\`; one API key → conversation list; OAuth → events feed; Tauri-only native PTY).

## Out of scope (ordered follow-ups)

- **Phase 2**: Noise_KK handshake to one agent. Bastion exposes \`GET /attest\` with TDX quote binding its Noise static pubkey in \`REPORT_DATA\`; client verifies + handshakes; replaces \`/api/sessions\` + \`/ws\` with an encrypted channel. Drops CF Access from the cross-origin path.
- **Phase 3**: at-rest ciphertext of stored \`BlockRecord\`s on the agent, keyed by client pubkey. Server goes blind.
- **Phase 3b**: multi-device pairing + encrypted connector-list sync across the user's devices.
- **Phase 4**: SSH / Anthropic / GitHub / local-shell connectors (each its own small PR once Phase 2 is stable).

## Test plan

- [x] \`npm run check\` + \`npm run build\` + \`cargo build\` + \`cargo test --workspace\` + \`cargo clippy --workspace --all-targets -- -D warnings\` + \`cargo fmt --all --check\` all green.
- [ ] Preview CI.
- [ ] Manual smoke: sidebar loads, boot-workload backfill still works (via #172's ee_sync path — connector list is seeded from the same \`__DD_AGENTS__\` injection); \`+\` button opens menu; typing a URL adds a new connector and sidebar refreshes; reloading preserves the connector list.