### PR TITLE
feat(noise): cut /ingress/replace over to m2m Noise RPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,6 +279,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -386,6 +396,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-tungstenite",
  "urlencoding",
  "uuid",
 ]
@@ -1077,6 +1088,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1421,6 +1438,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1452,6 +1481,38 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -1891,7 +1952,11 @@ checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
 dependencies = [
  "futures-util",
  "log",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
  "tokio",
+ "tokio-rustls",
  "tungstenite",
 ]
 
@@ -1979,6 +2044,8 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.9.2",
+ "rustls",
+ "rustls-pki-types",
  "sha1",
  "thiserror 2.0.18",
  "utf-8",

--- a/crates/dd/Cargo.toml
+++ b/crates/dd/Cargo.toml
@@ -21,6 +21,7 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"
+tokio-tungstenite = { version = "0.28", default-features = false, features = ["connect", "rustls-tls-native-roots"] }
 sysinfo = { version = "0.33", default-features = false, features = ["system", "disk", "network"] }
 thiserror = "2"
 tokio = { version = "1", features = ["macros", "process", "rt-multi-thread", "signal", "time", "fs", "net", "io-util", "sync"] }

--- a/crates/dd/src/agent.rs
+++ b/crates/dd/src/agent.rs
@@ -66,6 +66,13 @@ struct St {
     /// without any shared secret; anyone else is denied at claim
     /// check.
     gh: Arc<gh_oidc::Verifier>,
+    /// Long-term Noise static keypair for m2m RPC. `None` when
+    /// `DD_NOISE_KEY_DIR` isn't set or the key couldn't be loaded.
+    noise_key: Option<Arc<dd_common::noise_static::NoiseStatic>>,
+    /// CP's pinned pubkey, learned at registration and persisted on
+    /// disk. `None` during the migration window where the CP side
+    /// hasn't been given a key yet.
+    cp_noise_pubkey: Option<[u8; 32]>,
 }
 
 pub async fn run() -> Result<()> {
@@ -114,6 +121,7 @@ pub async fn run() -> Result<()> {
 
     // Pin the CP's pubkey for future m2m handshakes. Silently ignored
     // if the CP didn't advertise one (migration window).
+    let mut cp_noise_pubkey: Option<[u8; 32]> = None;
     if let (Some(hex), Some(dir)) = (
         b.cp_noise_pubkey_hex.as_deref(),
         std::env::var("DD_NOISE_KEY_DIR")
@@ -122,6 +130,7 @@ pub async fn run() -> Result<()> {
     ) {
         match crate::noise_m2m::decode_pubkey(hex) {
             Ok(pk) => {
+                cp_noise_pubkey = Some(pk);
                 if let Err(e) = crate::noise_m2m::save_cp_pubkey(std::path::Path::new(&dir), &pk) {
                     eprintln!("agent: save CP noise pubkey: {e}");
                 } else {
@@ -132,6 +141,16 @@ pub async fn run() -> Result<()> {
                 }
             }
             Err(e) => eprintln!("agent: CP noise pubkey decode: {e}"),
+        }
+    }
+    // Fall back to the on-disk cache if the CP didn't advertise one
+    // this boot but did previously.
+    if cp_noise_pubkey.is_none() {
+        if let Some(dir) = std::env::var("DD_NOISE_KEY_DIR")
+            .ok()
+            .filter(|s| !s.is_empty())
+        {
+            cp_noise_pubkey = crate::noise_m2m::load_cp_pubkey(std::path::Path::new(&dir));
         }
     }
 
@@ -172,6 +191,8 @@ pub async fn run() -> Result<()> {
         ita_token,
         extras: Arc::new(RwLock::new(cfg.extra_ingress.clone())),
         gh,
+        noise_key,
+        cp_noise_pubkey,
     };
 
     let app = Router::new()
@@ -585,6 +606,39 @@ async fn push_extra_ingress(s: &St, label: String, port: u16) -> Result<()> {
         .iter()
         .map(|(l, p)| serde_json::json!({"hostname_label": l, "port": p}))
         .collect();
+
+    // Prefer Noise RPC when both sides have pinned keys — closes out
+    // the ITA-bearer-on-every-call pattern. The HTTP+ITA path below
+    // stays live as a migration fallback for any agent/CP pair
+    // where one side doesn't have a key yet.
+    if let (Some(key), Some(pk)) = (s.noise_key.as_ref(), s.cp_noise_pubkey.as_ref()) {
+        let wss = http_to_wss(&s.cfg.cp_url) + "/noise/rpc";
+        let req = serde_json::json!({
+            "op": "ingress_replace",
+            "agent_id": s.agent_id,
+            "extras": body_extras.clone(),
+        });
+        match crate::noise_rpc::call(&wss, key, pk, req).await {
+            Ok(resp) if resp.get("ok").and_then(|v| v.as_bool()) == Some(true) => {
+                eprintln!(
+                    "agent: ingress/replace (noise) ok ({} extras total)",
+                    extras.len()
+                );
+                return Ok(());
+            }
+            Ok(resp) => {
+                let msg = resp
+                    .get("error")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("unknown");
+                eprintln!("agent: ingress/replace (noise) rejected: {msg} — falling back to HTTP");
+            }
+            Err(e) => {
+                eprintln!("agent: ingress/replace (noise) error: {e} — falling back to HTTP");
+            }
+        }
+    }
+
     let ita_token = s.ita_token.read().await.clone();
     let body = serde_json::json!({
         "agent_id": s.agent_id,
@@ -606,8 +660,23 @@ async fn push_extra_ingress(s: &St, label: String, port: u16) -> Result<()> {
             "ingress/replace {url} → {status}: {text}"
         )));
     }
-    eprintln!("agent: ingress/replace ok ({} extras total)", extras.len());
+    eprintln!(
+        "agent: ingress/replace (http) ok ({} extras total)",
+        extras.len()
+    );
     Ok(())
+}
+
+/// Convert an http(s) URL to a ws(s) URL for WebSocket upgrade. Keeps
+/// the host/port/path intact; only the scheme changes.
+fn http_to_wss(url: &str) -> String {
+    if let Some(rest) = url.strip_prefix("https://") {
+        format!("wss://{}", rest.trim_end_matches('/'))
+    } else if let Some(rest) = url.strip_prefix("http://") {
+        format!("ws://{}", rest.trim_end_matches('/'))
+    } else {
+        url.trim_end_matches('/').to_string()
+    }
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/dd/src/cp.rs
+++ b/crates/dd/src/cp.rs
@@ -291,6 +291,7 @@ pub async fn run() -> Result<()> {
         .route("/cp/attest", get(cp_attest))
         .route("/cp/ita", get(cp_ita))
         .route("/cp/noise/attest", get(cp_noise_attest))
+        .route("/noise/rpc", get(noise_rpc_upgrade))
         .with_state(state);
 
     let addr = format!("0.0.0.0:{}", cfg.common.port);
@@ -552,29 +553,41 @@ struct IngressPair {
 /// The agent forwards its full current ingress list; the CP re-PUTs
 /// the tunnel config + CNAMEs and reconciles per-workload CF Access
 /// bypass apps (creates new, deletes stale).
+///
+/// Retained alongside the new Noise RPC path so agents built before
+/// the m2m migration still work. Once every agent has a pinned
+/// pubkey, this endpoint becomes removable.
 async fn ingress_replace(
     State(s): State<St>,
     Json(req): Json<IngressReplaceReq>,
 ) -> Result<Json<serde_json::Value>> {
     // ITA is the auth — any failure → 401.
     let _claims = s.verifier.verify(&req.ita_token).await?;
+    do_ingress_replace(&s, &req.agent_id, req.extras).await
+}
 
+/// Pure ingress-replace logic with no auth check. Called by both the
+/// HTTP+ITA path (above) and the Noise RPC path (below); they each
+/// own their own auth.
+async fn do_ingress_replace(
+    s: &St,
+    agent_id: &str,
+    extras_in: Vec<IngressPair>,
+) -> Result<Json<serde_json::Value>> {
     let (tunnel_id, hostname) = {
         let store = s.store.lock().await;
-        let agent = store.get(&req.agent_id).ok_or(Error::NotFound)?;
+        let agent = store.get(agent_id).ok_or(Error::NotFound)?;
         if agent.tunnel_id.is_empty() {
             // Control-plane pseudo-entry, or an older store entry that
             // pre-dates the tunnel_id field. Either way, nothing to update.
             return Err(Error::BadRequest(format!(
-                "{} has no tunnel — runtime ingress applies only to agent tunnels",
-                req.agent_id
+                "{agent_id} has no tunnel — runtime ingress applies only to agent tunnels"
             )));
         }
         (agent.tunnel_id.clone(), agent.hostname.clone())
     };
 
-    let extras: Vec<(String, u16)> = req
-        .extras
+    let extras: Vec<(String, u16)> = extras_in
         .iter()
         .map(|e| (e.hostname_label.clone(), e.port))
         .collect();
@@ -594,21 +607,82 @@ async fn ingress_replace(
     )
     .await
     {
-        eprintln!("cp: provision_agent_access on /ingress/replace failed: {e}");
+        eprintln!("cp: provision_agent_access on ingress_replace failed: {e}");
     }
 
     {
         let mut store = s.store.lock().await;
-        if let Some(agent) = store.get_mut(&req.agent_id) {
+        if let Some(agent) = store.get_mut(agent_id) {
             agent.extras = extras;
         }
     }
 
-    eprintln!("cp: ingress/replace {} → {:?}", req.agent_id, hostnames);
+    eprintln!("cp: ingress/replace {agent_id} → {hostnames:?}");
     Ok(Json(serde_json::json!({
-        "agent_id": req.agent_id,
+        "agent_id": agent_id,
         "extra_hostnames": hostnames,
     })))
+}
+
+/// GET /noise/rpc — authenticated by the Noise_IK handshake's pinned
+/// pubkey. Currently supports one op: `ingress_replace`. Others
+/// (`api_agents`, `heartbeat`) migrate on follow-up PRs.
+async fn noise_rpc_upgrade(
+    ws: axum::extract::ws::WebSocketUpgrade,
+    State(s): State<St>,
+) -> axum::response::Response {
+    ws.on_upgrade(move |socket| noise_rpc_loop(socket, s))
+}
+
+async fn noise_rpc_loop(socket: axum::extract::ws::WebSocket, s: St) {
+    let Some(key) = s.noise.clone() else {
+        eprintln!("cp: /noise/rpc but no key configured; closing");
+        return;
+    };
+    crate::noise_rpc::serve(socket, &key, move |peer_pubkey, req| async move {
+        dispatch_m2m_rpc(&s, peer_pubkey, req).await
+    })
+    .await;
+}
+
+/// Dispatch one decrypted m2m RPC. Verifies the peer pubkey matches
+/// the pinned key for the claimed `agent_id` before doing any work.
+async fn dispatch_m2m_rpc(s: &St, peer: [u8; 32], req: serde_json::Value) -> serde_json::Value {
+    let op = req
+        .get("op")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let agent_id = req
+        .get("agent_id")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+
+    let pinned = s.agent_pubkeys.get(&agent_id).await;
+    match pinned {
+        Some(pk) if pk == peer => {}
+        Some(_) => return err("peer pubkey mismatch"),
+        None => return err(&format!("agent_id {agent_id} not enrolled")),
+    }
+
+    match op.as_str() {
+        "ingress_replace" => {
+            let extras: Vec<IngressPair> = req
+                .get("extras")
+                .and_then(|v| serde_json::from_value(v.clone()).ok())
+                .unwrap_or_default();
+            match do_ingress_replace(s, &agent_id, extras).await {
+                Ok(Json(data)) => serde_json::json!({"ok": true, "data": data}),
+                Err(e) => err(&format!("{e}")),
+            }
+        }
+        other => err(&format!("unknown op: {other}")),
+    }
+}
+
+fn err(msg: &str) -> serde_json::Value {
+    serde_json::json!({"ok": false, "error": msg})
 }
 
 /// Mint the CP's own ITA token at startup. Fatal on any failure —

--- a/crates/dd/src/lib.rs
+++ b/crates/dd/src/lib.rs
@@ -10,4 +10,5 @@ pub mod html;
 pub mod ita;
 pub mod metrics;
 pub mod noise_m2m;
+pub mod noise_rpc;
 pub mod stonith;

--- a/crates/dd/src/noise_rpc.rs
+++ b/crates/dd/src/noise_rpc.rs
@@ -1,0 +1,223 @@
+//! CP↔agent m2m RPC over a Noise_IK-tunneled WebSocket.
+//!
+//! Replaces the ITA-bearer-over-HTTP pattern for calls where both
+//! sides have pinned static keys (set up at registration in
+//! `crate::noise_m2m::AgentRegistry`). Each call is a fresh
+//! WebSocket with a 1-RTT handshake + one request/response pair;
+//! no connection pooling. The rare-ops set (`ingress_replace`,
+//! `api_agents`, later `heartbeat`) absorbs the ~150 ms handshake
+//! cost without blinking.
+//!
+//! Auth is by pinned pubkey. The responder learns the initiator's
+//! static during the IK handshake and matches it against the
+//! registry; a mismatch or unknown pubkey → `unauthorized` response.
+//! No ITA bearer, no timestamp dance, no token rotation.
+//!
+//! Wire shape inside the encrypted tunnel is JSON:
+//!
+//! ```json
+//! // Request
+//! {"op": "ingress_replace", "agent_id": "...", "extras": [...]}
+//! // Response
+//! {"ok": true, "data": {...}}  |  {"ok": false, "error": "..."}
+//! ```
+//!
+//! The module exposes one server entry point (`serve`) and one
+//! client entry point (`call`); individual ops live in `cp.rs` /
+//! `agent.rs` where the state they need is already in scope.
+
+use dd_common::noise_static::NoiseStatic;
+use dd_common::noise_tunnel::{Initiator, Responder};
+use serde_json::Value;
+use std::sync::Arc;
+
+/// Drive one full responder session on an already-upgraded axum
+/// WebSocket. Consumes `msg1`, emits `msg2`, then reads a single
+/// encrypted request and sends a single encrypted response. Caller
+/// supplies the request dispatcher which receives the initiator's
+/// pubkey + the decoded request value.
+pub async fn serve<F, Fut>(
+    mut socket: axum::extract::ws::WebSocket,
+    noise_key: &NoiseStatic,
+    handler: F,
+) where
+    F: FnOnce([u8; 32], Value) -> Fut,
+    Fut: std::future::Future<Output = Value>,
+{
+    use axum::extract::ws::Message;
+
+    let mut responder = match Responder::new(noise_key.secret_bytes()) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("noise-rpc: responder init: {e}");
+            return;
+        }
+    };
+
+    let msg1 = match socket.recv().await {
+        Some(Ok(Message::Binary(b))) => b,
+        other => {
+            eprintln!("noise-rpc: expected binary msg1, got {other:?}");
+            return;
+        }
+    };
+    if let Err(e) = responder.read_msg1(&msg1) {
+        eprintln!("noise-rpc: msg1 read: {e}");
+        return;
+    }
+    let peer = match responder.peer_pubkey() {
+        Some(p) => p,
+        None => {
+            eprintln!("noise-rpc: missing peer pubkey after msg1");
+            return;
+        }
+    };
+    let msg2 = match responder.write_msg2(&[]) {
+        Ok(b) => b,
+        Err(e) => {
+            eprintln!("noise-rpc: msg2 write: {e}");
+            return;
+        }
+    };
+    if socket.send(Message::Binary(msg2.into())).await.is_err() {
+        return;
+    }
+    let mut transport = match responder.into_transport() {
+        Ok(t) => t,
+        Err(e) => {
+            eprintln!("noise-rpc: transport xition: {e}");
+            return;
+        }
+    };
+
+    // Single request / single response.
+    let cipher = match socket.recv().await {
+        Some(Ok(Message::Binary(b))) => b,
+        _ => return,
+    };
+    let plain = match transport.recv(&cipher) {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("noise-rpc: decrypt: {e}");
+            return;
+        }
+    };
+    let req: Value = match serde_json::from_slice(&plain) {
+        Ok(v) => v,
+        Err(e) => {
+            let _ = send_err(&mut socket, &mut transport, &format!("bad request: {e}")).await;
+            return;
+        }
+    };
+    let resp = handler(peer, req).await;
+    let Ok(out) = serde_json::to_vec(&resp) else {
+        return;
+    };
+    let Ok(ct) = transport.send(&out) else {
+        return;
+    };
+    let _ = socket.send(Message::Binary(ct.into())).await;
+}
+
+async fn send_err(
+    socket: &mut axum::extract::ws::WebSocket,
+    transport: &mut dd_common::noise_tunnel::Transport,
+    msg: &str,
+) -> std::io::Result<()> {
+    use axum::extract::ws::Message;
+    let body = serde_json::json!({"ok": false, "error": msg});
+    let Ok(bytes) = serde_json::to_vec(&body) else {
+        return Ok(());
+    };
+    let Ok(ct) = transport.send(&bytes) else {
+        return Ok(());
+    };
+    socket
+        .send(Message::Binary(ct.into()))
+        .await
+        .map_err(|e| std::io::Error::other(format!("{e}")))
+}
+
+/// Open `wss_url`, run the Noise_IK handshake as initiator, send one
+/// encrypted JSON request, read one encrypted response, close.
+///
+/// `client_static` is the agent's long-term keypair;
+/// `server_pubkey` is the CP's pinned pubkey (cached after
+/// `/cp/noise/attest`). Returns the decoded response `Value` or an
+/// error if any step fails.
+pub async fn call(
+    wss_url: &str,
+    client_static: &Arc<NoiseStatic>,
+    server_pubkey: &[u8; 32],
+    request: Value,
+) -> Result<Value, CallError> {
+    use futures_util::{SinkExt, StreamExt};
+    use tokio_tungstenite::tungstenite::protocol::Message;
+
+    let (mut ws, _resp) = tokio_tungstenite::connect_async(wss_url)
+        .await
+        .map_err(|e| CallError::Connect(format!("{e}")))?;
+
+    let mut initiator = Initiator::new(client_static.secret_bytes(), server_pubkey)
+        .map_err(|e| CallError::Handshake(format!("init: {e}")))?;
+    let msg1 = initiator
+        .write_msg1(&[])
+        .map_err(|e| CallError::Handshake(format!("msg1: {e}")))?;
+    ws.send(Message::Binary(msg1.into()))
+        .await
+        .map_err(|e| CallError::Connect(format!("send msg1: {e}")))?;
+
+    let msg2 = match ws.next().await {
+        Some(Ok(Message::Binary(b))) => b,
+        Some(Ok(other)) => return Err(CallError::Handshake(format!("msg2 wrong kind: {other:?}"))),
+        Some(Err(e)) => return Err(CallError::Connect(format!("{e}"))),
+        None => return Err(CallError::Connect("closed before msg2".into())),
+    };
+    initiator
+        .read_msg2(&msg2)
+        .map_err(|e| CallError::Handshake(format!("msg2: {e}")))?;
+    let mut transport = initiator
+        .into_transport()
+        .map_err(|e| CallError::Handshake(format!("transport: {e}")))?;
+
+    let plain = serde_json::to_vec(&request).map_err(|e| CallError::Encode(format!("{e}")))?;
+    let ct = transport
+        .send(&plain)
+        .map_err(|e| CallError::Encode(format!("encrypt: {e}")))?;
+    ws.send(Message::Binary(ct.into()))
+        .await
+        .map_err(|e| CallError::Connect(format!("send req: {e}")))?;
+
+    let resp = match ws.next().await {
+        Some(Ok(Message::Binary(b))) => b,
+        Some(Ok(other)) => return Err(CallError::Decode(format!("resp wrong kind: {other:?}"))),
+        Some(Err(e)) => return Err(CallError::Connect(format!("{e}"))),
+        None => return Err(CallError::Connect("closed before response".into())),
+    };
+    let plain_resp = transport
+        .recv(&resp)
+        .map_err(|e| CallError::Decode(format!("decrypt: {e}")))?;
+    let _ = ws.close(None).await;
+    serde_json::from_slice(&plain_resp).map_err(|e| CallError::Decode(format!("{e}")))
+}
+
+#[derive(Debug)]
+pub enum CallError {
+    Connect(String),
+    Handshake(String),
+    Encode(String),
+    Decode(String),
+}
+
+impl std::fmt::Display for CallError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CallError::Connect(s) => write!(f, "connect: {s}"),
+            CallError::Handshake(s) => write!(f, "handshake: {s}"),
+            CallError::Encode(s) => write!(f, "encode: {s}"),
+            CallError::Decode(s) => write!(f, "decode: {s}"),
+        }
+    }
+}
+
+impl std::error::Error for CallError {}


### PR DESCRIPTION
Stacked on #180 (tip of #176→#177→#178→#179→#180).

## Summary

First concrete cutover from ITA-bearer-on-every-call to Noise_IK-authenticated m2m RPC. Establishes the pattern the rest of the m2m surface will follow in subsequent PRs.

## What ships

**Server**
- `noise_rpc` module — `serve()` drives a one-shot Noise_IK handshake + request/response on an axum WS; `call()` is the mirror for the agent (tokio-tungstenite).
- `GET /noise/rpc` on CP, dispatcher verifies peer pubkey matches `agent_pubkeys[agent_id]` before any work.
- `ingress_replace` body extracted to pure `do_ingress_replace(state, agent_id, extras)`; HTTP+ITA and Noise paths share it.

**Agent**
- `St` gains `noise_key` + `cp_noise_pubkey` slots; cache falls back to on-disk if this boot's register didn't re-advertise.
- `push_extra_ingress` prefers Noise when both keys present; falls back to HTTP+ITA on any Noise failure (connect / handshake / unauthorized).

## Auth model change

Before: every `/ingress/replace` mints a fresh ITA JWT that the CP verifies against Intel Trust Authority. Rotation on every call.

After: CP pinned the agent's pubkey at registration (ITA-attested then). Every subsequent call authenticates by owning the pinned private key — pure cryptographic, no per-call ITA roundtrip.

## Deferred

- `/api/agents` bearer → Noise
- Heartbeat scraping → Noise push
- `/register` stays ITA forever (first contact has no pubkey yet)

## Test plan

- [x] `cargo test --workspace` — 39 pass
- [x] `cargo clippy -D warnings`, `cargo fmt --check`
- [ ] Preview: deploy a workload with `expose`; agent logs show `ingress/replace (noise) ok ({n} extras total)` instead of `(http)`
- [ ] Observability: `curl -X POST $cp/ingress/replace …` with wrong ITA should still fail (backward compat with any unmigrated agent)
- [ ] Breaking the Noise path (wrong pubkey cache) should soft-fall-back to HTTP+ITA — agent logs `falling back to HTTP` then `(http) ok`

🤖 Generated with [Claude Code](https://claude.com/claude-code)