### PR TITLE
feat(bastion): Noise_IK TS client — sidebar uses encrypted tunnel

### DIFF
--- a/.github/workflows/release-bastion.yml
+++ b/.github/workflows/release-bastion.yml
@@ -51,6 +51,7 @@ jobs:
         working-directory: crates/bastion/web
         run: |
           npm ci
+          npm test
           npm run build
 
       - name: Build bastion

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,6 +76,7 @@ jobs:
         working-directory: crates/bastion/web
         run: |
           npm ci
+          npm test
           npm run build
 
       # Folded in from the old ci.yml so we don't duplicate the compile

--- a/crates/bastion/src/lib.rs
+++ b/crates/bastion/src/lib.rs
@@ -1118,11 +1118,21 @@ struct NoiseResp {
 #[derive(Debug, Serialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 enum NoiseRespBody {
-    Sessions(Vec<SessionInfo>),
-    Session(SessionInfo),
+    /// Named `sessions` field so serde's `#[serde(tag)]` internal-
+    /// tagging works (it can't internally-tag a bare `Vec`).
+    Sessions {
+        sessions: Vec<SessionInfo>,
+    },
+    Session {
+        session: SessionInfo,
+    },
     Ok,
-    Err { msg: String },
-    Pong { server_time_ms: u64 },
+    Err {
+        msg: String,
+    },
+    Pong {
+        server_time_ms: u64,
+    },
 }
 
 async fn noise_ws_upgrade(ws: WebSocketUpgrade, State(m): State<Manager>) -> impl IntoResponse {
@@ -1233,11 +1243,13 @@ async fn dispatch_noise_req(m: &Manager, plain: &[u8]) -> NoiseResp {
         }
     };
     let body = match req.body {
-        NoiseReqBody::SessionsList => NoiseRespBody::Sessions(m.list().await),
+        NoiseReqBody::SessionsList => NoiseRespBody::Sessions {
+            sessions: m.list().await,
+        },
         NoiseReqBody::SessionsCreate { title } => {
             let t = title.unwrap_or_else(|| "shell".to_string());
             match m.create(t).await {
-                Ok(s) => NoiseRespBody::Session(s.info()),
+                Ok(s) => NoiseRespBody::Session { session: s.info() },
                 Err(e) => NoiseRespBody::Err {
                     msg: format!("create: {e}"),
                 },

--- a/crates/bastion/web/package-lock.json
+++ b/crates/bastion/web/package-lock.json
@@ -8,6 +8,9 @@
       "name": "bastion-web",
       "version": "0.1.0",
       "dependencies": {
+        "@noble/ciphers": "^2.2.0",
+        "@noble/curves": "^2.2.0",
+        "@noble/hashes": "^2.2.0",
         "@xterm/addon-fit": "^0.10.0",
         "@xterm/xterm": "^5.5.0"
       },
@@ -19,7 +22,8 @@
         "tslib": "^2.8.1",
         "typescript": "^5.7.3",
         "vite": "^6.0.11",
-        "vite-plugin-singlefile": "^2.1.0"
+        "vite-plugin-singlefile": "^2.1.0",
+        "vitest": "^4.1.5"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -514,6 +518,45 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@noble/ciphers": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-2.2.0.tgz",
+      "integrity": "sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
+      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.2.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.60.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
@@ -864,6 +907,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@sveltejs/acorn-typescript": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.9.tgz",
@@ -921,6 +971,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -934,6 +1002,119 @@
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.5",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.5",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
     },
     "node_modules/@xterm/addon-fit": {
       "version": "0.10.0",
@@ -973,6 +1154,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/axobject-query": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
@@ -994,6 +1185,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chokidar": {
@@ -1021,6 +1222,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -1054,6 +1262,13 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.7.1.tgz",
       "integrity": "sha512-MUbZ586EgQqdRnC4yDrlod3BEdyvE4TapGYHMW2CiaW+KkkFmWEFqBUaLltEZCGi0iFXCEjRF0OjF0DV2QHjOA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
       "dev": true,
       "license": "MIT"
     },
@@ -1122,6 +1337,26 @@
         "@typescript-eslint/types": {
           "optional": true
         }
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fdir": {
@@ -1280,6 +1515,24 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -1401,6 +1654,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1410,6 +1670,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/svelte": {
       "version": "5.55.4",
@@ -1463,6 +1737,23 @@
         "typescript": ">=5.0.0"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -1478,6 +1769,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -1629,6 +1930,113 @@
         "vite": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/zimmerframe": {

--- a/crates/bastion/web/package.json
+++ b/crates/bastion/web/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "check": "svelte-check --tsconfig ./tsconfig.json",
+    "test": "vitest run",
     "preview": "vite preview"
   },
   "devDependencies": {
@@ -17,9 +18,13 @@
     "tslib": "^2.8.1",
     "typescript": "^5.7.3",
     "vite": "^6.0.11",
-    "vite-plugin-singlefile": "^2.1.0"
+    "vite-plugin-singlefile": "^2.1.0",
+    "vitest": "^4.1.5"
   },
   "dependencies": {
+    "@noble/ciphers": "^2.2.0",
+    "@noble/curves": "^2.2.0",
+    "@noble/hashes": "^2.2.0",
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/xterm": "^5.5.0"
   }

--- a/crates/bastion/web/src/noise.test.ts
+++ b/crates/bastion/web/src/noise.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import {
+  IkInitiator,
+  IkResponder,
+  Transport,
+  keypairFromSeed,
+  randomKeypair,
+  equal,
+} from "./noise";
+
+describe("Noise_IK TS round-trip", () => {
+  it("initiator ↔ responder hand a payload both ways", () => {
+    const server = randomKeypair();
+    const client = randomKeypair();
+
+    const responder = new IkResponder(server);
+    const initiator = new IkInitiator(client, server.publicKey);
+
+    const msg1 = initiator.writeMessage(new TextEncoder().encode("hello"));
+    const seenByServer = responder.readMessage(msg1);
+    expect(new TextDecoder().decode(seenByServer)).toBe("hello");
+
+    const msg2Out = responder.writeMessage(new TextEncoder().encode("hi"));
+    expect(equal(msg2Out.peerPubkey, client.publicKey)).toBe(true);
+
+    const msg2In = initiator.readMessage(msg2Out.bytes);
+    expect(new TextDecoder().decode(msg2In.payload)).toBe("hi");
+
+    // Transport mode: bidirectional.
+    const clientTx = new Transport(msg2In.send, msg2In.recv, server.publicKey);
+    const serverTx = new Transport(msg2Out.send, msg2Out.recv, client.publicKey);
+
+    const c1 = clientTx.send(new TextEncoder().encode("ping one"));
+    expect(new TextDecoder().decode(serverTx.recv(c1))).toBe("ping one");
+    const c2 = clientTx.send(new TextEncoder().encode("ping two"));
+    expect(new TextDecoder().decode(serverTx.recv(c2))).toBe("ping two");
+
+    const s1 = serverTx.send(new TextEncoder().encode("pong"));
+    expect(new TextDecoder().decode(clientTx.recv(s1))).toBe("pong");
+  });
+
+  it("a wrong server pubkey fails at decrypt of the static", () => {
+    const server = randomKeypair();
+    const other = randomKeypair();
+    const client = randomKeypair();
+
+    const responder = new IkResponder(server);
+    // Initiator points at a different server's static → `es` DH
+    // yields the wrong key, so `decryptAndHash(s_ct)` AEAD fails.
+    const initiator = new IkInitiator(client, other.publicKey);
+    const msg1 = initiator.writeMessage(new Uint8Array(0));
+    expect(() => responder.readMessage(msg1)).toThrow();
+  });
+
+  it("tampered transport ciphertext is rejected", () => {
+    const server = randomKeypair();
+    const client = randomKeypair();
+    const responder = new IkResponder(server);
+    const initiator = new IkInitiator(client, server.publicKey);
+    const msg1 = initiator.writeMessage(new Uint8Array(0));
+    responder.readMessage(msg1);
+    const msg2Out = responder.writeMessage(new Uint8Array(0));
+    const msg2In = initiator.readMessage(msg2Out.bytes);
+
+    const clientTx = new Transport(msg2In.send, msg2In.recv, server.publicKey);
+    const serverTx = new Transport(msg2Out.send, msg2Out.recv, client.publicKey);
+
+    const frame = clientTx.send(new TextEncoder().encode("payload"));
+    frame[0] ^= 0x01;
+    expect(() => serverTx.recv(frame)).toThrow();
+  });
+
+  it("keypairFromSeed is deterministic", () => {
+    const seed = new Uint8Array(32).fill(7);
+    const a = keypairFromSeed(seed);
+    const b = keypairFromSeed(seed);
+    expect(equal(a.publicKey, b.publicKey)).toBe(true);
+    expect(equal(a.secretKey, b.secretKey)).toBe(true);
+    expect(a.publicKey.length).toBe(32);
+  });
+
+  it("different seeds produce different keys", () => {
+    const a = keypairFromSeed(new Uint8Array(32).fill(1));
+    const b = keypairFromSeed(new Uint8Array(32).fill(2));
+    expect(equal(a.publicKey, b.publicKey)).toBe(false);
+  });
+});

--- a/crates/bastion/web/src/noise.ts
+++ b/crates/bastion/web/src/noise.ts
@@ -1,0 +1,416 @@
+/**
+ * Noise_IK_25519_ChaChaPoly_SHA256 — initiator state machine.
+ *
+ * Browser-side counterpart to the Rust responder in
+ * `crates/dd-common/src/noise_tunnel.rs`. Small hand-rolled
+ * implementation of §5 of the Noise Protocol spec, pattern IK only.
+ *
+ * Why hand-rolled: the two popular npm packages (`noise-protocol`,
+ * `noise-handshake`) both pull `sodium-universal` + `libsodium.js`
+ * into the bundle. Building on `@noble/*` primitives keeps the SPA
+ * payload ~40 KB instead of ~250 KB and avoids a wasm runtime.
+ *
+ * Spec references are to
+ * https://noiseprotocol.org/noise.html rev-34.
+ */
+
+import { x25519 } from "@noble/curves/ed25519.js";
+import { chacha20poly1305 } from "@noble/ciphers/chacha.js";
+import { sha256 } from "@noble/hashes/sha2.js";
+import { hmac } from "@noble/hashes/hmac.js";
+
+const PROTOCOL_NAME = "Noise_IK_25519_ChaChaPoly_SHA256";
+const HASHLEN = 32;
+const DHLEN = 32;
+
+/// Concatenate two byte arrays into a new one. Explicitly-typed
+/// return so TS 5.7's stricter `Uint8Array<ArrayBuffer>` inference
+/// doesn't downgrade callers to `Uint8Array<ArrayBufferLike>`.
+function concat(a: Uint8Array, b: Uint8Array): Uint8Array<ArrayBuffer> {
+  const out = new Uint8Array(a.length + b.length);
+  out.set(a, 0);
+  out.set(b, a.length);
+  return out;
+}
+
+function equal(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) diff |= a[i] ^ b[i];
+  return diff === 0;
+}
+
+/// 12-byte ChaCha20-Poly1305 nonce per §5.2: 4 zero bytes followed by
+/// the 64-bit counter in little-endian order.
+function nonce12(n: bigint): Uint8Array {
+  const out = new Uint8Array(12);
+  const view = new DataView(out.buffer);
+  // First 4 bytes stay zero.
+  view.setBigUint64(4, n, true);
+  return out;
+}
+
+/// HKDF-with-HMAC-SHA256 as the Noise spec defines it — returns 1, 2,
+/// or 3 32-byte outputs depending on `num_outputs`.
+function hkdf(
+  chainingKey: Uint8Array,
+  inputKeyMaterial: Uint8Array,
+  numOutputs: 1 | 2 | 3,
+): Uint8Array[] {
+  const tempKey = hmac(sha256, chainingKey, inputKeyMaterial);
+  const out1 = hmac(sha256, tempKey, new Uint8Array([0x01]));
+  if (numOutputs === 1) return [out1];
+  const out2 = hmac(sha256, tempKey, concat(out1, new Uint8Array([0x02])));
+  if (numOutputs === 2) return [out1, out2];
+  const out3 = hmac(sha256, tempKey, concat(out2, new Uint8Array([0x03])));
+  return [out1, out2, out3];
+}
+
+/**
+ * CipherState — §5.1. Wraps a 32-byte key and a 64-bit counter.
+ * Nonce overflow (after 2^64-1 messages) is fatal per spec. The
+ * `hasKey` gating mirrors the spec's `k == empty` sentinel.
+ */
+class CipherState {
+  k: Uint8Array | null = null;
+  n: bigint = 0n;
+
+  initializeKey(k: Uint8Array | null): void {
+    this.k = k;
+    this.n = 0n;
+  }
+
+  hasKey(): boolean {
+    return this.k !== null;
+  }
+
+  encryptWithAd(ad: Uint8Array, plaintext: Uint8Array): Uint8Array {
+    if (!this.k) return plaintext;
+    // @noble/ciphers factory takes AAD as the 3rd arg (not `encrypt`).
+    const cipher = chacha20poly1305(this.k, nonce12(this.n), ad);
+    const ct = cipher.encrypt(plaintext);
+    this.n += 1n;
+    return ct;
+  }
+
+  decryptWithAd(ad: Uint8Array, ciphertext: Uint8Array): Uint8Array {
+    if (!this.k) return ciphertext;
+    const cipher = chacha20poly1305(this.k, nonce12(this.n), ad);
+    const pt = cipher.decrypt(ciphertext);
+    this.n += 1n;
+    return pt;
+  }
+}
+
+/**
+ * SymmetricState — §5.2. Owns the chaining key, transcript hash,
+ * and the currently-active CipherState. Drives the MixHash / MixKey
+ * flow that IK's message tokens translate into.
+ */
+class SymmetricState {
+  ck: Uint8Array;
+  h: Uint8Array;
+  cs: CipherState;
+
+  constructor() {
+    const name = new TextEncoder().encode(PROTOCOL_NAME);
+    // Protocol name fits in HASHLEN? §5.2: "If protocol_name is less
+    // than or equal to HASHLEN bytes in length, sets h equal to
+    // protocol_name with zero bytes appended to make HASHLEN bytes.
+    // Otherwise sets h = HASH(protocol_name)." Ours is 32 bytes on the
+    // nose, so zero-pad (no-op) and done.
+    if (name.length <= HASHLEN) {
+      this.h = new Uint8Array(HASHLEN);
+      this.h.set(name, 0);
+    } else {
+      this.h = sha256(name);
+    }
+    this.ck = new Uint8Array(this.h);
+    this.cs = new CipherState();
+  }
+
+  mixHash(data: Uint8Array): void {
+    this.h = sha256(concat(this.h, data));
+  }
+
+  mixKey(ikm: Uint8Array): void {
+    const [newCk, tempK] = hkdf(this.ck, ikm, 2);
+    this.ck = newCk;
+    this.cs.initializeKey(tempK);
+  }
+
+  encryptAndHash(plaintext: Uint8Array): Uint8Array {
+    const ct = this.cs.encryptWithAd(this.h, plaintext);
+    this.mixHash(ct);
+    return ct;
+  }
+
+  decryptAndHash(ciphertext: Uint8Array): Uint8Array {
+    const pt = this.cs.decryptWithAd(this.h, ciphertext);
+    this.mixHash(ciphertext);
+    return pt;
+  }
+
+  /// Finalize into two CipherStates per §5.2's Split(): one for each
+  /// direction. For the initiator, `c1` encrypts outbound, `c2`
+  /// decrypts inbound.
+  split(): [CipherState, CipherState] {
+    const [k1, k2] = hkdf(this.ck, new Uint8Array(0), 2);
+    const c1 = new CipherState();
+    const c2 = new CipherState();
+    c1.initializeKey(k1);
+    c2.initializeKey(k2);
+    return [c1, c2];
+  }
+}
+
+export interface Keypair {
+  secretKey: Uint8Array;
+  publicKey: Uint8Array;
+}
+
+/// Derive the client's X25519 keypair from a stable 32-byte seed.
+/// Same seed → same keypair, so the SPA's identity (stored in
+/// localStorage as `dd-identity-seed`) survives reloads.
+export function keypairFromSeed(seed: Uint8Array): Keypair {
+  if (seed.length !== 32) {
+    throw new Error(`expected 32-byte seed, got ${seed.length}`);
+  }
+  // x25519 clamps the scalar internally, so any 32 random bytes
+  // produce a valid keypair. HMAC-SHA256 the seed with a domain tag
+  // so the Noise key is distinct from anything else the seed is used
+  // to derive (device fingerprint, at-rest ciphertext key, etc.).
+  const secretKey = hmac(sha256, seed, new TextEncoder().encode("dd-noise-static-v1"));
+  const publicKey = x25519.getPublicKey(secretKey);
+  return { secretKey, publicKey };
+}
+
+/// Generate a fresh throwaway keypair — used as the handshake
+/// ephemeral `e`.
+export function randomKeypair(): Keypair {
+  const { secretKey, publicKey } = x25519.keygen();
+  return { secretKey, publicKey };
+}
+
+/**
+ * Initiator-side IK handshake driver. Pattern messages per §7.5:
+ *
+ * ```
+ * IK:
+ *   <- s
+ *   ...
+ *   -> e, es, s, ss
+ *   <- e, ee, se
+ * ```
+ *
+ * `<- s` is a pre-message: the initiator knows the responder's
+ * static pubkey up front (fetched via `GET /attest`).
+ */
+export class IkInitiator {
+  private sym: SymmetricState;
+  private s: Keypair;
+  private e: Keypair | null = null;
+  private rs: Uint8Array;
+
+  constructor(s: Keypair, rs: Uint8Array, prologue: Uint8Array = new Uint8Array(0)) {
+    if (rs.length !== DHLEN) throw new Error(`rs: expected ${DHLEN} bytes`);
+    this.sym = new SymmetricState();
+    this.sym.mixHash(prologue);
+    // `<- s` pre-message: hash the responder's static into the
+    // transcript.
+    this.sym.mixHash(rs);
+    this.s = s;
+    this.rs = rs;
+  }
+
+  /// Produce the first handshake message `-> e, es, s, ss`.
+  /// `payload` is application data carried inside the encrypted
+  /// handshake — typically empty in our deployment.
+  writeMessage(payload: Uint8Array): Uint8Array {
+    this.e = randomKeypair();
+    // -> e
+    let buf = new Uint8Array(this.e.publicKey);
+    this.sym.mixHash(this.e.publicKey);
+    // -> es
+    this.sym.mixKey(x25519.getSharedSecret(this.e.secretKey, this.rs));
+    // -> s (encrypted)
+    const sCt = this.sym.encryptAndHash(this.s.publicKey);
+    buf = concat(buf, sCt);
+    // -> ss
+    this.sym.mixKey(x25519.getSharedSecret(this.s.secretKey, this.rs));
+    // -> payload (encrypted)
+    const payloadCt = this.sym.encryptAndHash(payload);
+    return concat(buf, payloadCt);
+  }
+
+  /// Consume the responder's reply `<- e, ee, se` and finalize the
+  /// handshake. Returns the decrypted payload and the two transport
+  /// CipherStates ([send, recv] from the initiator's perspective).
+  readMessage(message: Uint8Array): {
+    payload: Uint8Array;
+    send: CipherState;
+    recv: CipherState;
+  } {
+    if (!this.e) throw new Error("readMessage before writeMessage");
+    if (message.length < DHLEN) throw new Error("msg2 too short");
+    // <- e
+    const re = message.slice(0, DHLEN);
+    this.sym.mixHash(re);
+    // <- ee
+    this.sym.mixKey(x25519.getSharedSecret(this.e.secretKey, re));
+    // <- se (initiator uses its static, responder their ephemeral)
+    this.sym.mixKey(x25519.getSharedSecret(this.s.secretKey, re));
+    // <- payload
+    const rest = message.slice(DHLEN);
+    const payload = this.sym.decryptAndHash(rest);
+    const [send, recv] = this.sym.split();
+    return { payload, send, recv };
+  }
+}
+
+/**
+ * Post-handshake transport. Wraps a pair of CipherStates and
+ * exposes a symmetric `send` / `recv` API. Matches the Rust
+ * `Transport` in `noise_tunnel.rs`.
+ */
+export class Transport {
+  constructor(
+    private send_: CipherState,
+    private recv_: CipherState,
+    readonly peerPubkey: Uint8Array,
+  ) {}
+
+  send(plaintext: Uint8Array): Uint8Array {
+    return this.send_.encryptWithAd(new Uint8Array(0), plaintext);
+  }
+
+  recv(ciphertext: Uint8Array): Uint8Array {
+    return this.recv_.decryptWithAd(new Uint8Array(0), ciphertext);
+  }
+}
+
+/**
+ * Open a Noise-tunneled WebSocket to `wssUrl`. Pins the server's
+ * long-term static key via the caller-supplied `serverPubkey` (hex
+ * decoded). Once the handshake completes, callers use `tunnel.fetch`
+ * and `tunnel.ws` as if they were same-origin HTTP/WS.
+ *
+ * Rejects with a concrete error so the sidebar can fall back to
+ * plain fetch when the origin doesn't support Noise (e.g. an older
+ * agent deployed before Phase 2b).
+ */
+export async function connectNoise(
+  wssUrl: string,
+  clientStatic: Keypair,
+  serverPubkey: Uint8Array,
+): Promise<{ socket: WebSocket; transport: Transport }> {
+  const socket = new WebSocket(wssUrl);
+  socket.binaryType = "arraybuffer";
+  await new Promise<void>((resolve, reject) => {
+    socket.addEventListener("open", () => resolve(), { once: true });
+    socket.addEventListener("error", () => reject(new Error(`ws open: ${wssUrl}`)), {
+      once: true,
+    });
+  });
+
+  const initiator = new IkInitiator(clientStatic, serverPubkey);
+  const msg1 = initiator.writeMessage(new Uint8Array(0));
+  socket.send(msg1);
+
+  const msg2 = await new Promise<Uint8Array>((resolve, reject) => {
+    socket.addEventListener(
+      "message",
+      (ev) => {
+        if (ev.data instanceof ArrayBuffer) resolve(new Uint8Array(ev.data));
+        else reject(new Error("msg2 was not binary"));
+      },
+      { once: true },
+    );
+    socket.addEventListener("error", () => reject(new Error("ws error during handshake")), {
+      once: true,
+    });
+    socket.addEventListener(
+      "close",
+      (ev) => reject(new Error(`ws closed during handshake: ${ev.code} ${ev.reason}`)),
+      { once: true },
+    );
+  });
+
+  const { send, recv } = initiator.readMessage(msg2);
+  const transport = new Transport(send, recv, serverPubkey);
+  return { socket, transport };
+}
+
+// --------------------------------------------------------------
+// Test-only exports. The build's treeshaker strips these from the
+// production bundle when nothing imports them; the unit test in
+// `noise.test.ts` is the only consumer.
+// --------------------------------------------------------------
+
+/// Responder-side IK driver — only used by the in-browser round-trip
+/// test so CI can gate on TS-TS consistency without spawning the
+/// Rust server. The real server lives in Rust / `snow`.
+export class IkResponder {
+  private sym: SymmetricState;
+  private s: Keypair;
+  private e: Keypair | null = null;
+  /// Initiator's ephemeral pubkey — learned from msg1, consumed by
+  /// msg2's `ee` + `se` DHs.
+  private re: Uint8Array | null = null;
+  /// Initiator's static pubkey — decrypted from msg1. Exposed after
+  /// the handshake so the caller can pin / authorize the peer.
+  private rs: Uint8Array | null = null;
+
+  constructor(s: Keypair, prologue: Uint8Array = new Uint8Array(0)) {
+    this.sym = new SymmetricState();
+    this.sym.mixHash(prologue);
+    // `<- s` pre-message from the responder's view: the responder's
+    // own static is pre-known.
+    this.sym.mixHash(s.publicKey);
+    this.s = s;
+  }
+
+  readMessage(message: Uint8Array): Uint8Array {
+    if (message.length < DHLEN) throw new Error("msg1 too short");
+    // <- e
+    this.re = message.slice(0, DHLEN);
+    this.sym.mixHash(this.re);
+    // <- es
+    this.sym.mixKey(x25519.getSharedSecret(this.s.secretKey, this.re));
+    // s_ct is DHLEN + 16 bytes (enc pubkey + tag)
+    const sCt = message.slice(DHLEN, DHLEN + DHLEN + 16);
+    this.rs = this.sym.decryptAndHash(sCt);
+    // <- ss
+    this.sym.mixKey(x25519.getSharedSecret(this.s.secretKey, this.rs));
+    const payloadCt = message.slice(DHLEN + DHLEN + 16);
+    const payload = this.sym.decryptAndHash(payloadCt);
+    // Mint our ephemeral for the reply.
+    this.e = randomKeypair();
+    return payload;
+  }
+
+  writeMessage(payload: Uint8Array): {
+    bytes: Uint8Array;
+    send: CipherState;
+    recv: CipherState;
+    peerPubkey: Uint8Array;
+  } {
+    if (!this.e || !this.re || !this.rs) {
+      throw new Error("writeMessage before readMessage");
+    }
+    let buf = new Uint8Array(this.e.publicKey);
+    this.sym.mixHash(this.e.publicKey);
+    // -> ee: responder ephemeral × initiator ephemeral
+    this.sym.mixKey(x25519.getSharedSecret(this.e.secretKey, this.re));
+    // -> se: responder ephemeral × initiator static
+    this.sym.mixKey(x25519.getSharedSecret(this.e.secretKey, this.rs));
+    const payloadCt = this.sym.encryptAndHash(payload);
+    buf = concat(buf, payloadCt);
+    // Split with direction swap — responder's "send" is initiator's
+    // "recv" and vice versa.
+    const [c1, c2] = this.sym.split();
+    return { bytes: buf, send: c2, recv: c1, peerPubkey: this.rs };
+  }
+}
+
+export { CipherState, SymmetricState, equal, concat };

--- a/crates/bastion/web/src/tunnel.ts
+++ b/crates/bastion/web/src/tunnel.ts
@@ -1,0 +1,146 @@
+/**
+ * Typed RPC over a Noise_IK-tunneled WebSocket.
+ *
+ * Wraps the raw `Transport` from `noise.ts` with a request/response
+ * correlator (`id` → Promise) so callers write `tunnel.sessions.list()`
+ * instead of hand-rolling the JSON envelope + encrypt + await.
+ *
+ * Matches the server-side `NoiseReq` / `NoiseResp` enums in
+ * `crates/bastion/src/lib.rs`. Phase 2b scope:
+ * `sessions.list` / `sessions.create` / `sessions.delete` / `ping`.
+ */
+
+import { connectNoise, keypairFromSeed, Transport } from "./noise";
+import { loadIdentitySeed } from "./identity";
+import type { SessionInfo } from "./types";
+
+type Resolve = (body: any) => void;
+type Reject = (err: unknown) => void;
+
+interface Pending {
+  resolve: Resolve;
+  reject: Reject;
+}
+
+/// Live Noise tunnel. Own the socket, the transport, and a
+/// `request_id → Promise<resolver>` map. Requests are fire-and-await
+/// serialized JSON; responses come back keyed by id.
+export class Tunnel {
+  private nextId = 1n;
+  private pending = new Map<bigint, Pending>();
+  private closed = false;
+
+  constructor(
+    private socket: WebSocket,
+    private transport: Transport,
+  ) {
+    socket.addEventListener("message", (ev) => this.onFrame(ev));
+    socket.addEventListener("close", () => this.onClose(new Error("tunnel closed")));
+    socket.addEventListener("error", () => this.onClose(new Error("tunnel error")));
+  }
+
+  private onFrame(ev: MessageEvent): void {
+    if (!(ev.data instanceof ArrayBuffer)) return;
+    let body: any;
+    try {
+      const plain = this.transport.recv(new Uint8Array(ev.data));
+      body = JSON.parse(new TextDecoder().decode(plain));
+    } catch (e) {
+      console.warn("tunnel: bad frame", e);
+      return;
+    }
+    const id = BigInt(body.id ?? 0);
+    const p = this.pending.get(id);
+    if (!p) return;
+    this.pending.delete(id);
+    p.resolve(body);
+  }
+
+  private onClose(err: unknown): void {
+    if (this.closed) return;
+    this.closed = true;
+    for (const p of this.pending.values()) p.reject(err);
+    this.pending.clear();
+  }
+
+  private call<T>(op: string, extra: Record<string, unknown> = {}): Promise<T> {
+    if (this.closed) return Promise.reject(new Error("tunnel closed"));
+    const id = this.nextId++;
+    const frame = { id: Number(id), op, ...extra };
+    const plain = new TextEncoder().encode(JSON.stringify(frame));
+    const cipher = this.transport.send(plain);
+    return new Promise<T>((resolve, reject) => {
+      this.pending.set(id, {
+        resolve: (body) => {
+          if (body.kind === "err") reject(new Error(body.msg));
+          else resolve(body as T);
+        },
+        reject,
+      });
+      this.socket.send(cipher);
+    });
+  }
+
+  sessionsList(): Promise<SessionInfo[]> {
+    return this.call<{ kind: "sessions"; sessions: SessionInfo[] }>("sessions_list").then(
+      // Server uses `kind` as discriminator and flattens the vec as
+      // `{kind:"sessions",sessions:[...]}` because serde's flatten +
+      // tuple variant would need a named field.
+      // Match on shape: the Rust side's `NoiseRespBody::Sessions(Vec)`
+      // serializes as `{"kind":"sessions"}` + the inner vec spread;
+      // we read it as `.sessions` if present, else as the value.
+      (body: any) => (Array.isArray(body?.sessions) ? body.sessions : []),
+    );
+  }
+
+  sessionsCreate(title?: string): Promise<SessionInfo> {
+    return this.call<any>("sessions_create", { title: title ?? null }).then((body: any) => {
+      if (body.kind !== "session") throw new Error(`unexpected resp kind: ${body.kind}`);
+      return body.session ?? body;
+    });
+  }
+
+  sessionsDelete(sessionId: string): Promise<void> {
+    return this.call<any>("sessions_delete", { session_id: sessionId }).then(() => undefined);
+  }
+
+  ping(): Promise<number> {
+    return this.call<any>("ping").then((body: any) => body.server_time_ms as number);
+  }
+
+  close(): void {
+    this.closed = true;
+    try {
+      this.socket.close();
+    } catch {
+      // already closed
+    }
+  }
+}
+
+/// Open a tunnel to `origin`, using the device's identity seed for
+/// the client's long-term static and the server pubkey from the
+/// connector config. Rejects if the server doesn't support Noise,
+/// if the handshake fails, or if the WS can't be established.
+export async function openTunnel(
+  origin: string,
+  serverPubkeyHex: string,
+): Promise<Tunnel> {
+  const trimmed = origin.replace(/\/+$/, "");
+  const wssUrl = trimmed.replace(/^http(s)?:/, (m) => (m === "http:" ? "ws:" : "wss:")) +
+    "/noise/ws";
+  const seed = loadIdentitySeed();
+  const client = keypairFromSeed(seed);
+  const serverPub = decodeHex(serverPubkeyHex);
+  const { socket, transport } = await connectNoise(wssUrl, client, serverPub);
+  return new Tunnel(socket, transport);
+}
+
+function decodeHex(hex: string): Uint8Array {
+  if (hex.length !== 64) throw new Error(`pubkey: expected 64 hex chars, got ${hex.length}`);
+  const out = new Uint8Array(32);
+  for (let i = 0; i < 32; i++) {
+    out[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  }
+  return out;
+}

--- a/crates/bastion/web/src/ui.svelte.ts
+++ b/crates/bastion/web/src/ui.svelte.ts
@@ -8,6 +8,7 @@ import {
   patchConnectorConfig,
 } from "./connectors";
 import { loadIdentitySeed, fingerprint } from "./identity";
+import { openTunnel, Tunnel } from "./tunnel";
 
 /// Composite key so session ids from different connectors can't collide.
 export type RowId = string; // `${connector.label}/${session_id}`
@@ -127,51 +128,82 @@ async function reloadSessions(): Promise<void> {
   ui.rows = next;
 }
 
-/// Fetch an enclave's live sessions. Cross-origin failures
-/// (CF-Access bounce, CORS reject, offline) degrade to "no rows" for
-/// that enclave rather than propagating — the sidebar still shows
-/// every connector the user configured, just empty for unreachable
-/// ones. Phase 2 replaces this with a Noise_KK channel that isn't
-/// subject to the same browser same-origin rules.
+/// Lazy per-connector Noise tunnel cache. Opened on first use by
+/// [`getTunnel`]; kept open for subsequent RPCs. Recreated
+/// transparently if the underlying socket dies.
+const tunnels = new Map<string, Promise<Tunnel>>();
+
+/// Open (or re-use) a Noise tunnel for `c`. Returns `null` if the
+/// server hasn't advertised a pubkey yet (Phase 2a hasn't run on
+/// this origin) or the handshake fails for any reason — callers
+/// should fall back to plain `fetch` in that case.
+async function getTunnel(c: Connector): Promise<Tunnel | null> {
+  const origin = (c.config.origin as string | undefined) ?? "";
+  const pubkey = c.config.serverNoisePubkeyHex as string | undefined;
+  if (!origin || !pubkey) return null;
+  const existing = tunnels.get(c.id);
+  if (existing) {
+    return existing.catch(() => {
+      tunnels.delete(c.id);
+      return null;
+    });
+  }
+  const p = openTunnel(origin, pubkey).catch((e) => {
+    console.warn(`tunnel: open ${origin} failed`, e);
+    tunnels.delete(c.id);
+    throw e;
+  });
+  tunnels.set(c.id, p);
+  try {
+    return await p;
+  } catch {
+    return null;
+  }
+}
+
+/// Fetch an enclave's live sessions. Prefers the Noise tunnel (no
+/// CORS preflight, no CF Access bounce); falls back to plain fetch
+/// for same-origin connectors or origins that predate Phase 2a.
+/// Either failure path degrades to "no rows" so the sidebar still
+/// shows every connector the user configured.
 async function fetchDdEnclave(c: Connector): Promise<Row[]> {
   const origin = (c.config.origin as string | undefined) ?? "";
   if (!origin) return [];
-  try {
-    const resp = await fetch(`${origin}/api/sessions`, {
-      credentials: "include",
-    });
-    if (!resp.ok) return [];
-    const sessions: SessionInfo[] = await resp.json();
-    return sessions.map((info) => ({
-      connector: c,
-      origin,
-      info,
-      blocks: [],
-      ws: null,
-      term: null,
-      fit: null,
-    }));
-  } catch {
-    return [];
-  }
+  const tunnel = await getTunnel(c);
+  const sessions = await (tunnel
+    ? tunnel.sessionsList().catch((): SessionInfo[] => [])
+    : fetch(`${origin}/api/sessions`, { credentials: "include" })
+        .then((r) => (r.ok ? r.json() : []))
+        .catch((): SessionInfo[] => []));
+  return sessions.map((info: SessionInfo) => ({
+    connector: c,
+    origin,
+    info,
+    blocks: [],
+    ws: null,
+    term: null,
+    fit: null,
+  }));
 }
 
 export async function createShell(c: Connector): Promise<void> {
   if (c.kind !== "dd-enclave") return;
   const origin = (c.config.origin as string | undefined) ?? "";
   if (!origin) return;
+  const tunnel = await getTunnel(c);
   try {
-    const resp = await fetch(`${origin}/api/sessions`, {
-      method: "POST",
-      credentials: "include",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ title: "shell" }),
-    });
-    if (!resp.ok) {
-      console.warn(`createShell: ${origin} → ${resp.status}`);
-      return;
-    }
-    const info: SessionInfo = await resp.json();
+    const info: SessionInfo = tunnel
+      ? await tunnel.sessionsCreate("shell")
+      : await (async () => {
+          const resp = await fetch(`${origin}/api/sessions`, {
+            method: "POST",
+            credentials: "include",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ title: "shell" }),
+          });
+          if (!resp.ok) throw new Error(`${origin} → ${resp.status}`);
+          return resp.json();
+        })();
     const id = rowKey(c, info.id);
     const rows = new Map(ui.rows);
     rows.set(id, {
@@ -186,11 +218,11 @@ export async function createShell(c: Connector): Promise<void> {
     ui.rows = rows;
     ui.active = id;
   } catch (e) {
-    // Cross-origin + CF Access fails here with a TypeError before
-    // fetch even reaches the origin. Swallow it — the sidebar falls
-    // back to "no new shell, try again" rather than throwing a red
-    // Uncaught (in promise) from a click handler.
-    console.warn(`createShell: ${origin} cross-origin blocked`, e);
+    // Cross-origin + CF Access fails plain fetch with a TypeError
+    // before it reaches the origin; the tunnel path would have
+    // rejected instead. Either way we swallow so the click handler
+    // doesn't throw red in the console.
+    console.warn(`createShell: ${origin}`, e);
   }
 }
 
@@ -214,11 +246,16 @@ export async function killShell(row: Row): Promise<void> {
     destroyRow(rowKey(row.connector, row.info.id));
     return;
   }
+  const tunnel = await getTunnel(row.connector);
   try {
-    await fetch(`${row.origin}/api/sessions/${row.info.id}`, {
-      method: "DELETE",
-      credentials: "include",
-    });
+    if (tunnel) {
+      await tunnel.sessionsDelete(row.info.id);
+    } else {
+      await fetch(`${row.origin}/api/sessions/${row.info.id}`, {
+        method: "DELETE",
+        credentials: "include",
+      });
+    }
   } catch {
     // Not fatal — the session might be gone already; the UI cleanup
     // below runs either way.

--- a/crates/dd-common/src/noise_tunnel.rs
+++ b/crates/dd-common/src/noise_tunnel.rs
@@ -106,9 +106,9 @@ impl Responder {
     /// Caller is responsible for having done one read + one write
     /// in order before calling; `snow` panics otherwise.
     pub fn into_transport(self) -> Result<Transport, snow::Error> {
-        let peer = self
-            .peer_pubkey()
-            .ok_or(snow::Error::State(snow::error::StateProblem::MissingKeyMaterial))?;
+        let peer = self.peer_pubkey().ok_or(snow::Error::State(
+            snow::error::StateProblem::MissingKeyMaterial,
+        ))?;
         let state = self.state.into_transport_mode()?;
         Ok(Transport {
             state,


### PR DESCRIPTION
Stacked on #176.

## Summary

Closes the cross-origin CORS wall by wiring a Noise_IK-encrypted WebSocket between the browser and each dd-enclave bastion.

## What ships

- **`noise.ts`** — hand-rolled Noise_IK state machine (initiator + responder) on `@noble/curves` / `@noble/ciphers` / `@noble/hashes`. ~280 LoC, spec-adherent, no wasm dep. Adds ~44 KB gzipped to the SPA.
- **`tunnel.ts`** — typed RPC wrapper (`sessions.list/create/delete/ping`), `id`-correlated request/response, matches the server's `NoiseReq`/`NoiseResp` wire format from #176.
- **`ui.svelte.ts`** — per-connector lazy tunnel cache. `fetchDdEnclave`, `createShell`, `killShell` prefer `tunnel.*` when `serverNoisePubkeyHex` is pinned; plain fetch stays as fallback for same-origin + pre-2a origins.
- **Server-side `NoiseRespBody`** → named-field variants so serde's internal tagging is unambiguous.
- **`npm test`** added to both SPA build workflows — vitest gates CI.

## Test plan

- [x] `npx vitest run` — 5 tests pass (round-trip, tamper rejection, wrong-pubkey rejection, seed determinism × 2)
- [x] `npm run build` — SPA 392 KB gzipped from 348 KB
- [x] `cargo test --workspace` — 39 tests pass
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [ ] Preview deploy: load `https://pr-177-block.devopsdefender.com`, click a cross-origin enclave in the sidebar, confirm sessions list without CORS console errors
- [ ] DevTools: `ws://.../noise/ws` handshake succeeds, subsequent frames are binary
- [ ] Server logs: `bastion/noise: tunnel up (peer=…)` with truncated client pubkey

## Known gap

Byte-level `snow` ↔ hand-rolled TS interop is verified on preview deploy only. Setting up a Rust ↔ Node IPC harness to gate it in CI costs more than the 1-2 iteration cycles of preview debugging.

## Follow-ups

- Shell WS (`/ws/{id}`) over Noise — Phase 2c. Current PR covers the JSON API only.
- TDX quote binding (`REPORT_DATA = sha256(noise_pubkey)`) — Phase 2d.
- Per-endpoint CP↔agent ITA cutover — independent of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)