### PR TITLE
feat(cf): path-scoped Access bypass for bastion /noise + /attest

### DIFF
--- a/crates/dd/src/cf.rs
+++ b/crates/dd/src/cf.rs
@@ -547,6 +547,22 @@ pub async fn provision_cp_access(
                 vec![human_policy(owner, admin_email, &idp)],
             )
             .await?;
+            // Bastion's Noise-tunneled endpoints authenticate via the
+            // Noise_IK handshake — CF Access would otherwise 302 the
+            // WS upgrade (no session cookie on a cross-origin WS from
+            // a different bastion), which kills the handshake. Path-
+            // scoped bypasses ride alongside the root human policy.
+            if label == "block" {
+                for (suffix, bypass_label) in [("/attest", "attest"), ("/noise", "noise")] {
+                    ensure_bypass_app(
+                        http,
+                        cf,
+                        &format!("dd-{env}-cp-{label}-{bypass_label}"),
+                        &format!("{domain}{suffix}"),
+                    )
+                    .await?;
+                }
+            }
         } else {
             ensure_bypass_app(http, cf, &format!("dd-{env}-cp-{label}"), &domain).await?;
         }
@@ -675,6 +691,22 @@ pub async fn provision_agent_access(
                 vec![human_policy(owner, admin_email, &idp)],
             )
             .await?;
+            // Path-scoped bypasses for the Noise tunnel (mirrors the
+            // CP-side wiring in `provision_cp_access`). Without these,
+            // a browser loading the aggregator on the CP's block can't
+            // open a cross-origin Noise WS to an agent's block —
+            // CF Access 302s the upgrade.
+            if label == "block" {
+                for (suffix, bypass_label) in [("/attest", "attest"), ("/noise", "noise")] {
+                    ensure_bypass_app(
+                        http,
+                        cf,
+                        &format!("dd-{env}-workload-{domain}-{bypass_label}"),
+                        &format!("{domain}{suffix}"),
+                    )
+                    .await?;
+                }
+            }
         } else {
             ensure_bypass_app(http, cf, &format!("dd-{env}-workload-{domain}"), &domain).await?;
         }


### PR DESCRIPTION
Stacked on #177.

## Summary

Unblocks #177's cross-origin flow. The Noise WS upgrade from the CP's bastion aggregator to an agent's bastion carries only the target origin's cookie, which a user who's never been there doesn't have — CF Access 302s the upgrade and the handshake dies. Path-scoped bypasses for `/attest` + `/noise*` let the Noise handshake itself be the gate.

## Changes

- `provision_cp_access`: for any admin-labeled workload named `block`, provision `dd-{env}-cp-block-attest` + `dd-{env}-cp-block-noise` bypass Access apps at `{domain}/attest` and `{domain}/noise`.
- `provision_agent_access`: same pattern on each agent's `block.{agent}.{domain}`.
- Root human policy on `block.{hostname}` stays — SPA loads still require CF Access login.

## Why it's safe

- `/attest` returns the long-term Noise pubkey, which is self-authenticating once Phase 2d binds it into the TDX quote's `REPORT_DATA`.
- `/noise*` is a Noise_IK-authenticated channel — the handshake + session keys are the gate, not CF Access's cookie.
- Existing workload reap uses a `ends_with(\".{tld}\")` check that trips on the path suffix, so these new apps aren't accidentally reaped at CP restart.

## Test plan

- [x] `cargo build`, `cargo test`, `cargo clippy -D warnings`, `cargo fmt --check`
- [ ] Preview deploy: `curl -I https://pr-178-block.devopsdefender.com/attest` → 200 with JSON (no CF Access 302)
- [ ] Preview deploy: load `https://pr-178.devopsdefender.com/bastion`, click an agent in sidebar, confirm sessions list via Noise tunnel in DevTools (binary WS frames after a 2-byte handshake)

🤖 Generated with [Claude Code](https://claude.com/claude-code)