### PR TITLE
feat(bastion): shell WS over Noise_IK (Phase 2c)

### DIFF
--- a/crates/bastion/src/lib.rs
+++ b/crates/bastion/src/lib.rs
@@ -787,6 +787,7 @@ pub fn router(manager: Manager) -> Router {
         .route("/api/sessions/{id}", delete(kill_session))
         .route("/ws/{id}", get(ws_upgrade))
         .route("/noise/ws", get(noise_ws_upgrade))
+        .route("/noise/shell/{id}", get(noise_shell_upgrade))
         .layer(cors)
         .with_state(manager)
 }
@@ -1073,6 +1074,297 @@ async fn ws_loop(mut socket: WebSocket, id: String, m: Manager) {
         _ = inbound => {},
         _ = outbound => {},
     }
+}
+
+// ---------------------------------------------------------------------
+// /noise/shell/{id} — Noise_IK-tunneled PTY streaming
+//
+// Mirrors `/ws/{id}` but every frame rides inside a Noise_IK
+// transport. Inside the encrypted tunnel we use a 1-byte type tag so
+// we don't pay base64 overhead on the high-volume stdout stream:
+//   0x01 <bytes>      — raw PTY data (stdin client→server or
+//                       stdout server→client)
+//   0x02 <json-bytes> — control frame (resize/hello/block/exit/...)
+// ---------------------------------------------------------------------
+
+const NOISE_FRAME_RAW: u8 = 0x01;
+const NOISE_FRAME_CTRL: u8 = 0x02;
+
+async fn noise_shell_upgrade(
+    ws: WebSocketUpgrade,
+    Path(id): Path<String>,
+    State(m): State<Manager>,
+) -> impl IntoResponse {
+    ws.on_upgrade(move |socket| noise_shell_loop(socket, id, m))
+}
+
+async fn noise_shell_loop(mut socket: WebSocket, id: String, m: Manager) {
+    use futures_util::StreamExt;
+
+    let Some(noise_key) = m.noise.clone() else {
+        let _ = socket
+            .send(Message::Text(
+                r#"{"error":"noise_not_configured"}"#.to_string().into(),
+            ))
+            .await;
+        return;
+    };
+
+    // Drive the IK handshake first. Same dance as /noise/ws.
+    let mut responder = match noise_tunnel::Responder::new(noise_key.secret_bytes()) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("bastion/noise-shell: responder init: {e}");
+            return;
+        }
+    };
+    let msg1 = match socket.recv().await {
+        Some(Ok(Message::Binary(b))) => b,
+        other => {
+            eprintln!("bastion/noise-shell: expected binary msg1, got {other:?}");
+            return;
+        }
+    };
+    if let Err(e) = responder.read_msg1(&msg1) {
+        eprintln!("bastion/noise-shell: msg1 read: {e}");
+        return;
+    }
+    let peer_pub = responder
+        .peer_pubkey()
+        .map(|p| format!("{}…", &crate::noise::hex_encode(&p)[..16]))
+        .unwrap_or_else(|| "?".into());
+    let msg2 = match responder.write_msg2(&[]) {
+        Ok(b) => b,
+        Err(e) => {
+            eprintln!("bastion/noise-shell: msg2 write: {e}");
+            return;
+        }
+    };
+    if socket.send(Message::Binary(msg2.into())).await.is_err() {
+        return;
+    }
+    let transport = match responder.into_transport() {
+        Ok(t) => t,
+        Err(e) => {
+            eprintln!("bastion/noise-shell: transport xition: {e}");
+            return;
+        }
+    };
+    eprintln!("bastion/noise-shell: tunnel up for session {id} (peer={peer_pub})");
+
+    // Wrap the transport + split socket eagerly so the not-found and
+    // replay paths use the same Arc<Mutex> dispatch as the hot loops.
+    let transport = Arc::new(Mutex::new(transport));
+    let (sink, mut stream) = socket.split();
+    let sink = Arc::new(Mutex::new(sink));
+
+    let Some(session) = m.get(&id).await else {
+        noise_send_ctrl(
+            &sink,
+            &transport,
+            &serde_json::json!({"type":"error","code":"not_found"}),
+        )
+        .await;
+        return;
+    };
+
+    // Replay: current ring + blocks + ready, same as ws_loop but
+    // through the encrypted channel.
+    {
+        let ring_bytes: Vec<u8> = session.ring.lock().await.iter().copied().collect();
+        if !ring_bytes.is_empty() {
+            noise_send_raw(&sink, &transport, &ring_bytes).await;
+        }
+        let blocks = session.blocks.read().await;
+        for b in blocks.iter() {
+            noise_send_ctrl(
+                &sink,
+                &transport,
+                &serde_json::json!({
+                    "type": "block",
+                    "session_id": b.session_id,
+                    "kind": b.kind,
+                    "seq": b.seq,
+                    "started_at_ms": b.started_at_ms,
+                    "ended_at_ms": b.ended_at_ms,
+                    "command": b.command,
+                    "output_b64": b.output_b64,
+                    "exit_code": b.exit_code,
+                }),
+            )
+            .await;
+        }
+        let seq = *session.next_seq.lock().await;
+        noise_send_ctrl(
+            &sink,
+            &transport,
+            &serde_json::json!({"type":"ready","seq":seq}),
+        )
+        .await;
+    }
+
+    let mut rx = session.tx.subscribe();
+    let writer = session.writer.clone();
+    let master = session.master.clone();
+    let transport_in = transport.clone();
+
+    let inbound = async move {
+        while let Some(Ok(msg)) = stream.next().await {
+            let Message::Binary(cipher) = msg else {
+                if matches!(msg, Message::Close(_)) {
+                    break;
+                }
+                // Plaintext text frames are invalid once the tunnel
+                // is up; drop them.
+                continue;
+            };
+            let plain = {
+                let mut t = transport_in.lock().await;
+                match t.recv(&cipher) {
+                    Ok(p) => p,
+                    Err(e) => {
+                        eprintln!("bastion/noise-shell: decrypt: {e}");
+                        break;
+                    }
+                }
+            };
+            if plain.is_empty() {
+                continue;
+            }
+            match plain[0] {
+                NOISE_FRAME_RAW => {
+                    let Some(w) = writer.clone() else { continue };
+                    let bytes = plain[1..].to_vec();
+                    let _ = tokio::task::spawn_blocking(move || {
+                        let mut g = w.blocking_lock();
+                        let _ = g.write_all(&bytes);
+                    })
+                    .await;
+                }
+                NOISE_FRAME_CTRL => {
+                    let Ok(msg) = serde_json::from_slice::<ClientMsg>(&plain[1..]) else {
+                        continue;
+                    };
+                    match msg {
+                        ClientMsg::Resize(r) => {
+                            let Some(m) = master.as_ref() else { continue };
+                            let g = m.lock().await;
+                            let _ = g.resize(PtySize {
+                                rows: r.rows.max(4),
+                                cols: r.cols.max(8),
+                                pixel_width: 0,
+                                pixel_height: 0,
+                            });
+                        }
+                        ClientMsg::Hello(_) => {}
+                    }
+                }
+                _ => {} // Unknown frame type — ignore.
+            }
+        }
+    };
+
+    let sink_out = sink.clone();
+    let transport_out = transport.clone();
+    let outbound = async move {
+        loop {
+            let ev = match rx.recv().await {
+                Ok(e) => e,
+                Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                Err(_) => break,
+            };
+            let ok = match ev {
+                Event::Raw(bytes) => noise_send_raw(&sink_out, &transport_out, &bytes).await,
+                Event::Block(b) => {
+                    noise_send_ctrl(
+                        &sink_out,
+                        &transport_out,
+                        &serde_json::json!({
+                            "type": "block",
+                            "session_id": b.session_id,
+                            "kind": b.kind,
+                            "seq": b.seq,
+                            "started_at_ms": b.started_at_ms,
+                            "ended_at_ms": b.ended_at_ms,
+                            "command": b.command,
+                            "output_b64": b.output_b64,
+                            "exit_code": b.exit_code,
+                        }),
+                    )
+                    .await
+                }
+                Event::Exit(code) => {
+                    noise_send_ctrl(
+                        &sink_out,
+                        &transport_out,
+                        &serde_json::json!({"type":"exit","code":code}),
+                    )
+                    .await;
+                    false
+                }
+            };
+            if !ok {
+                break;
+            }
+        }
+    };
+
+    tokio::select! {
+        _ = inbound => {},
+        _ = outbound => {},
+    }
+}
+
+/// Encrypt + send a raw-bytes frame (PTY stdout). Returns `false` if
+/// the sink has died so the caller can break its loop.
+async fn noise_send_raw(
+    sink: &Arc<Mutex<futures_util::stream::SplitSink<WebSocket, Message>>>,
+    transport: &Arc<Mutex<noise_tunnel::Transport>>,
+    bytes: &[u8],
+) -> bool {
+    let mut framed = Vec::with_capacity(bytes.len() + 1);
+    framed.push(NOISE_FRAME_RAW);
+    framed.extend_from_slice(bytes);
+    let cipher = {
+        let mut t = transport.lock().await;
+        match t.send(&framed) {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("bastion/noise-shell: encrypt raw: {e}");
+                return false;
+            }
+        }
+    };
+    use futures_util::SinkExt;
+    let mut s = sink.lock().await;
+    s.send(Message::Binary(cipher.into())).await.is_ok()
+}
+
+/// Encrypt + send a JSON control frame (block, exit, ready, ...).
+async fn noise_send_ctrl(
+    sink: &Arc<Mutex<futures_util::stream::SplitSink<WebSocket, Message>>>,
+    transport: &Arc<Mutex<noise_tunnel::Transport>>,
+    payload: &serde_json::Value,
+) -> bool {
+    let Ok(json) = serde_json::to_vec(payload) else {
+        return false;
+    };
+    let mut framed = Vec::with_capacity(json.len() + 1);
+    framed.push(NOISE_FRAME_CTRL);
+    framed.extend_from_slice(&json);
+    let cipher = {
+        let mut t = transport.lock().await;
+        match t.send(&framed) {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("bastion/noise-shell: encrypt ctrl: {e}");
+                return false;
+            }
+        }
+    };
+    use futures_util::SinkExt;
+    let mut s = sink.lock().await;
+    s.send(Message::Binary(cipher.into())).await.is_ok()
 }
 
 // ---------------------------------------------------------------------

--- a/crates/bastion/web/src/lib/TerminalPane.svelte
+++ b/crates/bastion/web/src/lib/TerminalPane.svelte
@@ -4,6 +4,7 @@
   import { FitAddon } from "@xterm/addon-fit";
   import type { BlockRecord } from "../types";
   import { ui } from "../ui.svelte";
+  import { openShellTunnel } from "../tunnel";
 
   interface Props {
     rowId: string;
@@ -44,7 +45,17 @@
     // the real dimensions.
     fit!.fit();
 
-    if (!row.ws || row.ws.readyState >= WebSocket.CLOSING) {
+    // Open the shell stream if we haven't already. Prefer the Noise
+    // tunnel when the connector has a cached server pubkey (cross-
+    // origin enclaves); fall back to plain /ws/{id} for same-origin.
+    const pubkey = row.connector.config.serverNoisePubkeyHex as
+      | string
+      | undefined;
+    const noiseWanted =
+      pubkey && row.origin.replace(/\/+$/, "") !== location.origin;
+    if (noiseWanted) {
+      if (!row.shell) openNoiseShell();
+    } else if (!row.ws || row.ws.readyState >= WebSocket.CLOSING) {
       openWs();
     }
 
@@ -122,6 +133,59 @@
       if (ws.readyState === WebSocket.OPEN) {
         ws.send(JSON.stringify({ type: "resize", cols, rows }));
       }
+    });
+  }
+
+  async function openNoiseShell() {
+    const row = ui.rows.get(rowId);
+    if (!row) return;
+    const term = row.term!;
+    const pubkey = row.connector.config.serverNoisePubkeyHex as
+      | string
+      | undefined;
+    if (!pubkey) return;
+
+    let shell;
+    try {
+      shell = await openShellTunnel(row.origin, pubkey, row.info.id);
+    } catch (e) {
+      console.warn(`noise-shell: open ${row.origin}/${row.info.id}`, e);
+      // Hard fail here — falling back to plain /ws would re-trigger
+      // the CORS/CF-Access wall we set up Noise to bypass.
+      term.writeln(`\r\n\x1b[2m[tunnel unavailable]\x1b[0m`);
+      return;
+    }
+    row.shell = shell;
+
+    shell.onCtrl((msg) => {
+      if (msg.type === "block") {
+        const b = msg as unknown as BlockRecord;
+        if (!row.blocks.some((x) => x.seq === b.seq)) {
+          row.blocks = [...row.blocks, b];
+        }
+      } else if (msg.type === "exit") {
+        term.writeln(`\r\n\x1b[2m[exited ${msg.code}]\x1b[0m`);
+      } else if (msg.type === "error" && msg.code === "not_found") {
+        term.writeln(`\r\n\x1b[2m[session not found]\x1b[0m`);
+      }
+    });
+    shell.onRaw((bytes) => {
+      term.write(bytes);
+    });
+
+    shell.sendCtrl({
+      type: "hello",
+      have_up_to: row.blocks.length
+        ? row.blocks[row.blocks.length - 1].seq
+        : -1,
+    });
+    shell.sendCtrl({ type: "resize", cols: term.cols, rows: term.rows });
+
+    term.onData((d) => {
+      shell.sendRaw(new TextEncoder().encode(d));
+    });
+    term.onResize(({ cols, rows }) => {
+      shell.sendCtrl({ type: "resize", cols, rows });
     });
   }
 </script>

--- a/crates/bastion/web/src/tunnel.ts
+++ b/crates/bastion/web/src/tunnel.ts
@@ -144,3 +144,118 @@ function decodeHex(hex: string): Uint8Array {
   }
   return out;
 }
+
+// -----------------------------------------------------------------
+// Shell (PTY) streaming — parallel to Tunnel but purpose-built for
+// the bidirectional byte stream xterm.js consumes.
+// -----------------------------------------------------------------
+
+/// In-tunnel frame type tag — must match the server-side constants
+/// `NOISE_FRAME_RAW` + `NOISE_FRAME_CTRL` in `crates/bastion/src/lib.rs`.
+const FRAME_RAW = 0x01;
+const FRAME_CTRL = 0x02;
+
+/// A WebSocket-shaped bidirectional Noise tunnel for a single PTY
+/// session. `sendRaw` writes PTY stdin; inbound raw frames go to
+/// `onRaw` (xterm.write). JSON control frames (resize / hello from
+/// the client, block / exit / ready from the server) use the ctrl
+/// channel.
+export class ShellTunnel {
+  private rawHandlers: Array<(bytes: Uint8Array) => void> = [];
+  private ctrlHandlers: Array<(msg: any) => void> = [];
+  private closed = false;
+
+  constructor(
+    private socket: WebSocket,
+    private transport: Transport,
+  ) {
+    socket.addEventListener("message", (ev) => this.onFrame(ev));
+    socket.addEventListener("close", () => this.onClose());
+    socket.addEventListener("error", () => this.onClose());
+  }
+
+  private onFrame(ev: MessageEvent): void {
+    if (!(ev.data instanceof ArrayBuffer)) return;
+    let plain: Uint8Array;
+    try {
+      plain = this.transport.recv(new Uint8Array(ev.data));
+    } catch (e) {
+      console.warn("shell-tunnel: decrypt failed", e);
+      this.close();
+      return;
+    }
+    if (plain.length === 0) return;
+    const tag = plain[0];
+    const body = plain.slice(1);
+    if (tag === FRAME_RAW) {
+      for (const cb of this.rawHandlers) cb(body);
+    } else if (tag === FRAME_CTRL) {
+      let msg: any;
+      try {
+        msg = JSON.parse(new TextDecoder().decode(body));
+      } catch {
+        return;
+      }
+      for (const cb of this.ctrlHandlers) cb(msg);
+    }
+  }
+
+  private onClose(): void {
+    if (this.closed) return;
+    this.closed = true;
+    for (const cb of this.ctrlHandlers) cb({ type: "close" });
+  }
+
+  sendRaw(bytes: Uint8Array): void {
+    if (this.closed) return;
+    const framed = new Uint8Array(bytes.length + 1);
+    framed[0] = FRAME_RAW;
+    framed.set(bytes, 1);
+    this.socket.send(this.transport.send(framed));
+  }
+
+  sendCtrl(msg: any): void {
+    if (this.closed) return;
+    const json = new TextEncoder().encode(JSON.stringify(msg));
+    const framed = new Uint8Array(json.length + 1);
+    framed[0] = FRAME_CTRL;
+    framed.set(json, 1);
+    this.socket.send(this.transport.send(framed));
+  }
+
+  onRaw(cb: (bytes: Uint8Array) => void): void {
+    this.rawHandlers.push(cb);
+  }
+
+  onCtrl(cb: (msg: any) => void): void {
+    this.ctrlHandlers.push(cb);
+  }
+
+  close(): void {
+    this.closed = true;
+    try {
+      this.socket.close();
+    } catch {
+      // already closed
+    }
+  }
+}
+
+/// Open a Noise-tunneled shell stream for one session. Use when
+/// cross-origin + CF-Access-bypassed /noise/shell/{id} is available;
+/// for same-origin loads the plain `/ws/{id}` is still cheaper.
+export async function openShellTunnel(
+  origin: string,
+  serverPubkeyHex: string,
+  sessionId: string,
+): Promise<ShellTunnel> {
+  const trimmed = origin.replace(/\/+$/, "");
+  const wssUrl =
+    trimmed.replace(/^http(s)?:/, (m) => (m === "http:" ? "ws:" : "wss:")) +
+    `/noise/shell/${encodeURIComponent(sessionId)}`;
+  const seed = loadIdentitySeed();
+  const client = keypairFromSeed(seed);
+  const serverPub = decodeHex(serverPubkeyHex);
+  const { socket, transport } = await connectNoise(wssUrl, client, serverPub);
+  return new ShellTunnel(socket, transport);
+}

--- a/crates/bastion/web/src/ui.svelte.ts
+++ b/crates/bastion/web/src/ui.svelte.ts
@@ -24,8 +24,14 @@ export interface Row {
   origin: string;
   info: SessionInfo;
   blocks: BlockRecord[];
-  /// Live WS to the owning origin. `null` until first activation.
+  /// Plain `/ws/{id}` WebSocket — used for same-origin loads where
+  /// CF Access already covers the upgrade. `null` until first
+  /// activation, or when the row is served over the Noise shell
+  /// tunnel instead.
   ws: WebSocket | null;
+  /// Noise-tunneled PTY stream for cross-origin enclaves. Mutually
+  /// exclusive with `ws` — whichever was opened first wins.
+  shell: import("./tunnel").ShellTunnel | null;
   /// xterm.js instance. `null` until first activation.
   term: import("@xterm/xterm").Terminal | null;
   fit: import("@xterm/addon-fit").FitAddon | null;
@@ -181,6 +187,7 @@ async function fetchDdEnclave(c: Connector): Promise<Row[]> {
     info,
     blocks: [],
     ws: null,
+    shell: null,
     term: null,
     fit: null,
   }));
@@ -212,6 +219,7 @@ export async function createShell(c: Connector): Promise<void> {
       info,
       blocks: [],
       ws: null,
+      shell: null,
       term: null,
       fit: null,
     });
@@ -268,6 +276,11 @@ export function destroyRow(id: RowId): void {
   if (!row) return;
   try {
     row.ws?.close();
+  } catch {
+    // Already closed; nothing to do.
+  }
+  try {
+    row.shell?.close();
   } catch {
     // Already closed; nothing to do.
   }


### PR DESCRIPTION
Stacked on #178 (which stacks on #177 → #176).

## Summary

Completes the cross-origin terminal story — the browser's PTY stream now rides inside the Noise_IK tunnel, not just the JSON session API.

## What ships

**Server**
- `GET /noise/shell/{id}` — Noise_IK handshake, then mirrors `/ws/{id}`'s replay + pump loop, one-byte frame-type discriminator (0x01 raw PTY bytes, 0x02 JSON control) inside the encrypted binary frames. No base64 overhead on stdout.
- Transport in `Arc<Mutex<_>>` so the inbound stdin + outbound broadcast pumps share it.

**Client**
- `tunnel.ts::ShellTunnel` — WebSocket-shaped wrapper: `sendRaw` / `sendCtrl` / `onRaw` / `onCtrl`, closes on AEAD or socket failure.
- `openShellTunnel(origin, pubkey, sessionId)` — opens the `wss` + handshake.
- `Row` gains a `shell` slot alongside `ws`; exactly one is live per session. `destroyRow` closes both.
- `TerminalPane` picks Noise when the connector has a cached pubkey AND the session isn't same-origin. Tunnel-open failure surfaces `[tunnel unavailable]` instead of silently falling back (the plain WS would re-hit the CF Access wall).

## Test plan

- [x] `cargo test --workspace` — 39 pass
- [x] `npx vitest run` — 5 Noise round-trips pass (ShellTunnel shape reuses the covered Transport)
- [x] `npm run build` — SPA 395 KB gzipped (+3 KB for ShellTunnel)
- [x] `cargo clippy -D warnings`, `cargo fmt --check`
- [ ] Preview: load the CP's aggregator, click an agent's shell, confirm terminal works over `wss://…/noise/shell/…` (DevTools: binary frames only after the 2-byte handshake)
- [ ] Confirm same-origin still uses plain `/ws/{id}` (avoid redundant handshake)
- [ ] Resize + block emission work through the encrypted channel

## Deferred

- Phase 2d — TDX quote binds `sha256(noise_pubkey)` in `REPORT_DATA`. Currently clients trust `/attest` because it's served over CF-Access-fronted TLS.
- Per-endpoint ITA cutover on CP↔agent (independent track).

🤖 Generated with [Claude Code](https://claude.com/claude-code)