### PR TITLE
feat(bastion): Noise static keypair + /attest endpoint (Phase 2a)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,6 +118,7 @@ dependencies = [
  "futures-util",
  "libc",
  "portable-pty",
+ "rand 0.8.5",
  "reqwest",
  "serde",
  "serde_json",
@@ -126,6 +127,7 @@ dependencies = [
  "tower-http",
  "uuid",
  "vte",
+ "x25519-dalek",
 ]
 
 [[package]]
@@ -223,6 +225,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -315,6 +343,12 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "filedescriptor"
@@ -1205,6 +1239,15 @@ name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -2416,6 +2459,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core 0.6.4",
+ "serde",
+ "zeroize",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2484,6 +2539,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"

--- a/apps/bastion/workload.json.tmpl
+++ b/apps/bastion/workload.json.tmpl
@@ -20,6 +20,8 @@
     "--ee-socket",
     "/var/lib/easyenclave/agent.sock",
     "--cp-url",
-    "http://127.0.0.1:8080"
+    "http://127.0.0.1:8080",
+    "--noise-key",
+    "/var/lib/easyenclave/bastion/noise-static.key"
   ]
 }

--- a/crates/bastion/Cargo.toml
+++ b/crates/bastion/Cargo.toml
@@ -27,11 +27,13 @@ libc = "0.2"
 portable-pty = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+rand = "0.8"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 tokio = { version = "1", features = ["fs", "macros", "rt-multi-thread", "sync", "io-util", "net", "signal"] }
 tower-http = { version = "0.6", features = ["cors"] }
 uuid = { version = "1", features = ["v4"] }
 vte = "0.13"
+x25519-dalek = { version = "2", features = ["static_secrets"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/bastion/src/bin/bastion.rs
+++ b/crates/bastion/src/bin/bastion.rs
@@ -8,7 +8,7 @@ use axum::Router;
 async fn main() -> std::io::Result<()> {
     let args: Vec<String> = std::env::args().collect();
     if args.get(1).map(|s| s.as_str()) != Some("serve") {
-        eprintln!("usage: bastion serve [--port N] [--bind ADDR] [--capture-socket PATH] [--ee-socket PATH] [--cp-url URL]");
+        eprintln!("usage: bastion serve [--port N] [--bind ADDR] [--capture-socket PATH] [--ee-socket PATH] [--cp-url URL] [--noise-key PATH]");
         std::process::exit(2);
     }
 
@@ -17,6 +17,7 @@ async fn main() -> std::io::Result<()> {
     let mut capture_socket: Option<String> = None;
     let mut ee_socket: Option<String> = None;
     let mut cp_url: Option<String> = None;
+    let mut noise_key_path: Option<String> = None;
     let mut i = 2;
     while i < args.len() {
         match args[i].as_str() {
@@ -42,6 +43,10 @@ async fn main() -> std::io::Result<()> {
                 cp_url = args.get(i + 1).cloned();
                 i += 2;
             }
+            "--noise-key" => {
+                noise_key_path = args.get(i + 1).cloned();
+                i += 2;
+            }
             other => {
                 eprintln!("bastion: unknown arg {other}");
                 std::process::exit(2);
@@ -56,6 +61,25 @@ async fn main() -> std::io::Result<()> {
         // failures fall through to single-node rendering.
         eprintln!("bastion: cross-node aggregator against CP {url}");
         mgr = mgr.with_cp_url(url);
+    }
+    if let Some(path) = noise_key_path.as_deref().filter(|s| !s.is_empty()) {
+        // Load (or mint on first boot) the long-term Noise static
+        // keypair. Exposed via `GET /attest` so clients can pin the
+        // pubkey for Phase 2b's Noise_KK handshake.
+        match bastion::noise::NoiseStatic::load_or_generate(path) {
+            Ok(key) => {
+                eprintln!(
+                    "bastion: noise static key {:?} ({}…)",
+                    key.source(),
+                    &key.public_hex()[..16]
+                );
+                mgr = mgr.with_noise_key(key);
+            }
+            Err(e) => {
+                eprintln!("bastion: noise key load at {path}: {e}");
+                std::process::exit(1);
+            }
+        }
     }
 
     if let Some(path) = capture_socket {

--- a/crates/bastion/src/lib.rs
+++ b/crates/bastion/src/lib.rs
@@ -47,6 +47,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 pub mod capture;
 pub mod ee;
 pub mod ee_sync;
+pub mod noise;
 
 use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
 use axum::extract::{Path, State};
@@ -220,6 +221,12 @@ pub struct Manager {
     /// in the fleet. Absent → single-node fallback.
     cp_url: Option<Arc<str>>,
     http: reqwest::Client,
+    /// Long-term Noise static keypair. Clients fetch the pubkey
+    /// via `GET /attest` and pin it; Phase 2b runs a Noise_KK
+    /// handshake keyed by this + a client static key. Absent in
+    /// standalone dev / local-embedder mode — `/attest` then
+    /// responds 404.
+    noise: Option<Arc<noise::NoiseStatic>>,
 }
 
 impl Default for Manager {
@@ -234,6 +241,7 @@ impl Manager {
             inner: Arc::new(RwLock::new(Default::default())),
             cp_url: None,
             http: reqwest::Client::new(),
+            noise: None,
         }
     }
 
@@ -247,6 +255,15 @@ impl Manager {
         if !url.is_empty() {
             self.cp_url = Some(Arc::from(url));
         }
+        self
+    }
+
+    /// Attach the persistent Noise static keypair. When set, `GET
+    /// /attest` returns `{noise_pubkey_hex}` so clients can pin it
+    /// before Phase 2b's Noise_KK handshake. Absent → `/attest`
+    /// returns 404.
+    pub fn with_noise_key(mut self, key: noise::NoiseStatic) -> Self {
+        self.noise = Some(Arc::new(key));
         self
     }
 
@@ -760,11 +777,37 @@ pub fn router(manager: Manager) -> Router {
 
     Router::new()
         .route("/", get(page))
+        .route("/attest", get(attest))
         .route("/api/sessions", get(list_sessions).post(create_session))
         .route("/api/sessions/{id}", delete(kill_session))
         .route("/ws/{id}", get(ws_upgrade))
         .layer(cors)
         .with_state(manager)
+}
+
+/// GET /attest — returns this bastion's long-term Noise static
+/// pubkey. Clients pin the returned `noise_pubkey_hex` and use it
+/// as the responder key for Phase 2b's Noise_KK handshake. Phase
+/// 2d will add the TDX attestation quote to the response body so
+/// clients can verify the pubkey came from a genuine enclave.
+///
+/// 404 when no Noise keypair is configured (standalone dev,
+/// embedders that didn't call `Manager::with_noise_key`).
+async fn attest(State(m): State<Manager>) -> impl IntoResponse {
+    let Some(key) = m.noise.as_ref() else {
+        return (
+            axum::http::StatusCode::NOT_FOUND,
+            Json(serde_json::json!({
+                "error": "noise key not configured"
+            })),
+        )
+            .into_response();
+    };
+    Json(serde_json::json!({
+        "noise_pubkey_hex": key.public_hex(),
+        "source": format!("{:?}", key.source()).to_lowercase(),
+    }))
+    .into_response()
 }
 
 async fn page(State(m): State<Manager>) -> impl IntoResponse {

--- a/crates/bastion/src/noise.rs
+++ b/crates/bastion/src/noise.rs
@@ -1,0 +1,182 @@
+//! Noise handshake groundwork (Phase 2a — scaffolding only).
+//!
+//! This module owns bastion's long-term Noise static keypair. The
+//! keypair is generated once on first boot and persisted so
+//! subsequent boots (or restarts within the same VM) reuse the same
+//! pubkey. Clients that have already pinned the pubkey after an
+//! attested handshake (Phase 2d) won't see it rotate without
+//! reason.
+//!
+//! Phase 2b will add the actual Noise_KK handshake + encrypted
+//! `/api/sessions` and `/ws/*` channels; Phase 2d binds the pubkey
+//! into the TDX quote's `REPORT_DATA` so clients can verify the
+//! keypair came from a genuine attested enclave. Today we just
+//! expose the pubkey via `GET /attest` so client code can start
+//! caching it.
+
+use std::path::{Path, PathBuf};
+
+use rand::rngs::OsRng;
+use x25519_dalek::{PublicKey, StaticSecret};
+
+/// 32-byte Noise static key material persisted on disk. Passed to
+/// [`Manager::with_noise_key`](crate::Manager::with_noise_key) so
+/// HTTP handlers can expose the pubkey.
+pub struct NoiseStatic {
+    #[allow(dead_code)] // Phase 2b consumes this for the handshake
+    secret: StaticSecret,
+    public: PublicKey,
+    source: NoiseKeySource,
+}
+
+impl std::fmt::Debug for NoiseStatic {
+    /// Never print the secret half. `{:?}` shows only the pubkey
+    /// (truncated) + the source so an accidental log line doesn't
+    /// leak the long-term identity.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let hex = self.public_hex();
+        let short = &hex[..hex.len().min(16)];
+        write!(f, "NoiseStatic({:?}, {}…)", self.source, short)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum NoiseKeySource {
+    /// Fresh random key, written to disk for the first time.
+    Generated,
+    /// Loaded from an existing on-disk key file.
+    Loaded,
+}
+
+impl NoiseStatic {
+    pub fn public(&self) -> &PublicKey {
+        &self.public
+    }
+
+    /// Hex-encoded pubkey for JSON wire use.
+    pub fn public_hex(&self) -> String {
+        hex::encode(self.public.as_bytes())
+    }
+
+    pub fn source(&self) -> NoiseKeySource {
+        self.source
+    }
+
+    /// Ephemeral in-memory keypair. Used for tests and for the
+    /// standalone `bastion serve` local-dev binary where persistence
+    /// isn't meaningful across restarts.
+    pub fn ephemeral() -> Self {
+        let secret = StaticSecret::random_from_rng(OsRng);
+        let public = PublicKey::from(&secret);
+        Self {
+            secret,
+            public,
+            source: NoiseKeySource::Generated,
+        }
+    }
+
+    /// Load an existing static key from `path`, or mint a fresh one
+    /// and write it if the file doesn't exist. Always `chmod 0600`
+    /// after write — the file is the enclave's long-term identity;
+    /// only bastion should read it.
+    pub fn load_or_generate(path: impl AsRef<Path>) -> std::io::Result<Self> {
+        let path: PathBuf = path.as_ref().to_path_buf();
+        if path.exists() {
+            let bytes = std::fs::read(&path)?;
+            if bytes.len() != 32 {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!(
+                        "noise key file {} is {} bytes; expected 32",
+                        path.display(),
+                        bytes.len()
+                    ),
+                ));
+            }
+            let mut sk = [0u8; 32];
+            sk.copy_from_slice(&bytes);
+            let secret = StaticSecret::from(sk);
+            let public = PublicKey::from(&secret);
+            return Ok(Self {
+                secret,
+                public,
+                source: NoiseKeySource::Loaded,
+            });
+        }
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let s = Self::ephemeral();
+        let bytes: [u8; 32] = s.secret.to_bytes();
+        std::fs::write(&path, bytes)?;
+        chmod_0600(&path)?;
+        Ok(Self {
+            secret: s.secret,
+            public: s.public,
+            source: NoiseKeySource::Generated,
+        })
+    }
+}
+
+fn chmod_0600(path: &Path) -> std::io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    let mut perms = std::fs::metadata(path)?.permissions();
+    perms.set_mode(0o600);
+    std::fs::set_permissions(path, perms)
+}
+
+// `hex` is pulled in transitively via existing deps; if the
+// transitive path changes, add `hex = "0.4"` to `Cargo.toml`
+// explicitly.
+mod hex {
+    pub fn encode(bytes: &[u8]) -> String {
+        let mut s = String::with_capacity(bytes.len() * 2);
+        for b in bytes {
+            s.push_str(&format!("{b:02x}"));
+        }
+        s
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ephemeral_is_random_each_call() {
+        let a = NoiseStatic::ephemeral();
+        let b = NoiseStatic::ephemeral();
+        assert_ne!(a.public().as_bytes(), b.public().as_bytes());
+        assert_eq!(a.public_hex().len(), 64);
+    }
+
+    #[test]
+    fn load_or_generate_is_stable_across_calls() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("noise-static.key");
+        let first = NoiseStatic::load_or_generate(&path).unwrap();
+        let second = NoiseStatic::load_or_generate(&path).unwrap();
+        assert_eq!(first.public().as_bytes(), second.public().as_bytes());
+        assert!(matches!(first.source(), NoiseKeySource::Generated));
+        assert!(matches!(second.source(), NoiseKeySource::Loaded));
+    }
+
+    #[test]
+    fn load_or_generate_rejects_wrong_length() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("corrupt.key");
+        std::fs::write(&path, b"too short").unwrap();
+        let err = NoiseStatic::load_or_generate(&path).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn key_file_is_chmod_0600() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("noise-static.key");
+        let _ = NoiseStatic::load_or_generate(&path).unwrap();
+        let perms = std::fs::metadata(&path).unwrap().permissions();
+        assert_eq!(perms.mode() & 0o777, 0o600);
+    }
+}

--- a/crates/bastion/web/src/connectors.ts
+++ b/crates/bastion/web/src/connectors.ts
@@ -122,3 +122,47 @@ export async function addDdEnclave(
   await addConnector(c);
   return c;
 }
+
+/// Fetch a DD enclave's long-term Noise pubkey via `GET /attest`.
+/// Returns `null` on any error (cross-origin CF-Access bounce,
+/// connector offline, server missing `--noise-key`). Phase 2b uses
+/// the returned pubkey as the responder static for the Noise_KK
+/// handshake; Phase 2d adds a TDX quote to the same response that
+/// binds the pubkey into `REPORT_DATA` so clients can verify.
+export async function fetchAttest(
+  origin: string,
+): Promise<{ noise_pubkey_hex: string; source: string } | null> {
+  try {
+    const resp = await fetch(`${origin}/attest`, { credentials: "include" });
+    if (!resp.ok) return null;
+    const body = await resp.json();
+    if (typeof body?.noise_pubkey_hex !== "string") return null;
+    return {
+      noise_pubkey_hex: body.noise_pubkey_hex,
+      source: typeof body?.source === "string" ? body.source : "unknown",
+    };
+  } catch {
+    return null;
+  }
+}
+
+/// Merge `patch` into an existing connector's `config` and persist.
+/// Used by the attest cache to remember server Noise pubkeys across
+/// page loads. Silent no-op if the connector isn't in IDB.
+export async function patchConnectorConfig(
+  id: string,
+  patch: Record<string, unknown>,
+): Promise<void> {
+  const db = await openDb();
+  const existing: Connector | undefined = await new Promise(
+    (resolve, reject) => {
+      const tx = db.transaction(DB_STORE, "readonly");
+      const req = tx.objectStore(DB_STORE).get(id);
+      req.onsuccess = () => resolve(req.result as Connector | undefined);
+      req.onerror = () => reject(req.error);
+    },
+  );
+  if (!existing) return;
+  existing.config = { ...existing.config, ...patch };
+  await addConnector(existing);
+}

--- a/crates/bastion/web/src/ui.svelte.ts
+++ b/crates/bastion/web/src/ui.svelte.ts
@@ -1,6 +1,12 @@
 import type { Agent, BlockRecord, SessionInfo } from "./types";
 import type { Connector } from "./connectors";
-import { listConnectors, seedFromAgents, addConnector } from "./connectors";
+import {
+  listConnectors,
+  seedFromAgents,
+  addConnector,
+  fetchAttest,
+  patchConnectorConfig,
+} from "./connectors";
 import { loadIdentitySeed, fingerprint } from "./identity";
 
 /// Composite key so session ids from different connectors can't collide.
@@ -54,14 +60,44 @@ export const ui = $state<{
 /// One-time setup at app load: mint/load the device identity, pull
 /// the connector list from IndexedDB (seed on first run from the
 /// server-injected `__DD_AGENTS__`), and fan out to each connector
-/// to populate `ui.rows`.
+/// to populate `ui.rows`. Also kicks off a background `/attest`
+/// fetch per enclave so Phase 2b's Noise_KK handshake has the
+/// server pubkey ready.
 export async function bootstrap(): Promise<void> {
   ui.deviceFp = fingerprint(loadIdentitySeed());
   if (window.__DD_AGENTS__ && window.__DD_AGENTS__.length > 0) {
     await seedFromAgents(window.__DD_AGENTS__);
   }
   await refreshConnectors();
+  // Fire-and-forget — attest can be slow/cross-origin-blocked and
+  // the sidebar shouldn't wait for it. Phase 2b will gate session
+  // connections on the pubkey being cached.
+  void refreshAttest();
   ui.ready = true;
+}
+
+/// Fetch `/attest` for every `dd-enclave` connector and merge the
+/// returned Noise pubkey into its config. Idempotent; runs quietly
+/// in the background on bootstrap. Console-logs the pubkey so
+/// Phase 2a can be visually verified before Phase 2b wires it up.
+async function refreshAttest(): Promise<void> {
+  for (const c of ui.connectors) {
+    if (c.kind !== "dd-enclave") continue;
+    const origin = c.config.origin as string | undefined;
+    if (!origin) continue;
+    const attest = await fetchAttest(origin);
+    if (!attest) continue;
+    const known = c.config.serverNoisePubkeyHex as string | undefined;
+    if (known === attest.noise_pubkey_hex) continue;
+    console.log(
+      `bastion: ${c.label} noise pubkey ${attest.noise_pubkey_hex.slice(0, 16)}… (${attest.source})`,
+    );
+    await patchConnectorConfig(c.id, {
+      serverNoisePubkeyHex: attest.noise_pubkey_hex,
+    });
+  }
+  // Re-read so `ui.connectors` has the patched config for Phase 2b.
+  ui.connectors = await listConnectors();
 }
 
 /// Reload connectors from IndexedDB and re-fetch sessions from each.


### PR DESCRIPTION
## Summary

Phase 2a of the Signal-style plan. Scaffolding only — lays the key-management groundwork both sides need. Phase 2b adds the Noise_KK handshake and swaps \`/api/sessions\` + \`/ws/*\` onto the encrypted channel. Phase 2d binds the pubkey into the TDX quote's \`REPORT_DATA\` for client-side verification.

## Server (Rust)

- **\`bastion::noise::NoiseStatic\`** — 32-byte X25519 static key. \`load_or_generate(path)\` reads the file if present or mints a fresh one + writes it. \`chmod 0600\` after write. Custom \`Debug\` impl never prints the secret. \`StaticSecret\` stays in memory only — Phase 2b consumes it for the handshake.
- **\`Manager::with_noise_key(key)\`** — optional builder. Embedders who don't call it get a 404 on \`/attest\`. Zero behavior change for the \`examples/standalone.rs\` local-dev path.
- **\`GET /attest\`** — \`{noise_pubkey_hex, source}\` where \`source\` is \`generated\`/\`loaded\`. 404 without a key.
- **\`--noise-key PATH\`** on \`bastion serve\`.
- **\`apps/bastion/workload.json.tmpl\`** — \`/var/lib/easyenclave/bastion/noise-static.key\` so the key survives bastion redeploys within the same VM.
- **4 unit tests**: stable across reloads, wrong length rejected, \`chmod 0600\` verified, ephemeral keys diverge.

## Client (TS)

- **\`fetchAttest(origin)\`** — cross-origin-safe helper. Logs \`<pubkey prefix>… (<source>)\` to console on success so Phase 2a is visually verifiable in devtools before Phase 2b wires it up.
- **\`patchConnectorConfig(id, patch)\`** — merges into an existing IDB connector record. Caches \`serverNoisePubkeyHex\` under each \`dd-enclave\` connector's config.
- **\`bootstrap()\`** fires a background \`refreshAttest()\` after sessions load — never blocks rendering.

## Out of scope (explicit follow-ups)

- **Phase 2b**: actual Noise_KK handshake (swap in \`snow\` server-side, \`@noble/curves\` client-side). Replace \`/api/sessions\` + \`/ws/*\` with encrypted variants. At that point CF Access stops being the cross-origin bottleneck.
- **Phase 2c**: WS shell tunneling over Noise.
- **Phase 2d**: TDX quote in \`/attest\` response body, \`REPORT_DATA = sha256(noise_pubkey)\` so clients can verify the pubkey came from a genuine attested enclave. At this point \`/attest\` starts mattering for security, not just plumbing.
- **Phase 3**: at-rest ciphertext of \`BlockRecord\`s under the client pubkey + multi-device pairing.
- **Phase 4**: SSH / Anthropic / GitHub / local-shell connectors.

## Test plan

- [x] \`cargo build --workspace\` + \`cargo test --workspace\` (11 bastion + 21 dd + 2 doc) + \`cargo clippy --workspace --all-targets -- -D warnings\` + \`cargo fmt --all --check\` all clean.
- [x] \`npm run check\` + \`npm run build\` clean (85 files, 0 errors).
- [ ] Preview CI.
- [ ] Manual: \`curl https://pr-XXX-block.devopsdefender.com/attest\` (once CF-access-bypassed — see followup below) returns \`{noise_pubkey_hex, source}\`. Sidebar console shows \`bastion: <connector-label> noise pubkey <hex16>… (generated|loaded)\` for every reachable enclave.

## Known wart

The \`/attest\` endpoint is under the CF Access human policy on block subdomains (same as \`/api/sessions\`). Cross-origin fetches from the SPA will CORS-bounce and \`fetchAttest\` will return null — same failure mode we already degrade silently for. A tiny follow-up PR can add \`/attest\` to the CF Access bypass list in \`cf::provision_agent_access\` / \`provision_cp_access\`, mirroring how \`/health\`, \`/deploy\`, \`/exec\`, \`/logs\` are handled on agent hostnames. Or we just wait for Phase 2b where Noise replaces the whole thing.