### PR TITLE
feat(noise): full Noise_IK stack — browser tunnel, m2m cutover, TDX-bound pubkey

### DIFF
--- a/.github/workflows/deploy-cp.yml
+++ b/.github/workflows/deploy-cp.yml
@@ -200,11 +200,16 @@ jobs:
               exit 1
             fi
 
-            if curl -fsS "${AGENT_URL}/health" >/dev/null 2>&1; then
-              echo "Agent healthy at ${AGENT_URL}"
+            # `-f` only fails on 4xx/5xx — a CF Access 302 login redirect
+            # passes and we falsely report "healthy" before the CP has
+            # actually come up. Insist on 200 explicitly so the serial
+            # streamer keeps running until we see a real origin response.
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' "${AGENT_URL}/health" || echo "000")
+            if [ "$CODE" = "200" ]; then
+              echo "Agent healthy at ${AGENT_URL} (HTTP 200)"
               exit 0
             fi
-            echo "  waiting for tunnel... (${i}/60)"
+            echo "  waiting for tunnel (got HTTP ${CODE})... (${i}/60)"
             sleep 5
           done
           echo "::error::Agent not healthy within 5 minutes"

--- a/.github/workflows/force-cleanup-tunnels.yml
+++ b/.github/workflows/force-cleanup-tunnels.yml
@@ -1,0 +1,132 @@
+name: Force cleanup tunnels
+
+# Manually reap CF tunnels + GCE VMs for a specific dd env (e.g. `pr-182`).
+#
+# Primary use case: a PR's preview deploy has left orphan CF tunnels
+# from previous failed attempts. Those tunnels survive `kill_old_tunnels`
+# races because all the old CPs have already stopped running and no
+# new CP has self_tunnel_id matching them. This workflow nukes the
+# orphans so the next deploy has a clean CF state.
+#
+# Unlike `reap-merged-pr-previews` in cleanup.yml, this runs regardless
+# of PR open/closed state — the operator explicitly names the env.
+
+on:
+  workflow_dispatch:
+    inputs:
+      env:
+        description: 'dd env to reap (e.g. pr-182, pr-200, staging)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  force-cleanup:
+    runs-on: ubuntu-latest
+    environment: staging
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      GCP_ZONE: us-central1-c
+    steps:
+      - uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: 'projects/654815109728/locations/global/workloadIdentityPools/github-actions-pool/providers/github-provider'
+          service_account: 'easyenclave-staging-ci@eestaging.iam.gserviceaccount.com'
+      - uses: google-github-actions/setup-gcloud@v2
+      - name: Reap ${{ inputs.env }} — VMs + CF tunnels + DNS
+        env:
+          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+          CF_API_TOKEN:   ${{ secrets.DD_CP_CF_API_TOKEN }}
+          CF_ACCOUNT_ID:  ${{ secrets.DD_CP_CF_ACCOUNT_ID }}
+          CF_ZONE_ID:     ${{ secrets.DD_CP_CF_ZONE_ID }}
+          DD_DOMAIN:      ${{ vars.DD_CF_DOMAIN || 'devopsdefender.com' }}
+          TARGET_ENV:     ${{ inputs.env }}
+        run: |
+          set -euo pipefail
+          echo "Force-reaping env: $TARGET_ENV"
+
+          # VMs
+          vms=$(gcloud compute instances list \
+            --project="$GCP_PROJECT_ID" \
+            --filter="labels.devopsdefender=managed AND labels.dd_env=$TARGET_ENV" \
+            --format='value(name)')
+          if [ -n "$vms" ]; then
+            echo "Deleting VMs: $(echo "$vms" | tr '\n' ' ')"
+            # shellcheck disable=SC2086
+            gcloud compute instances delete $vms \
+              --project="$GCP_PROJECT_ID" --zone="$GCP_ZONE" --quiet
+          else
+            echo "No VMs to delete."
+          fi
+
+          # CF tunnels — named `dd-{env}-{uuid}` (cp-*, agent-*, etc.)
+          resp=$(curl -fsS \
+            -H "Authorization: Bearer $CF_API_TOKEN" \
+            "https://api.cloudflare.com/client/v4/accounts/$CF_ACCOUNT_ID/cfd_tunnel?is_deleted=false&per_page=200")
+          ids=$(echo "$resp" | jq -r --arg prefix "dd-$TARGET_ENV-" \
+            '.result[] | select(.name | startswith($prefix)) | "\(.id)\t\(.name)"')
+          if [ -n "$ids" ]; then
+            echo "Found tunnels:"
+            echo "$ids" | sed 's/^/  /'
+            echo "$ids" | while IFS=$'\t' read -r id name; do
+              echo "  deleting connections for $name ($id)"
+              curl -fsS -X DELETE \
+                -H "Authorization: Bearer $CF_API_TOKEN" \
+                "https://api.cloudflare.com/client/v4/accounts/$CF_ACCOUNT_ID/cfd_tunnel/$id/connections" \
+                >/dev/null || true
+              echo "  deleting tunnel $id"
+              curl -fsS -X DELETE \
+                -H "Authorization: Bearer $CF_API_TOKEN" \
+                "https://api.cloudflare.com/client/v4/accounts/$CF_ACCOUNT_ID/cfd_tunnel/$id" \
+                >/dev/null || true
+            done
+          else
+            echo "No tunnels to delete."
+          fi
+
+          # CF Access apps — named `dd-{env}-*`.
+          apps=$(curl -fsS \
+            -H "Authorization: Bearer $CF_API_TOKEN" \
+            "https://api.cloudflare.com/client/v4/accounts/$CF_ACCOUNT_ID/access/apps?per_page=1000" \
+            | jq -r --arg prefix "dd-$TARGET_ENV-" \
+            '.result[] | select(.name | startswith($prefix)) | "\(.id)\t\(.name)"')
+          if [ -n "$apps" ]; then
+            echo "Found Access apps:"
+            echo "$apps" | sed 's/^/  /'
+            echo "$apps" | while IFS=$'\t' read -r id name; do
+              echo "  deleting app $name ($id)"
+              curl -fsS -X DELETE \
+                -H "Authorization: Bearer $CF_API_TOKEN" \
+                "https://api.cloudflare.com/client/v4/accounts/$CF_ACCOUNT_ID/access/apps/$id" \
+                >/dev/null || true
+            done
+          else
+            echo "No Access apps to delete."
+          fi
+
+          # DNS records pointing at *.cfargotunnel.com for this env
+          # (the CP's primary hostname + any workload subdomains).
+          dns=$(curl -fsS \
+            -H "Authorization: Bearer $CF_API_TOKEN" \
+            "https://api.cloudflare.com/client/v4/zones/$CF_ZONE_ID/dns_records?per_page=500&type=CNAME" \
+            | jq -r --arg host "$TARGET_ENV.$DD_DOMAIN" --arg dash "$TARGET_ENV-" \
+            '.result[] | select((.name == $host) or (.name | startswith($dash))) | "\(.id)\t\(.name)"')
+          if [ -n "$dns" ]; then
+            echo "Found DNS records:"
+            echo "$dns" | sed 's/^/  /'
+            echo "$dns" | while IFS=$'\t' read -r id name; do
+              echo "  deleting DNS $name ($id)"
+              curl -fsS -X DELETE \
+                -H "Authorization: Bearer $CF_API_TOKEN" \
+                "https://api.cloudflare.com/client/v4/zones/$CF_ZONE_ID/dns_records/$id" \
+                >/dev/null || true
+            done
+          else
+            echo "No DNS records to delete."
+          fi
+
+          echo "Done reaping $TARGET_ENV."

--- a/.github/workflows/release-bastion.yml
+++ b/.github/workflows/release-bastion.yml
@@ -51,6 +51,7 @@ jobs:
         working-directory: crates/bastion/web
         run: |
           npm ci
+          npm test
           npm run build
 
       - name: Build bastion

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,6 +76,7 @@ jobs:
         working-directory: crates/bastion/web
         run: |
           npm ci
+          npm test
           npm run build
 
       # Folded in from the old ci.yml so we don't duplicate the compile

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,41 @@
 version = 4
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -118,9 +153,11 @@ dependencies = [
  "futures-util",
  "libc",
  "portable-pty",
+ "rand 0.8.5",
  "reqwest",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
  "tokio",
  "tower-http",
@@ -139,6 +176,15 @@ name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "block-buffer"
@@ -184,6 +230,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -195,6 +265,27 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+ "zeroize",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -223,6 +314,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -232,8 +358,12 @@ checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 name = "dd-common"
 version = "0.1.0"
 dependencies = [
+ "rand 0.8.5",
  "serde",
  "serde_json",
+ "snow",
+ "tempfile",
+ "x25519-dalek",
 ]
 
 [[package]]
@@ -253,6 +383,7 @@ dependencies = [
  "base64",
  "bastion-term",
  "chrono",
+ "dd-common",
  "futures-util",
  "jsonwebtoken",
  "libc",
@@ -260,9 +391,12 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "sha2",
  "sysinfo",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-tungstenite",
  "urlencoding",
  "uuid",
 ]
@@ -275,6 +409,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -315,6 +450,12 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "filedescriptor"
@@ -448,6 +589,16 @@ dependencies = [
  "r-efi 6.0.0",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
 ]
 
 [[package]]
@@ -723,6 +874,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "ioctl-rs"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -922,6 +1082,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -948,6 +1120,29 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
 
 [[package]]
 name = "portable-pty"
@@ -1207,6 +1402,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1231,6 +1435,18 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -1265,6 +1481,38 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -1392,6 +1640,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shared_library"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1446,6 +1705,23 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "snow"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "599b506ccc4aff8cf7844bc42cf783009a434c1e26c964432560fb6d6ad02d82"
+dependencies = [
+ "aes-gcm",
+ "blake2",
+ "chacha20poly1305",
+ "curve25519-dalek",
+ "getrandom 0.3.4",
+ "ring",
+ "rustc_version",
+ "sha2",
+ "subtle",
+]
 
 [[package]]
 name = "socket2"
@@ -1676,7 +1952,11 @@ checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
 dependencies = [
  "futures-util",
  "log",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
  "tokio",
+ "tokio-rustls",
  "tungstenite",
 ]
 
@@ -1764,6 +2044,8 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.9.2",
+ "rustls",
+ "rustls-pki-types",
  "sha1",
  "thiserror 2.0.18",
  "utf-8",
@@ -1786,6 +2068,16 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "untrusted"
@@ -2416,6 +2708,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core 0.6.4",
+ "serde",
+ "zeroize",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2484,6 +2788,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"

--- a/apps/bastion/workload.json.tmpl
+++ b/apps/bastion/workload.json.tmpl
@@ -20,6 +20,8 @@
     "--ee-socket",
     "/var/lib/easyenclave/agent.sock",
     "--cp-url",
-    "http://127.0.0.1:8080"
+    "http://127.0.0.1:8080",
+    "--noise-key",
+    "/var/lib/easyenclave/bastion/noise-static.key"
   ]
 }

--- a/apps/dd-agent/workload.json.tmpl
+++ b/apps/dd-agent/workload.json.tmpl
@@ -18,6 +18,7 @@
     "DD_ENV=${DD_ENV}",
     "DD_VM_NAME=${DD_VM_NAME}",
     "DD_PORT=8080",
-    "DD_EXTRA_INGRESS=${DD_EXTRA_INGRESS}"
+    "DD_EXTRA_INGRESS=${DD_EXTRA_INGRESS}",
+    "DD_NOISE_KEY_DIR=/var/lib/dd/agent-noise"
   ]
 }

--- a/apps/dd-management/workload.json.tmpl
+++ b/apps/dd-management/workload.json.tmpl
@@ -21,6 +21,7 @@
     "DD_ITA_API_KEY=${DD_ITA_API_KEY}",
     "DD_ITA_BASE_URL=${DD_ITA_BASE_URL}",
     "DD_ITA_JWKS_URL=${DD_ITA_JWKS_URL}",
-    "DD_ITA_ISSUER=${DD_ITA_ISSUER}"
+    "DD_ITA_ISSUER=${DD_ITA_ISSUER}",
+    "DD_NOISE_KEY_DIR=/var/lib/dd/cp-noise"
   ]
 }

--- a/crates/bastion/Cargo.toml
+++ b/crates/bastion/Cargo.toml
@@ -27,6 +27,8 @@ libc = "0.2"
 portable-pty = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+sha2 = "0.10"
+rand = "0.8"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 tokio = { version = "1", features = ["fs", "macros", "rt-multi-thread", "sync", "io-util", "net", "signal"] }
 tower-http = { version = "0.6", features = ["cors"] }

--- a/crates/bastion/src/bin/bastion.rs
+++ b/crates/bastion/src/bin/bastion.rs
@@ -8,7 +8,7 @@ use axum::Router;
 async fn main() -> std::io::Result<()> {
     let args: Vec<String> = std::env::args().collect();
     if args.get(1).map(|s| s.as_str()) != Some("serve") {
-        eprintln!("usage: bastion serve [--port N] [--bind ADDR] [--capture-socket PATH] [--ee-socket PATH] [--cp-url URL]");
+        eprintln!("usage: bastion serve [--port N] [--bind ADDR] [--capture-socket PATH] [--ee-socket PATH] [--cp-url URL] [--noise-key PATH]");
         std::process::exit(2);
     }
 
@@ -17,6 +17,7 @@ async fn main() -> std::io::Result<()> {
     let mut capture_socket: Option<String> = None;
     let mut ee_socket: Option<String> = None;
     let mut cp_url: Option<String> = None;
+    let mut noise_key_path: Option<String> = None;
     let mut i = 2;
     while i < args.len() {
         match args[i].as_str() {
@@ -42,6 +43,10 @@ async fn main() -> std::io::Result<()> {
                 cp_url = args.get(i + 1).cloned();
                 i += 2;
             }
+            "--noise-key" => {
+                noise_key_path = args.get(i + 1).cloned();
+                i += 2;
+            }
             other => {
                 eprintln!("bastion: unknown arg {other}");
                 std::process::exit(2);
@@ -57,6 +62,25 @@ async fn main() -> std::io::Result<()> {
         eprintln!("bastion: cross-node aggregator against CP {url}");
         mgr = mgr.with_cp_url(url);
     }
+    if let Some(path) = noise_key_path.as_deref().filter(|s| !s.is_empty()) {
+        // Load (or mint on first boot) the long-term Noise static
+        // keypair. Exposed via `GET /attest` so clients can pin the
+        // pubkey for Phase 2b's Noise_KK handshake.
+        match bastion::noise::NoiseStatic::load_or_generate(path) {
+            Ok(key) => {
+                eprintln!(
+                    "bastion: noise static key {:?} ({}…)",
+                    key.source(),
+                    &key.public_hex()[..16]
+                );
+                mgr = mgr.with_noise_key(key);
+            }
+            Err(e) => {
+                eprintln!("bastion: noise key load at {path}: {e}");
+                std::process::exit(1);
+            }
+        }
+    }
 
     if let Some(path) = capture_socket {
         if let Err(e) = bastion::capture::spawn_listener(&path, mgr.clone()).await {
@@ -67,14 +91,18 @@ async fn main() -> std::io::Result<()> {
         }
     }
 
-    if let Some(path) = ee_socket {
+    if let Some(path) = ee_socket.as_deref().filter(|s| !s.is_empty()) {
         // Pull-based bootstrap: on startup (and every 30s after),
         // query EE's `list` + `logs` over its unix socket and seed
         // the Manager so boot workloads render with their history.
         // Requires `inherit_token: true` in the workload spec so the
         // Tier-1 seal lets us talk to EE.
         eprintln!("bastion: ee_sync polling {path}");
-        bastion::ee_sync::start(mgr.clone(), &path);
+        bastion::ee_sync::start(mgr.clone(), path);
+        // Also remember the path so /attest can mint a TDX quote
+        // bound to the Noise pubkey (Phase 2d). Same socket, different
+        // EE method.
+        mgr = mgr.with_ee_socket(path);
     }
 
     let addr = format!("{bind}:{port}");

--- a/crates/bastion/src/ee.rs
+++ b/crates/bastion/src/ee.rs
@@ -97,4 +97,19 @@ impl EeClient {
             })
             .unwrap_or_default())
     }
+
+    /// `{"method":"attest","report_data_b64":"..."}` — TDX quote with
+    /// caller-supplied REPORT_DATA. Used by `/attest` to bind the
+    /// Noise static pubkey into the quote (Phase 2d). `data_b64` must
+    /// base64-decode to ≤64 bytes; EE rejects longer.
+    pub async fn attest_with_report_data(
+        &self,
+        data_b64: &str,
+    ) -> std::io::Result<serde_json::Value> {
+        self.call(serde_json::json!({
+            "method": "attest",
+            "report_data_b64": data_b64,
+        }))
+        .await
+    }
 }

--- a/crates/bastion/src/lib.rs
+++ b/crates/bastion/src/lib.rs
@@ -48,6 +48,12 @@ pub mod capture;
 pub mod ee;
 pub mod ee_sync;
 
+/// Re-export so `bastion::noise::NoiseStatic` + `bastion::noise_tunnel::*`
+/// continue to work after the primitives moved into `dd-common` (shared
+/// with the CP / agent m2m path).
+pub use dd_common::noise_static as noise;
+pub use dd_common::noise_tunnel;
+
 use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
 use axum::extract::{Path, State};
 use axum::response::{Html, IntoResponse};
@@ -220,6 +226,19 @@ pub struct Manager {
     /// in the fleet. Absent → single-node fallback.
     cp_url: Option<Arc<str>>,
     http: reqwest::Client,
+    /// Long-term Noise static keypair. Clients fetch the pubkey
+    /// via `GET /attest` and pin it; Phase 2b runs a Noise_KK
+    /// handshake keyed by this + a client static key. Absent in
+    /// standalone dev / local-embedder mode — `/attest` then
+    /// responds 404.
+    noise: Option<Arc<noise::NoiseStatic>>,
+    /// Path to easyenclave's unix socket. When set, `/attest`
+    /// fetches a fresh TDX quote with `REPORT_DATA = sha256(noise_pubkey)`
+    /// and includes it in the response so clients can verify the
+    /// pubkey came from a genuine enclave (Phase 2d). Absent →
+    /// `/attest` still returns the pubkey, just without an
+    /// attached quote.
+    ee_socket: Option<Arc<str>>,
 }
 
 impl Default for Manager {
@@ -234,6 +253,8 @@ impl Manager {
             inner: Arc::new(RwLock::new(Default::default())),
             cp_url: None,
             http: reqwest::Client::new(),
+            noise: None,
+            ee_socket: None,
         }
     }
 
@@ -246,6 +267,27 @@ impl Manager {
         let url = url.into();
         if !url.is_empty() {
             self.cp_url = Some(Arc::from(url));
+        }
+        self
+    }
+
+    /// Attach the persistent Noise static keypair. When set, `GET
+    /// /attest` returns `{noise_pubkey_hex}` so clients can pin it
+    /// before Phase 2b's Noise_KK handshake. Absent → `/attest`
+    /// returns 404.
+    pub fn with_noise_key(mut self, key: noise::NoiseStatic) -> Self {
+        self.noise = Some(Arc::new(key));
+        self
+    }
+
+    /// Point at easyenclave's unix socket so `/attest` can return a
+    /// TDX quote with `REPORT_DATA = sha256(noise_pubkey)`. Clients
+    /// / auditors use this to verify the advertised pubkey came from
+    /// a genuine enclave rather than a MITM serving its own key.
+    pub fn with_ee_socket(mut self, path: impl Into<String>) -> Self {
+        let p = path.into();
+        if !p.is_empty() {
+            self.ee_socket = Some(Arc::from(p));
         }
         self
     }
@@ -760,11 +802,94 @@ pub fn router(manager: Manager) -> Router {
 
     Router::new()
         .route("/", get(page))
+        .route("/attest", get(attest))
         .route("/api/sessions", get(list_sessions).post(create_session))
         .route("/api/sessions/{id}", delete(kill_session))
         .route("/ws/{id}", get(ws_upgrade))
+        .route("/noise/ws", get(noise_ws_upgrade))
+        .route("/noise/shell/{id}", get(noise_shell_upgrade))
         .layer(cors)
         .with_state(manager)
+}
+
+/// GET /attest — returns this bastion's long-term Noise static
+/// pubkey. Clients pin the returned `noise_pubkey_hex` and use it
+/// as the responder key for the Noise_IK handshake.
+///
+/// When an easyenclave socket is configured (`with_ee_socket`), the
+/// response also carries a TDX attestation quote whose REPORT_DATA
+/// is `sha256(noise_pubkey)`. Clients / auditors submit the quote
+/// to Intel Trust Authority; a successful verify proves the advertised
+/// pubkey came from a genuinely-measured enclave rather than a MITM
+/// serving its own key. Quote mint failures don't fail the endpoint
+/// — the pubkey is still useful for transport encryption even without
+/// the attestation, and callers can retry.
+///
+/// 404 when no Noise keypair is configured (standalone dev,
+/// embedders that didn't call `Manager::with_noise_key`).
+async fn attest(State(m): State<Manager>) -> impl IntoResponse {
+    let Some(key) = m.noise.as_ref() else {
+        return (
+            axum::http::StatusCode::NOT_FOUND,
+            Json(serde_json::json!({
+                "error": "noise key not configured"
+            })),
+        )
+            .into_response();
+    };
+
+    // Bind sha256(pubkey) into the TDX quote's REPORT_DATA. SHA-256
+    // is 32 bytes; EE pads to 64 internally. Client verifies by
+    // re-hashing the cached pubkey and comparing against the quote's
+    // REPORT_DATA field after ITA verification.
+    let quote = attach_noise_quote(&m, key.public().as_bytes()).await;
+
+    let mut body = serde_json::json!({
+        "noise_pubkey_hex": key.public_hex(),
+        "source": format!("{:?}", key.source()).to_lowercase(),
+    });
+    if let Some((quote_b64, report_data_b64)) = quote {
+        body["tdx_quote_b64"] = serde_json::Value::String(quote_b64);
+        body["report_data_b64"] = serde_json::Value::String(report_data_b64);
+    }
+    Json(body).into_response()
+}
+
+/// Mint a TDX quote binding `sha256(noise_pubkey)` into REPORT_DATA.
+/// Returns `(quote_b64, report_data_b64)` on success, or `None` if no
+/// EE socket is configured or the socket call failed — the caller
+/// downgrades gracefully by omitting the fields from the response.
+async fn attach_noise_quote(m: &Manager, pubkey_bytes: &[u8]) -> Option<(String, String)> {
+    let ee_path = m.ee_socket.as_ref()?;
+    // SHA-256 over the raw 32-byte pubkey. Domain separation isn't
+    // needed: REPORT_DATA is scoped to this bastion's quote and the
+    // client verifies both halves against the same pubkey.
+    let digest = {
+        use sha2::{Digest, Sha256};
+        let mut h = Sha256::new();
+        h.update(pubkey_bytes);
+        let d = h.finalize();
+        let mut out = [0u8; 32];
+        out.copy_from_slice(&d);
+        out
+    };
+    use base64::Engine as _;
+    let report_data_b64 = base64::engine::general_purpose::STANDARD.encode(digest);
+    let ee = crate::ee::EeClient::new(ee_path.as_ref());
+    match ee.attest_with_report_data(&report_data_b64).await {
+        Ok(v) if v.get("ok").and_then(|b| b.as_bool()) == Some(true) => {
+            let q = v.get("quote_b64")?.as_str()?.to_string();
+            Some((q, report_data_b64))
+        }
+        Ok(v) => {
+            eprintln!("bastion: /attest EE said {v}");
+            None
+        }
+        Err(e) => {
+            eprintln!("bastion: /attest EE error: {e}");
+            None
+        }
+    }
 }
 
 async fn page(State(m): State<Manager>) -> impl IntoResponse {
@@ -1024,6 +1149,493 @@ async fn ws_loop(mut socket: WebSocket, id: String, m: Manager) {
         _ = inbound => {},
         _ = outbound => {},
     }
+}
+
+// ---------------------------------------------------------------------
+// /noise/shell/{id} — Noise_IK-tunneled PTY streaming
+//
+// Mirrors `/ws/{id}` but every frame rides inside a Noise_IK
+// transport. Inside the encrypted tunnel we use a 1-byte type tag so
+// we don't pay base64 overhead on the high-volume stdout stream:
+//   0x01 <bytes>      — raw PTY data (stdin client→server or
+//                       stdout server→client)
+//   0x02 <json-bytes> — control frame (resize/hello/block/exit/...)
+// ---------------------------------------------------------------------
+
+const NOISE_FRAME_RAW: u8 = 0x01;
+const NOISE_FRAME_CTRL: u8 = 0x02;
+
+async fn noise_shell_upgrade(
+    ws: WebSocketUpgrade,
+    Path(id): Path<String>,
+    State(m): State<Manager>,
+) -> impl IntoResponse {
+    ws.on_upgrade(move |socket| noise_shell_loop(socket, id, m))
+}
+
+async fn noise_shell_loop(mut socket: WebSocket, id: String, m: Manager) {
+    use futures_util::StreamExt;
+
+    let Some(noise_key) = m.noise.clone() else {
+        let _ = socket
+            .send(Message::Text(
+                r#"{"error":"noise_not_configured"}"#.to_string().into(),
+            ))
+            .await;
+        return;
+    };
+
+    // Drive the IK handshake first. Same dance as /noise/ws.
+    let mut responder = match noise_tunnel::Responder::new(noise_key.secret_bytes()) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("bastion/noise-shell: responder init: {e}");
+            return;
+        }
+    };
+    let msg1 = match socket.recv().await {
+        Some(Ok(Message::Binary(b))) => b,
+        other => {
+            eprintln!("bastion/noise-shell: expected binary msg1, got {other:?}");
+            return;
+        }
+    };
+    if let Err(e) = responder.read_msg1(&msg1) {
+        eprintln!("bastion/noise-shell: msg1 read: {e}");
+        return;
+    }
+    let peer_pub = responder
+        .peer_pubkey()
+        .map(|p| format!("{}…", &crate::noise::hex_encode(&p)[..16]))
+        .unwrap_or_else(|| "?".into());
+    let msg2 = match responder.write_msg2(&[]) {
+        Ok(b) => b,
+        Err(e) => {
+            eprintln!("bastion/noise-shell: msg2 write: {e}");
+            return;
+        }
+    };
+    if socket.send(Message::Binary(msg2.into())).await.is_err() {
+        return;
+    }
+    let transport = match responder.into_transport() {
+        Ok(t) => t,
+        Err(e) => {
+            eprintln!("bastion/noise-shell: transport xition: {e}");
+            return;
+        }
+    };
+    eprintln!("bastion/noise-shell: tunnel up for session {id} (peer={peer_pub})");
+
+    // Wrap the transport + split socket eagerly so the not-found and
+    // replay paths use the same Arc<Mutex> dispatch as the hot loops.
+    let transport = Arc::new(Mutex::new(transport));
+    let (sink, mut stream) = socket.split();
+    let sink = Arc::new(Mutex::new(sink));
+
+    let Some(session) = m.get(&id).await else {
+        noise_send_ctrl(
+            &sink,
+            &transport,
+            &serde_json::json!({"type":"error","code":"not_found"}),
+        )
+        .await;
+        return;
+    };
+
+    // Replay: current ring + blocks + ready, same as ws_loop but
+    // through the encrypted channel.
+    {
+        let ring_bytes: Vec<u8> = session.ring.lock().await.iter().copied().collect();
+        if !ring_bytes.is_empty() {
+            noise_send_raw(&sink, &transport, &ring_bytes).await;
+        }
+        let blocks = session.blocks.read().await;
+        for b in blocks.iter() {
+            noise_send_ctrl(
+                &sink,
+                &transport,
+                &serde_json::json!({
+                    "type": "block",
+                    "session_id": b.session_id,
+                    "kind": b.kind,
+                    "seq": b.seq,
+                    "started_at_ms": b.started_at_ms,
+                    "ended_at_ms": b.ended_at_ms,
+                    "command": b.command,
+                    "output_b64": b.output_b64,
+                    "exit_code": b.exit_code,
+                }),
+            )
+            .await;
+        }
+        let seq = *session.next_seq.lock().await;
+        noise_send_ctrl(
+            &sink,
+            &transport,
+            &serde_json::json!({"type":"ready","seq":seq}),
+        )
+        .await;
+    }
+
+    let mut rx = session.tx.subscribe();
+    let writer = session.writer.clone();
+    let master = session.master.clone();
+    let transport_in = transport.clone();
+
+    let inbound = async move {
+        while let Some(Ok(msg)) = stream.next().await {
+            let Message::Binary(cipher) = msg else {
+                if matches!(msg, Message::Close(_)) {
+                    break;
+                }
+                // Plaintext text frames are invalid once the tunnel
+                // is up; drop them.
+                continue;
+            };
+            let plain = {
+                let mut t = transport_in.lock().await;
+                match t.recv(&cipher) {
+                    Ok(p) => p,
+                    Err(e) => {
+                        eprintln!("bastion/noise-shell: decrypt: {e}");
+                        break;
+                    }
+                }
+            };
+            if plain.is_empty() {
+                continue;
+            }
+            match plain[0] {
+                NOISE_FRAME_RAW => {
+                    let Some(w) = writer.clone() else { continue };
+                    let bytes = plain[1..].to_vec();
+                    let _ = tokio::task::spawn_blocking(move || {
+                        let mut g = w.blocking_lock();
+                        let _ = g.write_all(&bytes);
+                    })
+                    .await;
+                }
+                NOISE_FRAME_CTRL => {
+                    let Ok(msg) = serde_json::from_slice::<ClientMsg>(&plain[1..]) else {
+                        continue;
+                    };
+                    match msg {
+                        ClientMsg::Resize(r) => {
+                            let Some(m) = master.as_ref() else { continue };
+                            let g = m.lock().await;
+                            let _ = g.resize(PtySize {
+                                rows: r.rows.max(4),
+                                cols: r.cols.max(8),
+                                pixel_width: 0,
+                                pixel_height: 0,
+                            });
+                        }
+                        ClientMsg::Hello(_) => {}
+                    }
+                }
+                _ => {} // Unknown frame type — ignore.
+            }
+        }
+    };
+
+    let sink_out = sink.clone();
+    let transport_out = transport.clone();
+    let outbound = async move {
+        loop {
+            let ev = match rx.recv().await {
+                Ok(e) => e,
+                Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                Err(_) => break,
+            };
+            let ok = match ev {
+                Event::Raw(bytes) => noise_send_raw(&sink_out, &transport_out, &bytes).await,
+                Event::Block(b) => {
+                    noise_send_ctrl(
+                        &sink_out,
+                        &transport_out,
+                        &serde_json::json!({
+                            "type": "block",
+                            "session_id": b.session_id,
+                            "kind": b.kind,
+                            "seq": b.seq,
+                            "started_at_ms": b.started_at_ms,
+                            "ended_at_ms": b.ended_at_ms,
+                            "command": b.command,
+                            "output_b64": b.output_b64,
+                            "exit_code": b.exit_code,
+                        }),
+                    )
+                    .await
+                }
+                Event::Exit(code) => {
+                    noise_send_ctrl(
+                        &sink_out,
+                        &transport_out,
+                        &serde_json::json!({"type":"exit","code":code}),
+                    )
+                    .await;
+                    false
+                }
+            };
+            if !ok {
+                break;
+            }
+        }
+    };
+
+    tokio::select! {
+        _ = inbound => {},
+        _ = outbound => {},
+    }
+}
+
+/// Encrypt + send a raw-bytes frame (PTY stdout). Returns `false` if
+/// the sink has died so the caller can break its loop.
+async fn noise_send_raw(
+    sink: &Arc<Mutex<futures_util::stream::SplitSink<WebSocket, Message>>>,
+    transport: &Arc<Mutex<noise_tunnel::Transport>>,
+    bytes: &[u8],
+) -> bool {
+    let mut framed = Vec::with_capacity(bytes.len() + 1);
+    framed.push(NOISE_FRAME_RAW);
+    framed.extend_from_slice(bytes);
+    let cipher = {
+        let mut t = transport.lock().await;
+        match t.send(&framed) {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("bastion/noise-shell: encrypt raw: {e}");
+                return false;
+            }
+        }
+    };
+    use futures_util::SinkExt;
+    let mut s = sink.lock().await;
+    s.send(Message::Binary(cipher.into())).await.is_ok()
+}
+
+/// Encrypt + send a JSON control frame (block, exit, ready, ...).
+async fn noise_send_ctrl(
+    sink: &Arc<Mutex<futures_util::stream::SplitSink<WebSocket, Message>>>,
+    transport: &Arc<Mutex<noise_tunnel::Transport>>,
+    payload: &serde_json::Value,
+) -> bool {
+    let Ok(json) = serde_json::to_vec(payload) else {
+        return false;
+    };
+    let mut framed = Vec::with_capacity(json.len() + 1);
+    framed.push(NOISE_FRAME_CTRL);
+    framed.extend_from_slice(&json);
+    let cipher = {
+        let mut t = transport.lock().await;
+        match t.send(&framed) {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("bastion/noise-shell: encrypt ctrl: {e}");
+                return false;
+            }
+        }
+    };
+    use futures_util::SinkExt;
+    let mut s = sink.lock().await;
+    s.send(Message::Binary(cipher.into())).await.is_ok()
+}
+
+// ---------------------------------------------------------------------
+// /noise/ws — Noise_IK-tunneled JSON RPC
+// ---------------------------------------------------------------------
+
+/// JSON-over-Noise request/response envelope. Every request carries an
+/// `id` so the client can correlate responses on a single multiplexed
+/// tunnel. `op` discriminates the call; payload fields are flattened.
+///
+/// Phase 2b scope: `sessions.list` / `sessions.create` / `sessions.delete`
+/// only. Phase 2c will add `shell.open` / `shell.input` / `shell.resize`
+/// for tunneling the terminal WS body.
+#[derive(Debug, Deserialize)]
+struct NoiseReq {
+    id: u64,
+    #[serde(flatten)]
+    body: NoiseReqBody,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "op", rename_all = "snake_case")]
+enum NoiseReqBody {
+    SessionsList,
+    SessionsCreate {
+        title: Option<String>,
+    },
+    SessionsDelete {
+        session_id: String,
+    },
+    /// Heartbeat — response echoes the current server time. Lets the
+    /// client tell "tunnel alive" from "app hung."
+    Ping,
+}
+
+#[derive(Debug, Serialize)]
+struct NoiseResp {
+    id: u64,
+    #[serde(flatten)]
+    body: NoiseRespBody,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+enum NoiseRespBody {
+    /// Named `sessions` field so serde's `#[serde(tag)]` internal-
+    /// tagging works (it can't internally-tag a bare `Vec`).
+    Sessions {
+        sessions: Vec<SessionInfo>,
+    },
+    Session {
+        session: SessionInfo,
+    },
+    Ok,
+    Err {
+        msg: String,
+    },
+    Pong {
+        server_time_ms: u64,
+    },
+}
+
+async fn noise_ws_upgrade(ws: WebSocketUpgrade, State(m): State<Manager>) -> impl IntoResponse {
+    ws.on_upgrade(move |socket| noise_ws_loop(socket, m))
+}
+
+async fn noise_ws_loop(mut socket: WebSocket, m: Manager) {
+    let Some(noise_key) = m.noise.clone() else {
+        // No server key configured. Close with an unencrypted text
+        // frame so the client can log a sensible error rather than
+        // staring at a silent drop.
+        let _ = socket
+            .send(Message::Text(
+                r#"{"error":"noise_not_configured"}"#.to_string().into(),
+            ))
+            .await;
+        return;
+    };
+
+    // Drive the IK handshake first. Client sends msg1, server
+    // responds with msg2, both enter transport mode.
+    let mut responder = match noise_tunnel::Responder::new(noise_key.secret_bytes()) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("bastion/noise: responder init: {e}");
+            return;
+        }
+    };
+
+    let msg1 = match socket.recv().await {
+        Some(Ok(Message::Binary(b))) => b,
+        other => {
+            eprintln!("bastion/noise: expected binary msg1, got {other:?}");
+            return;
+        }
+    };
+    if let Err(e) = responder.read_msg1(&msg1) {
+        eprintln!("bastion/noise: msg1 read: {e}");
+        return;
+    }
+    let peer_pub = responder
+        .peer_pubkey()
+        .map(|p| format!("{}…", &crate::noise::hex_encode(&p)[..16]))
+        .unwrap_or_else(|| "?".into());
+    let msg2 = match responder.write_msg2(&[]) {
+        Ok(b) => b,
+        Err(e) => {
+            eprintln!("bastion/noise: msg2 write: {e}");
+            return;
+        }
+    };
+    if socket.send(Message::Binary(msg2.into())).await.is_err() {
+        return;
+    }
+    let mut transport = match responder.into_transport() {
+        Ok(t) => t,
+        Err(e) => {
+            eprintln!("bastion/noise: transport xition: {e}");
+            return;
+        }
+    };
+    eprintln!("bastion/noise: tunnel up (peer={peer_pub})");
+
+    // Serve requests on the encrypted stream. Each inbound binary
+    // frame is one decrypted JSON `NoiseReq`; response is one frame.
+    while let Some(frame) = socket.recv().await {
+        let Ok(Message::Binary(cipher)) = frame else {
+            continue;
+        };
+        let plain = match transport.recv(&cipher) {
+            Ok(p) => p,
+            Err(e) => {
+                eprintln!("bastion/noise: decrypt: {e}");
+                break;
+            }
+        };
+        let resp = dispatch_noise_req(&m, &plain).await;
+        let resp_bytes = match serde_json::to_vec(&resp) {
+            Ok(b) => b,
+            Err(e) => {
+                eprintln!("bastion/noise: encode resp: {e}");
+                break;
+            }
+        };
+        let ct = match transport.send(&resp_bytes) {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("bastion/noise: encrypt: {e}");
+                break;
+            }
+        };
+        if socket.send(Message::Binary(ct.into())).await.is_err() {
+            break;
+        }
+    }
+}
+
+async fn dispatch_noise_req(m: &Manager, plain: &[u8]) -> NoiseResp {
+    let req: NoiseReq = match serde_json::from_slice(plain) {
+        Ok(r) => r,
+        Err(e) => {
+            return NoiseResp {
+                id: 0,
+                body: NoiseRespBody::Err {
+                    msg: format!("bad request: {e}"),
+                },
+            };
+        }
+    };
+    let body = match req.body {
+        NoiseReqBody::SessionsList => NoiseRespBody::Sessions {
+            sessions: m.list().await,
+        },
+        NoiseReqBody::SessionsCreate { title } => {
+            let t = title.unwrap_or_else(|| "shell".to_string());
+            match m.create(t).await {
+                Ok(s) => NoiseRespBody::Session { session: s.info() },
+                Err(e) => NoiseRespBody::Err {
+                    msg: format!("create: {e}"),
+                },
+            }
+        }
+        NoiseReqBody::SessionsDelete { session_id } => {
+            if m.remove(&session_id).await {
+                NoiseRespBody::Ok
+            } else {
+                NoiseRespBody::Err {
+                    msg: "not_found".to_string(),
+                }
+            }
+        }
+        NoiseReqBody::Ping => NoiseRespBody::Pong {
+            server_time_ms: now_ms(),
+        },
+    };
+    NoiseResp { id: req.id, body }
 }
 
 // ---------------------------------------------------------------------

--- a/crates/bastion/web/package-lock.json
+++ b/crates/bastion/web/package-lock.json
@@ -8,6 +8,9 @@
       "name": "bastion-web",
       "version": "0.1.0",
       "dependencies": {
+        "@noble/ciphers": "^2.2.0",
+        "@noble/curves": "^2.2.0",
+        "@noble/hashes": "^2.2.0",
         "@xterm/addon-fit": "^0.10.0",
         "@xterm/xterm": "^5.5.0"
       },
@@ -19,7 +22,8 @@
         "tslib": "^2.8.1",
         "typescript": "^5.7.3",
         "vite": "^6.0.11",
-        "vite-plugin-singlefile": "^2.1.0"
+        "vite-plugin-singlefile": "^2.1.0",
+        "vitest": "^4.1.5"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -514,6 +518,45 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@noble/ciphers": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-2.2.0.tgz",
+      "integrity": "sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
+      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.2.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.60.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
@@ -864,6 +907,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@sveltejs/acorn-typescript": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.9.tgz",
@@ -921,6 +971,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -934,6 +1002,119 @@
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.5",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.5",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
     },
     "node_modules/@xterm/addon-fit": {
       "version": "0.10.0",
@@ -973,6 +1154,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/axobject-query": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
@@ -994,6 +1185,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chokidar": {
@@ -1021,6 +1222,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -1054,6 +1262,13 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.7.1.tgz",
       "integrity": "sha512-MUbZ586EgQqdRnC4yDrlod3BEdyvE4TapGYHMW2CiaW+KkkFmWEFqBUaLltEZCGi0iFXCEjRF0OjF0DV2QHjOA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
       "dev": true,
       "license": "MIT"
     },
@@ -1122,6 +1337,26 @@
         "@typescript-eslint/types": {
           "optional": true
         }
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fdir": {
@@ -1280,6 +1515,24 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -1401,6 +1654,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1410,6 +1670,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/svelte": {
       "version": "5.55.4",
@@ -1463,6 +1737,23 @@
         "typescript": ">=5.0.0"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -1478,6 +1769,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -1629,6 +1930,113 @@
         "vite": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/zimmerframe": {

--- a/crates/bastion/web/package.json
+++ b/crates/bastion/web/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "check": "svelte-check --tsconfig ./tsconfig.json",
+    "test": "vitest run",
     "preview": "vite preview"
   },
   "devDependencies": {
@@ -17,9 +18,13 @@
     "tslib": "^2.8.1",
     "typescript": "^5.7.3",
     "vite": "^6.0.11",
-    "vite-plugin-singlefile": "^2.1.0"
+    "vite-plugin-singlefile": "^2.1.0",
+    "vitest": "^4.1.5"
   },
   "dependencies": {
+    "@noble/ciphers": "^2.2.0",
+    "@noble/curves": "^2.2.0",
+    "@noble/hashes": "^2.2.0",
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/xterm": "^5.5.0"
   }

--- a/crates/bastion/web/src/connectors.ts
+++ b/crates/bastion/web/src/connectors.ts
@@ -122,3 +122,47 @@ export async function addDdEnclave(
   await addConnector(c);
   return c;
 }
+
+/// Fetch a DD enclave's long-term Noise pubkey via `GET /attest`.
+/// Returns `null` on any error (cross-origin CF-Access bounce,
+/// connector offline, server missing `--noise-key`). Phase 2b uses
+/// the returned pubkey as the responder static for the Noise_KK
+/// handshake; Phase 2d adds a TDX quote to the same response that
+/// binds the pubkey into `REPORT_DATA` so clients can verify.
+export async function fetchAttest(
+  origin: string,
+): Promise<{ noise_pubkey_hex: string; source: string } | null> {
+  try {
+    const resp = await fetch(`${origin}/attest`, { credentials: "include" });
+    if (!resp.ok) return null;
+    const body = await resp.json();
+    if (typeof body?.noise_pubkey_hex !== "string") return null;
+    return {
+      noise_pubkey_hex: body.noise_pubkey_hex,
+      source: typeof body?.source === "string" ? body.source : "unknown",
+    };
+  } catch {
+    return null;
+  }
+}
+
+/// Merge `patch` into an existing connector's `config` and persist.
+/// Used by the attest cache to remember server Noise pubkeys across
+/// page loads. Silent no-op if the connector isn't in IDB.
+export async function patchConnectorConfig(
+  id: string,
+  patch: Record<string, unknown>,
+): Promise<void> {
+  const db = await openDb();
+  const existing: Connector | undefined = await new Promise(
+    (resolve, reject) => {
+      const tx = db.transaction(DB_STORE, "readonly");
+      const req = tx.objectStore(DB_STORE).get(id);
+      req.onsuccess = () => resolve(req.result as Connector | undefined);
+      req.onerror = () => reject(req.error);
+    },
+  );
+  if (!existing) return;
+  existing.config = { ...existing.config, ...patch };
+  await addConnector(existing);
+}

--- a/crates/bastion/web/src/lib/TerminalPane.svelte
+++ b/crates/bastion/web/src/lib/TerminalPane.svelte
@@ -4,6 +4,7 @@
   import { FitAddon } from "@xterm/addon-fit";
   import type { BlockRecord } from "../types";
   import { ui } from "../ui.svelte";
+  import { openShellTunnel } from "../tunnel";
 
   interface Props {
     rowId: string;
@@ -44,7 +45,17 @@
     // the real dimensions.
     fit!.fit();
 
-    if (!row.ws || row.ws.readyState >= WebSocket.CLOSING) {
+    // Open the shell stream if we haven't already. Prefer the Noise
+    // tunnel when the connector has a cached server pubkey (cross-
+    // origin enclaves); fall back to plain /ws/{id} for same-origin.
+    const pubkey = row.connector.config.serverNoisePubkeyHex as
+      | string
+      | undefined;
+    const noiseWanted =
+      pubkey && row.origin.replace(/\/+$/, "") !== location.origin;
+    if (noiseWanted) {
+      if (!row.shell) openNoiseShell();
+    } else if (!row.ws || row.ws.readyState >= WebSocket.CLOSING) {
       openWs();
     }
 
@@ -122,6 +133,59 @@
       if (ws.readyState === WebSocket.OPEN) {
         ws.send(JSON.stringify({ type: "resize", cols, rows }));
       }
+    });
+  }
+
+  async function openNoiseShell() {
+    const row = ui.rows.get(rowId);
+    if (!row) return;
+    const term = row.term!;
+    const pubkey = row.connector.config.serverNoisePubkeyHex as
+      | string
+      | undefined;
+    if (!pubkey) return;
+
+    let shell;
+    try {
+      shell = await openShellTunnel(row.origin, pubkey, row.info.id);
+    } catch (e) {
+      console.warn(`noise-shell: open ${row.origin}/${row.info.id}`, e);
+      // Hard fail here — falling back to plain /ws would re-trigger
+      // the CORS/CF-Access wall we set up Noise to bypass.
+      term.writeln(`\r\n\x1b[2m[tunnel unavailable]\x1b[0m`);
+      return;
+    }
+    row.shell = shell;
+
+    shell.onCtrl((msg) => {
+      if (msg.type === "block") {
+        const b = msg as unknown as BlockRecord;
+        if (!row.blocks.some((x) => x.seq === b.seq)) {
+          row.blocks = [...row.blocks, b];
+        }
+      } else if (msg.type === "exit") {
+        term.writeln(`\r\n\x1b[2m[exited ${msg.code}]\x1b[0m`);
+      } else if (msg.type === "error" && msg.code === "not_found") {
+        term.writeln(`\r\n\x1b[2m[session not found]\x1b[0m`);
+      }
+    });
+    shell.onRaw((bytes) => {
+      term.write(bytes);
+    });
+
+    shell.sendCtrl({
+      type: "hello",
+      have_up_to: row.blocks.length
+        ? row.blocks[row.blocks.length - 1].seq
+        : -1,
+    });
+    shell.sendCtrl({ type: "resize", cols: term.cols, rows: term.rows });
+
+    term.onData((d) => {
+      shell.sendRaw(new TextEncoder().encode(d));
+    });
+    term.onResize(({ cols, rows }) => {
+      shell.sendCtrl({ type: "resize", cols, rows });
     });
   }
 </script>

--- a/crates/bastion/web/src/noise.test.ts
+++ b/crates/bastion/web/src/noise.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import {
+  IkInitiator,
+  IkResponder,
+  Transport,
+  keypairFromSeed,
+  randomKeypair,
+  equal,
+} from "./noise";
+
+describe("Noise_IK TS round-trip", () => {
+  it("initiator ↔ responder hand a payload both ways", () => {
+    const server = randomKeypair();
+    const client = randomKeypair();
+
+    const responder = new IkResponder(server);
+    const initiator = new IkInitiator(client, server.publicKey);
+
+    const msg1 = initiator.writeMessage(new TextEncoder().encode("hello"));
+    const seenByServer = responder.readMessage(msg1);
+    expect(new TextDecoder().decode(seenByServer)).toBe("hello");
+
+    const msg2Out = responder.writeMessage(new TextEncoder().encode("hi"));
+    expect(equal(msg2Out.peerPubkey, client.publicKey)).toBe(true);
+
+    const msg2In = initiator.readMessage(msg2Out.bytes);
+    expect(new TextDecoder().decode(msg2In.payload)).toBe("hi");
+
+    // Transport mode: bidirectional.
+    const clientTx = new Transport(msg2In.send, msg2In.recv, server.publicKey);
+    const serverTx = new Transport(msg2Out.send, msg2Out.recv, client.publicKey);
+
+    const c1 = clientTx.send(new TextEncoder().encode("ping one"));
+    expect(new TextDecoder().decode(serverTx.recv(c1))).toBe("ping one");
+    const c2 = clientTx.send(new TextEncoder().encode("ping two"));
+    expect(new TextDecoder().decode(serverTx.recv(c2))).toBe("ping two");
+
+    const s1 = serverTx.send(new TextEncoder().encode("pong"));
+    expect(new TextDecoder().decode(clientTx.recv(s1))).toBe("pong");
+  });
+
+  it("a wrong server pubkey fails at decrypt of the static", () => {
+    const server = randomKeypair();
+    const other = randomKeypair();
+    const client = randomKeypair();
+
+    const responder = new IkResponder(server);
+    // Initiator points at a different server's static → `es` DH
+    // yields the wrong key, so `decryptAndHash(s_ct)` AEAD fails.
+    const initiator = new IkInitiator(client, other.publicKey);
+    const msg1 = initiator.writeMessage(new Uint8Array(0));
+    expect(() => responder.readMessage(msg1)).toThrow();
+  });
+
+  it("tampered transport ciphertext is rejected", () => {
+    const server = randomKeypair();
+    const client = randomKeypair();
+    const responder = new IkResponder(server);
+    const initiator = new IkInitiator(client, server.publicKey);
+    const msg1 = initiator.writeMessage(new Uint8Array(0));
+    responder.readMessage(msg1);
+    const msg2Out = responder.writeMessage(new Uint8Array(0));
+    const msg2In = initiator.readMessage(msg2Out.bytes);
+
+    const clientTx = new Transport(msg2In.send, msg2In.recv, server.publicKey);
+    const serverTx = new Transport(msg2Out.send, msg2Out.recv, client.publicKey);
+
+    const frame = clientTx.send(new TextEncoder().encode("payload"));
+    frame[0] ^= 0x01;
+    expect(() => serverTx.recv(frame)).toThrow();
+  });
+
+  it("keypairFromSeed is deterministic", () => {
+    const seed = new Uint8Array(32).fill(7);
+    const a = keypairFromSeed(seed);
+    const b = keypairFromSeed(seed);
+    expect(equal(a.publicKey, b.publicKey)).toBe(true);
+    expect(equal(a.secretKey, b.secretKey)).toBe(true);
+    expect(a.publicKey.length).toBe(32);
+  });
+
+  it("different seeds produce different keys", () => {
+    const a = keypairFromSeed(new Uint8Array(32).fill(1));
+    const b = keypairFromSeed(new Uint8Array(32).fill(2));
+    expect(equal(a.publicKey, b.publicKey)).toBe(false);
+  });
+});

--- a/crates/bastion/web/src/noise.ts
+++ b/crates/bastion/web/src/noise.ts
@@ -1,0 +1,416 @@
+/**
+ * Noise_IK_25519_ChaChaPoly_SHA256 — initiator state machine.
+ *
+ * Browser-side counterpart to the Rust responder in
+ * `crates/dd-common/src/noise_tunnel.rs`. Small hand-rolled
+ * implementation of §5 of the Noise Protocol spec, pattern IK only.
+ *
+ * Why hand-rolled: the two popular npm packages (`noise-protocol`,
+ * `noise-handshake`) both pull `sodium-universal` + `libsodium.js`
+ * into the bundle. Building on `@noble/*` primitives keeps the SPA
+ * payload ~40 KB instead of ~250 KB and avoids a wasm runtime.
+ *
+ * Spec references are to
+ * https://noiseprotocol.org/noise.html rev-34.
+ */
+
+import { x25519 } from "@noble/curves/ed25519.js";
+import { chacha20poly1305 } from "@noble/ciphers/chacha.js";
+import { sha256 } from "@noble/hashes/sha2.js";
+import { hmac } from "@noble/hashes/hmac.js";
+
+const PROTOCOL_NAME = "Noise_IK_25519_ChaChaPoly_SHA256";
+const HASHLEN = 32;
+const DHLEN = 32;
+
+/// Concatenate two byte arrays into a new one. Explicitly-typed
+/// return so TS 5.7's stricter `Uint8Array<ArrayBuffer>` inference
+/// doesn't downgrade callers to `Uint8Array<ArrayBufferLike>`.
+function concat(a: Uint8Array, b: Uint8Array): Uint8Array<ArrayBuffer> {
+  const out = new Uint8Array(a.length + b.length);
+  out.set(a, 0);
+  out.set(b, a.length);
+  return out;
+}
+
+function equal(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) diff |= a[i] ^ b[i];
+  return diff === 0;
+}
+
+/// 12-byte ChaCha20-Poly1305 nonce per §5.2: 4 zero bytes followed by
+/// the 64-bit counter in little-endian order.
+function nonce12(n: bigint): Uint8Array {
+  const out = new Uint8Array(12);
+  const view = new DataView(out.buffer);
+  // First 4 bytes stay zero.
+  view.setBigUint64(4, n, true);
+  return out;
+}
+
+/// HKDF-with-HMAC-SHA256 as the Noise spec defines it — returns 1, 2,
+/// or 3 32-byte outputs depending on `num_outputs`.
+function hkdf(
+  chainingKey: Uint8Array,
+  inputKeyMaterial: Uint8Array,
+  numOutputs: 1 | 2 | 3,
+): Uint8Array[] {
+  const tempKey = hmac(sha256, chainingKey, inputKeyMaterial);
+  const out1 = hmac(sha256, tempKey, new Uint8Array([0x01]));
+  if (numOutputs === 1) return [out1];
+  const out2 = hmac(sha256, tempKey, concat(out1, new Uint8Array([0x02])));
+  if (numOutputs === 2) return [out1, out2];
+  const out3 = hmac(sha256, tempKey, concat(out2, new Uint8Array([0x03])));
+  return [out1, out2, out3];
+}
+
+/**
+ * CipherState — §5.1. Wraps a 32-byte key and a 64-bit counter.
+ * Nonce overflow (after 2^64-1 messages) is fatal per spec. The
+ * `hasKey` gating mirrors the spec's `k == empty` sentinel.
+ */
+class CipherState {
+  k: Uint8Array | null = null;
+  n: bigint = 0n;
+
+  initializeKey(k: Uint8Array | null): void {
+    this.k = k;
+    this.n = 0n;
+  }
+
+  hasKey(): boolean {
+    return this.k !== null;
+  }
+
+  encryptWithAd(ad: Uint8Array, plaintext: Uint8Array): Uint8Array {
+    if (!this.k) return plaintext;
+    // @noble/ciphers factory takes AAD as the 3rd arg (not `encrypt`).
+    const cipher = chacha20poly1305(this.k, nonce12(this.n), ad);
+    const ct = cipher.encrypt(plaintext);
+    this.n += 1n;
+    return ct;
+  }
+
+  decryptWithAd(ad: Uint8Array, ciphertext: Uint8Array): Uint8Array {
+    if (!this.k) return ciphertext;
+    const cipher = chacha20poly1305(this.k, nonce12(this.n), ad);
+    const pt = cipher.decrypt(ciphertext);
+    this.n += 1n;
+    return pt;
+  }
+}
+
+/**
+ * SymmetricState — §5.2. Owns the chaining key, transcript hash,
+ * and the currently-active CipherState. Drives the MixHash / MixKey
+ * flow that IK's message tokens translate into.
+ */
+class SymmetricState {
+  ck: Uint8Array;
+  h: Uint8Array;
+  cs: CipherState;
+
+  constructor() {
+    const name = new TextEncoder().encode(PROTOCOL_NAME);
+    // Protocol name fits in HASHLEN? §5.2: "If protocol_name is less
+    // than or equal to HASHLEN bytes in length, sets h equal to
+    // protocol_name with zero bytes appended to make HASHLEN bytes.
+    // Otherwise sets h = HASH(protocol_name)." Ours is 32 bytes on the
+    // nose, so zero-pad (no-op) and done.
+    if (name.length <= HASHLEN) {
+      this.h = new Uint8Array(HASHLEN);
+      this.h.set(name, 0);
+    } else {
+      this.h = sha256(name);
+    }
+    this.ck = new Uint8Array(this.h);
+    this.cs = new CipherState();
+  }
+
+  mixHash(data: Uint8Array): void {
+    this.h = sha256(concat(this.h, data));
+  }
+
+  mixKey(ikm: Uint8Array): void {
+    const [newCk, tempK] = hkdf(this.ck, ikm, 2);
+    this.ck = newCk;
+    this.cs.initializeKey(tempK);
+  }
+
+  encryptAndHash(plaintext: Uint8Array): Uint8Array {
+    const ct = this.cs.encryptWithAd(this.h, plaintext);
+    this.mixHash(ct);
+    return ct;
+  }
+
+  decryptAndHash(ciphertext: Uint8Array): Uint8Array {
+    const pt = this.cs.decryptWithAd(this.h, ciphertext);
+    this.mixHash(ciphertext);
+    return pt;
+  }
+
+  /// Finalize into two CipherStates per §5.2's Split(): one for each
+  /// direction. For the initiator, `c1` encrypts outbound, `c2`
+  /// decrypts inbound.
+  split(): [CipherState, CipherState] {
+    const [k1, k2] = hkdf(this.ck, new Uint8Array(0), 2);
+    const c1 = new CipherState();
+    const c2 = new CipherState();
+    c1.initializeKey(k1);
+    c2.initializeKey(k2);
+    return [c1, c2];
+  }
+}
+
+export interface Keypair {
+  secretKey: Uint8Array;
+  publicKey: Uint8Array;
+}
+
+/// Derive the client's X25519 keypair from a stable 32-byte seed.
+/// Same seed → same keypair, so the SPA's identity (stored in
+/// localStorage as `dd-identity-seed`) survives reloads.
+export function keypairFromSeed(seed: Uint8Array): Keypair {
+  if (seed.length !== 32) {
+    throw new Error(`expected 32-byte seed, got ${seed.length}`);
+  }
+  // x25519 clamps the scalar internally, so any 32 random bytes
+  // produce a valid keypair. HMAC-SHA256 the seed with a domain tag
+  // so the Noise key is distinct from anything else the seed is used
+  // to derive (device fingerprint, at-rest ciphertext key, etc.).
+  const secretKey = hmac(sha256, seed, new TextEncoder().encode("dd-noise-static-v1"));
+  const publicKey = x25519.getPublicKey(secretKey);
+  return { secretKey, publicKey };
+}
+
+/// Generate a fresh throwaway keypair — used as the handshake
+/// ephemeral `e`.
+export function randomKeypair(): Keypair {
+  const { secretKey, publicKey } = x25519.keygen();
+  return { secretKey, publicKey };
+}
+
+/**
+ * Initiator-side IK handshake driver. Pattern messages per §7.5:
+ *
+ * ```
+ * IK:
+ *   <- s
+ *   ...
+ *   -> e, es, s, ss
+ *   <- e, ee, se
+ * ```
+ *
+ * `<- s` is a pre-message: the initiator knows the responder's
+ * static pubkey up front (fetched via `GET /attest`).
+ */
+export class IkInitiator {
+  private sym: SymmetricState;
+  private s: Keypair;
+  private e: Keypair | null = null;
+  private rs: Uint8Array;
+
+  constructor(s: Keypair, rs: Uint8Array, prologue: Uint8Array = new Uint8Array(0)) {
+    if (rs.length !== DHLEN) throw new Error(`rs: expected ${DHLEN} bytes`);
+    this.sym = new SymmetricState();
+    this.sym.mixHash(prologue);
+    // `<- s` pre-message: hash the responder's static into the
+    // transcript.
+    this.sym.mixHash(rs);
+    this.s = s;
+    this.rs = rs;
+  }
+
+  /// Produce the first handshake message `-> e, es, s, ss`.
+  /// `payload` is application data carried inside the encrypted
+  /// handshake — typically empty in our deployment.
+  writeMessage(payload: Uint8Array): Uint8Array {
+    this.e = randomKeypair();
+    // -> e
+    let buf = new Uint8Array(this.e.publicKey);
+    this.sym.mixHash(this.e.publicKey);
+    // -> es
+    this.sym.mixKey(x25519.getSharedSecret(this.e.secretKey, this.rs));
+    // -> s (encrypted)
+    const sCt = this.sym.encryptAndHash(this.s.publicKey);
+    buf = concat(buf, sCt);
+    // -> ss
+    this.sym.mixKey(x25519.getSharedSecret(this.s.secretKey, this.rs));
+    // -> payload (encrypted)
+    const payloadCt = this.sym.encryptAndHash(payload);
+    return concat(buf, payloadCt);
+  }
+
+  /// Consume the responder's reply `<- e, ee, se` and finalize the
+  /// handshake. Returns the decrypted payload and the two transport
+  /// CipherStates ([send, recv] from the initiator's perspective).
+  readMessage(message: Uint8Array): {
+    payload: Uint8Array;
+    send: CipherState;
+    recv: CipherState;
+  } {
+    if (!this.e) throw new Error("readMessage before writeMessage");
+    if (message.length < DHLEN) throw new Error("msg2 too short");
+    // <- e
+    const re = message.slice(0, DHLEN);
+    this.sym.mixHash(re);
+    // <- ee
+    this.sym.mixKey(x25519.getSharedSecret(this.e.secretKey, re));
+    // <- se (initiator uses its static, responder their ephemeral)
+    this.sym.mixKey(x25519.getSharedSecret(this.s.secretKey, re));
+    // <- payload
+    const rest = message.slice(DHLEN);
+    const payload = this.sym.decryptAndHash(rest);
+    const [send, recv] = this.sym.split();
+    return { payload, send, recv };
+  }
+}
+
+/**
+ * Post-handshake transport. Wraps a pair of CipherStates and
+ * exposes a symmetric `send` / `recv` API. Matches the Rust
+ * `Transport` in `noise_tunnel.rs`.
+ */
+export class Transport {
+  constructor(
+    private send_: CipherState,
+    private recv_: CipherState,
+    readonly peerPubkey: Uint8Array,
+  ) {}
+
+  send(plaintext: Uint8Array): Uint8Array {
+    return this.send_.encryptWithAd(new Uint8Array(0), plaintext);
+  }
+
+  recv(ciphertext: Uint8Array): Uint8Array {
+    return this.recv_.decryptWithAd(new Uint8Array(0), ciphertext);
+  }
+}
+
+/**
+ * Open a Noise-tunneled WebSocket to `wssUrl`. Pins the server's
+ * long-term static key via the caller-supplied `serverPubkey` (hex
+ * decoded). Once the handshake completes, callers use `tunnel.fetch`
+ * and `tunnel.ws` as if they were same-origin HTTP/WS.
+ *
+ * Rejects with a concrete error so the sidebar can fall back to
+ * plain fetch when the origin doesn't support Noise (e.g. an older
+ * agent deployed before Phase 2b).
+ */
+export async function connectNoise(
+  wssUrl: string,
+  clientStatic: Keypair,
+  serverPubkey: Uint8Array,
+): Promise<{ socket: WebSocket; transport: Transport }> {
+  const socket = new WebSocket(wssUrl);
+  socket.binaryType = "arraybuffer";
+  await new Promise<void>((resolve, reject) => {
+    socket.addEventListener("open", () => resolve(), { once: true });
+    socket.addEventListener("error", () => reject(new Error(`ws open: ${wssUrl}`)), {
+      once: true,
+    });
+  });
+
+  const initiator = new IkInitiator(clientStatic, serverPubkey);
+  const msg1 = initiator.writeMessage(new Uint8Array(0));
+  socket.send(msg1);
+
+  const msg2 = await new Promise<Uint8Array>((resolve, reject) => {
+    socket.addEventListener(
+      "message",
+      (ev) => {
+        if (ev.data instanceof ArrayBuffer) resolve(new Uint8Array(ev.data));
+        else reject(new Error("msg2 was not binary"));
+      },
+      { once: true },
+    );
+    socket.addEventListener("error", () => reject(new Error("ws error during handshake")), {
+      once: true,
+    });
+    socket.addEventListener(
+      "close",
+      (ev) => reject(new Error(`ws closed during handshake: ${ev.code} ${ev.reason}`)),
+      { once: true },
+    );
+  });
+
+  const { send, recv } = initiator.readMessage(msg2);
+  const transport = new Transport(send, recv, serverPubkey);
+  return { socket, transport };
+}
+
+// --------------------------------------------------------------
+// Test-only exports. The build's treeshaker strips these from the
+// production bundle when nothing imports them; the unit test in
+// `noise.test.ts` is the only consumer.
+// --------------------------------------------------------------
+
+/// Responder-side IK driver — only used by the in-browser round-trip
+/// test so CI can gate on TS-TS consistency without spawning the
+/// Rust server. The real server lives in Rust / `snow`.
+export class IkResponder {
+  private sym: SymmetricState;
+  private s: Keypair;
+  private e: Keypair | null = null;
+  /// Initiator's ephemeral pubkey — learned from msg1, consumed by
+  /// msg2's `ee` + `se` DHs.
+  private re: Uint8Array | null = null;
+  /// Initiator's static pubkey — decrypted from msg1. Exposed after
+  /// the handshake so the caller can pin / authorize the peer.
+  private rs: Uint8Array | null = null;
+
+  constructor(s: Keypair, prologue: Uint8Array = new Uint8Array(0)) {
+    this.sym = new SymmetricState();
+    this.sym.mixHash(prologue);
+    // `<- s` pre-message from the responder's view: the responder's
+    // own static is pre-known.
+    this.sym.mixHash(s.publicKey);
+    this.s = s;
+  }
+
+  readMessage(message: Uint8Array): Uint8Array {
+    if (message.length < DHLEN) throw new Error("msg1 too short");
+    // <- e
+    this.re = message.slice(0, DHLEN);
+    this.sym.mixHash(this.re);
+    // <- es
+    this.sym.mixKey(x25519.getSharedSecret(this.s.secretKey, this.re));
+    // s_ct is DHLEN + 16 bytes (enc pubkey + tag)
+    const sCt = message.slice(DHLEN, DHLEN + DHLEN + 16);
+    this.rs = this.sym.decryptAndHash(sCt);
+    // <- ss
+    this.sym.mixKey(x25519.getSharedSecret(this.s.secretKey, this.rs));
+    const payloadCt = message.slice(DHLEN + DHLEN + 16);
+    const payload = this.sym.decryptAndHash(payloadCt);
+    // Mint our ephemeral for the reply.
+    this.e = randomKeypair();
+    return payload;
+  }
+
+  writeMessage(payload: Uint8Array): {
+    bytes: Uint8Array;
+    send: CipherState;
+    recv: CipherState;
+    peerPubkey: Uint8Array;
+  } {
+    if (!this.e || !this.re || !this.rs) {
+      throw new Error("writeMessage before readMessage");
+    }
+    let buf = new Uint8Array(this.e.publicKey);
+    this.sym.mixHash(this.e.publicKey);
+    // -> ee: responder ephemeral × initiator ephemeral
+    this.sym.mixKey(x25519.getSharedSecret(this.e.secretKey, this.re));
+    // -> se: responder ephemeral × initiator static
+    this.sym.mixKey(x25519.getSharedSecret(this.e.secretKey, this.rs));
+    const payloadCt = this.sym.encryptAndHash(payload);
+    buf = concat(buf, payloadCt);
+    // Split with direction swap — responder's "send" is initiator's
+    // "recv" and vice versa.
+    const [c1, c2] = this.sym.split();
+    return { bytes: buf, send: c2, recv: c1, peerPubkey: this.rs };
+  }
+}
+
+export { CipherState, SymmetricState, equal, concat };

--- a/crates/bastion/web/src/tunnel.ts
+++ b/crates/bastion/web/src/tunnel.ts
@@ -1,0 +1,261 @@
+/**
+ * Typed RPC over a Noise_IK-tunneled WebSocket.
+ *
+ * Wraps the raw `Transport` from `noise.ts` with a request/response
+ * correlator (`id` → Promise) so callers write `tunnel.sessions.list()`
+ * instead of hand-rolling the JSON envelope + encrypt + await.
+ *
+ * Matches the server-side `NoiseReq` / `NoiseResp` enums in
+ * `crates/bastion/src/lib.rs`. Phase 2b scope:
+ * `sessions.list` / `sessions.create` / `sessions.delete` / `ping`.
+ */
+
+import { connectNoise, keypairFromSeed, Transport } from "./noise";
+import { loadIdentitySeed } from "./identity";
+import type { SessionInfo } from "./types";
+
+type Resolve = (body: any) => void;
+type Reject = (err: unknown) => void;
+
+interface Pending {
+  resolve: Resolve;
+  reject: Reject;
+}
+
+/// Live Noise tunnel. Own the socket, the transport, and a
+/// `request_id → Promise<resolver>` map. Requests are fire-and-await
+/// serialized JSON; responses come back keyed by id.
+export class Tunnel {
+  private nextId = 1n;
+  private pending = new Map<bigint, Pending>();
+  private closed = false;
+
+  constructor(
+    private socket: WebSocket,
+    private transport: Transport,
+  ) {
+    socket.addEventListener("message", (ev) => this.onFrame(ev));
+    socket.addEventListener("close", () => this.onClose(new Error("tunnel closed")));
+    socket.addEventListener("error", () => this.onClose(new Error("tunnel error")));
+  }
+
+  private onFrame(ev: MessageEvent): void {
+    if (!(ev.data instanceof ArrayBuffer)) return;
+    let body: any;
+    try {
+      const plain = this.transport.recv(new Uint8Array(ev.data));
+      body = JSON.parse(new TextDecoder().decode(plain));
+    } catch (e) {
+      console.warn("tunnel: bad frame", e);
+      return;
+    }
+    const id = BigInt(body.id ?? 0);
+    const p = this.pending.get(id);
+    if (!p) return;
+    this.pending.delete(id);
+    p.resolve(body);
+  }
+
+  private onClose(err: unknown): void {
+    if (this.closed) return;
+    this.closed = true;
+    for (const p of this.pending.values()) p.reject(err);
+    this.pending.clear();
+  }
+
+  private call<T>(op: string, extra: Record<string, unknown> = {}): Promise<T> {
+    if (this.closed) return Promise.reject(new Error("tunnel closed"));
+    const id = this.nextId++;
+    const frame = { id: Number(id), op, ...extra };
+    const plain = new TextEncoder().encode(JSON.stringify(frame));
+    const cipher = this.transport.send(plain);
+    return new Promise<T>((resolve, reject) => {
+      this.pending.set(id, {
+        resolve: (body) => {
+          if (body.kind === "err") reject(new Error(body.msg));
+          else resolve(body as T);
+        },
+        reject,
+      });
+      this.socket.send(cipher);
+    });
+  }
+
+  sessionsList(): Promise<SessionInfo[]> {
+    return this.call<{ kind: "sessions"; sessions: SessionInfo[] }>("sessions_list").then(
+      // Server uses `kind` as discriminator and flattens the vec as
+      // `{kind:"sessions",sessions:[...]}` because serde's flatten +
+      // tuple variant would need a named field.
+      // Match on shape: the Rust side's `NoiseRespBody::Sessions(Vec)`
+      // serializes as `{"kind":"sessions"}` + the inner vec spread;
+      // we read it as `.sessions` if present, else as the value.
+      (body: any) => (Array.isArray(body?.sessions) ? body.sessions : []),
+    );
+  }
+
+  sessionsCreate(title?: string): Promise<SessionInfo> {
+    return this.call<any>("sessions_create", { title: title ?? null }).then((body: any) => {
+      if (body.kind !== "session") throw new Error(`unexpected resp kind: ${body.kind}`);
+      return body.session ?? body;
+    });
+  }
+
+  sessionsDelete(sessionId: string): Promise<void> {
+    return this.call<any>("sessions_delete", { session_id: sessionId }).then(() => undefined);
+  }
+
+  ping(): Promise<number> {
+    return this.call<any>("ping").then((body: any) => body.server_time_ms as number);
+  }
+
+  close(): void {
+    this.closed = true;
+    try {
+      this.socket.close();
+    } catch {
+      // already closed
+    }
+  }
+}
+
+/// Open a tunnel to `origin`, using the device's identity seed for
+/// the client's long-term static and the server pubkey from the
+/// connector config. Rejects if the server doesn't support Noise,
+/// if the handshake fails, or if the WS can't be established.
+export async function openTunnel(
+  origin: string,
+  serverPubkeyHex: string,
+): Promise<Tunnel> {
+  const trimmed = origin.replace(/\/+$/, "");
+  const wssUrl = trimmed.replace(/^http(s)?:/, (m) => (m === "http:" ? "ws:" : "wss:")) +
+    "/noise/ws";
+  const seed = loadIdentitySeed();
+  const client = keypairFromSeed(seed);
+  const serverPub = decodeHex(serverPubkeyHex);
+  const { socket, transport } = await connectNoise(wssUrl, client, serverPub);
+  return new Tunnel(socket, transport);
+}
+
+function decodeHex(hex: string): Uint8Array {
+  if (hex.length !== 64) throw new Error(`pubkey: expected 64 hex chars, got ${hex.length}`);
+  const out = new Uint8Array(32);
+  for (let i = 0; i < 32; i++) {
+    out[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  }
+  return out;
+}
+
+// -----------------------------------------------------------------
+// Shell (PTY) streaming — parallel to Tunnel but purpose-built for
+// the bidirectional byte stream xterm.js consumes.
+// -----------------------------------------------------------------
+
+/// In-tunnel frame type tag — must match the server-side constants
+/// `NOISE_FRAME_RAW` + `NOISE_FRAME_CTRL` in `crates/bastion/src/lib.rs`.
+const FRAME_RAW = 0x01;
+const FRAME_CTRL = 0x02;
+
+/// A WebSocket-shaped bidirectional Noise tunnel for a single PTY
+/// session. `sendRaw` writes PTY stdin; inbound raw frames go to
+/// `onRaw` (xterm.write). JSON control frames (resize / hello from
+/// the client, block / exit / ready from the server) use the ctrl
+/// channel.
+export class ShellTunnel {
+  private rawHandlers: Array<(bytes: Uint8Array) => void> = [];
+  private ctrlHandlers: Array<(msg: any) => void> = [];
+  private closed = false;
+
+  constructor(
+    private socket: WebSocket,
+    private transport: Transport,
+  ) {
+    socket.addEventListener("message", (ev) => this.onFrame(ev));
+    socket.addEventListener("close", () => this.onClose());
+    socket.addEventListener("error", () => this.onClose());
+  }
+
+  private onFrame(ev: MessageEvent): void {
+    if (!(ev.data instanceof ArrayBuffer)) return;
+    let plain: Uint8Array;
+    try {
+      plain = this.transport.recv(new Uint8Array(ev.data));
+    } catch (e) {
+      console.warn("shell-tunnel: decrypt failed", e);
+      this.close();
+      return;
+    }
+    if (plain.length === 0) return;
+    const tag = plain[0];
+    const body = plain.slice(1);
+    if (tag === FRAME_RAW) {
+      for (const cb of this.rawHandlers) cb(body);
+    } else if (tag === FRAME_CTRL) {
+      let msg: any;
+      try {
+        msg = JSON.parse(new TextDecoder().decode(body));
+      } catch {
+        return;
+      }
+      for (const cb of this.ctrlHandlers) cb(msg);
+    }
+  }
+
+  private onClose(): void {
+    if (this.closed) return;
+    this.closed = true;
+    for (const cb of this.ctrlHandlers) cb({ type: "close" });
+  }
+
+  sendRaw(bytes: Uint8Array): void {
+    if (this.closed) return;
+    const framed = new Uint8Array(bytes.length + 1);
+    framed[0] = FRAME_RAW;
+    framed.set(bytes, 1);
+    this.socket.send(this.transport.send(framed));
+  }
+
+  sendCtrl(msg: any): void {
+    if (this.closed) return;
+    const json = new TextEncoder().encode(JSON.stringify(msg));
+    const framed = new Uint8Array(json.length + 1);
+    framed[0] = FRAME_CTRL;
+    framed.set(json, 1);
+    this.socket.send(this.transport.send(framed));
+  }
+
+  onRaw(cb: (bytes: Uint8Array) => void): void {
+    this.rawHandlers.push(cb);
+  }
+
+  onCtrl(cb: (msg: any) => void): void {
+    this.ctrlHandlers.push(cb);
+  }
+
+  close(): void {
+    this.closed = true;
+    try {
+      this.socket.close();
+    } catch {
+      // already closed
+    }
+  }
+}
+
+/// Open a Noise-tunneled shell stream for one session. Use when
+/// cross-origin + CF-Access-bypassed /noise/shell/{id} is available;
+/// for same-origin loads the plain `/ws/{id}` is still cheaper.
+export async function openShellTunnel(
+  origin: string,
+  serverPubkeyHex: string,
+  sessionId: string,
+): Promise<ShellTunnel> {
+  const trimmed = origin.replace(/\/+$/, "");
+  const wssUrl =
+    trimmed.replace(/^http(s)?:/, (m) => (m === "http:" ? "ws:" : "wss:")) +
+    `/noise/shell/${encodeURIComponent(sessionId)}`;
+  const seed = loadIdentitySeed();
+  const client = keypairFromSeed(seed);
+  const serverPub = decodeHex(serverPubkeyHex);
+  const { socket, transport } = await connectNoise(wssUrl, client, serverPub);
+  return new ShellTunnel(socket, transport);
+}

--- a/crates/bastion/web/src/ui.svelte.ts
+++ b/crates/bastion/web/src/ui.svelte.ts
@@ -1,7 +1,14 @@
 import type { Agent, BlockRecord, SessionInfo } from "./types";
 import type { Connector } from "./connectors";
-import { listConnectors, seedFromAgents, addConnector } from "./connectors";
+import {
+  listConnectors,
+  seedFromAgents,
+  addConnector,
+  fetchAttest,
+  patchConnectorConfig,
+} from "./connectors";
 import { loadIdentitySeed, fingerprint } from "./identity";
+import { openTunnel, Tunnel } from "./tunnel";
 
 /// Composite key so session ids from different connectors can't collide.
 export type RowId = string; // `${connector.label}/${session_id}`
@@ -17,8 +24,14 @@ export interface Row {
   origin: string;
   info: SessionInfo;
   blocks: BlockRecord[];
-  /// Live WS to the owning origin. `null` until first activation.
+  /// Plain `/ws/{id}` WebSocket — used for same-origin loads where
+  /// CF Access already covers the upgrade. `null` until first
+  /// activation, or when the row is served over the Noise shell
+  /// tunnel instead.
   ws: WebSocket | null;
+  /// Noise-tunneled PTY stream for cross-origin enclaves. Mutually
+  /// exclusive with `ws` — whichever was opened first wins.
+  shell: import("./tunnel").ShellTunnel | null;
   /// xterm.js instance. `null` until first activation.
   term: import("@xterm/xterm").Terminal | null;
   fit: import("@xterm/addon-fit").FitAddon | null;
@@ -54,14 +67,44 @@ export const ui = $state<{
 /// One-time setup at app load: mint/load the device identity, pull
 /// the connector list from IndexedDB (seed on first run from the
 /// server-injected `__DD_AGENTS__`), and fan out to each connector
-/// to populate `ui.rows`.
+/// to populate `ui.rows`. Also kicks off a background `/attest`
+/// fetch per enclave so Phase 2b's Noise_KK handshake has the
+/// server pubkey ready.
 export async function bootstrap(): Promise<void> {
   ui.deviceFp = fingerprint(loadIdentitySeed());
   if (window.__DD_AGENTS__ && window.__DD_AGENTS__.length > 0) {
     await seedFromAgents(window.__DD_AGENTS__);
   }
   await refreshConnectors();
+  // Fire-and-forget — attest can be slow/cross-origin-blocked and
+  // the sidebar shouldn't wait for it. Phase 2b will gate session
+  // connections on the pubkey being cached.
+  void refreshAttest();
   ui.ready = true;
+}
+
+/// Fetch `/attest` for every `dd-enclave` connector and merge the
+/// returned Noise pubkey into its config. Idempotent; runs quietly
+/// in the background on bootstrap. Console-logs the pubkey so
+/// Phase 2a can be visually verified before Phase 2b wires it up.
+async function refreshAttest(): Promise<void> {
+  for (const c of ui.connectors) {
+    if (c.kind !== "dd-enclave") continue;
+    const origin = c.config.origin as string | undefined;
+    if (!origin) continue;
+    const attest = await fetchAttest(origin);
+    if (!attest) continue;
+    const known = c.config.serverNoisePubkeyHex as string | undefined;
+    if (known === attest.noise_pubkey_hex) continue;
+    console.log(
+      `bastion: ${c.label} noise pubkey ${attest.noise_pubkey_hex.slice(0, 16)}… (${attest.source})`,
+    );
+    await patchConnectorConfig(c.id, {
+      serverNoisePubkeyHex: attest.noise_pubkey_hex,
+    });
+  }
+  // Re-read so `ui.connectors` has the patched config for Phase 2b.
+  ui.connectors = await listConnectors();
 }
 
 /// Reload connectors from IndexedDB and re-fetch sessions from each.
@@ -91,51 +134,83 @@ async function reloadSessions(): Promise<void> {
   ui.rows = next;
 }
 
-/// Fetch an enclave's live sessions. Cross-origin failures
-/// (CF-Access bounce, CORS reject, offline) degrade to "no rows" for
-/// that enclave rather than propagating — the sidebar still shows
-/// every connector the user configured, just empty for unreachable
-/// ones. Phase 2 replaces this with a Noise_KK channel that isn't
-/// subject to the same browser same-origin rules.
+/// Lazy per-connector Noise tunnel cache. Opened on first use by
+/// [`getTunnel`]; kept open for subsequent RPCs. Recreated
+/// transparently if the underlying socket dies.
+const tunnels = new Map<string, Promise<Tunnel>>();
+
+/// Open (or re-use) a Noise tunnel for `c`. Returns `null` if the
+/// server hasn't advertised a pubkey yet (Phase 2a hasn't run on
+/// this origin) or the handshake fails for any reason — callers
+/// should fall back to plain `fetch` in that case.
+async function getTunnel(c: Connector): Promise<Tunnel | null> {
+  const origin = (c.config.origin as string | undefined) ?? "";
+  const pubkey = c.config.serverNoisePubkeyHex as string | undefined;
+  if (!origin || !pubkey) return null;
+  const existing = tunnels.get(c.id);
+  if (existing) {
+    return existing.catch(() => {
+      tunnels.delete(c.id);
+      return null;
+    });
+  }
+  const p = openTunnel(origin, pubkey).catch((e) => {
+    console.warn(`tunnel: open ${origin} failed`, e);
+    tunnels.delete(c.id);
+    throw e;
+  });
+  tunnels.set(c.id, p);
+  try {
+    return await p;
+  } catch {
+    return null;
+  }
+}
+
+/// Fetch an enclave's live sessions. Prefers the Noise tunnel (no
+/// CORS preflight, no CF Access bounce); falls back to plain fetch
+/// for same-origin connectors or origins that predate Phase 2a.
+/// Either failure path degrades to "no rows" so the sidebar still
+/// shows every connector the user configured.
 async function fetchDdEnclave(c: Connector): Promise<Row[]> {
   const origin = (c.config.origin as string | undefined) ?? "";
   if (!origin) return [];
-  try {
-    const resp = await fetch(`${origin}/api/sessions`, {
-      credentials: "include",
-    });
-    if (!resp.ok) return [];
-    const sessions: SessionInfo[] = await resp.json();
-    return sessions.map((info) => ({
-      connector: c,
-      origin,
-      info,
-      blocks: [],
-      ws: null,
-      term: null,
-      fit: null,
-    }));
-  } catch {
-    return [];
-  }
+  const tunnel = await getTunnel(c);
+  const sessions = await (tunnel
+    ? tunnel.sessionsList().catch((): SessionInfo[] => [])
+    : fetch(`${origin}/api/sessions`, { credentials: "include" })
+        .then((r) => (r.ok ? r.json() : []))
+        .catch((): SessionInfo[] => []));
+  return sessions.map((info: SessionInfo) => ({
+    connector: c,
+    origin,
+    info,
+    blocks: [],
+    ws: null,
+    shell: null,
+    term: null,
+    fit: null,
+  }));
 }
 
 export async function createShell(c: Connector): Promise<void> {
   if (c.kind !== "dd-enclave") return;
   const origin = (c.config.origin as string | undefined) ?? "";
   if (!origin) return;
+  const tunnel = await getTunnel(c);
   try {
-    const resp = await fetch(`${origin}/api/sessions`, {
-      method: "POST",
-      credentials: "include",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ title: "shell" }),
-    });
-    if (!resp.ok) {
-      console.warn(`createShell: ${origin} → ${resp.status}`);
-      return;
-    }
-    const info: SessionInfo = await resp.json();
+    const info: SessionInfo = tunnel
+      ? await tunnel.sessionsCreate("shell")
+      : await (async () => {
+          const resp = await fetch(`${origin}/api/sessions`, {
+            method: "POST",
+            credentials: "include",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ title: "shell" }),
+          });
+          if (!resp.ok) throw new Error(`${origin} → ${resp.status}`);
+          return resp.json();
+        })();
     const id = rowKey(c, info.id);
     const rows = new Map(ui.rows);
     rows.set(id, {
@@ -144,17 +219,18 @@ export async function createShell(c: Connector): Promise<void> {
       info,
       blocks: [],
       ws: null,
+      shell: null,
       term: null,
       fit: null,
     });
     ui.rows = rows;
     ui.active = id;
   } catch (e) {
-    // Cross-origin + CF Access fails here with a TypeError before
-    // fetch even reaches the origin. Swallow it — the sidebar falls
-    // back to "no new shell, try again" rather than throwing a red
-    // Uncaught (in promise) from a click handler.
-    console.warn(`createShell: ${origin} cross-origin blocked`, e);
+    // Cross-origin + CF Access fails plain fetch with a TypeError
+    // before it reaches the origin; the tunnel path would have
+    // rejected instead. Either way we swallow so the click handler
+    // doesn't throw red in the console.
+    console.warn(`createShell: ${origin}`, e);
   }
 }
 
@@ -178,11 +254,16 @@ export async function killShell(row: Row): Promise<void> {
     destroyRow(rowKey(row.connector, row.info.id));
     return;
   }
+  const tunnel = await getTunnel(row.connector);
   try {
-    await fetch(`${row.origin}/api/sessions/${row.info.id}`, {
-      method: "DELETE",
-      credentials: "include",
-    });
+    if (tunnel) {
+      await tunnel.sessionsDelete(row.info.id);
+    } else {
+      await fetch(`${row.origin}/api/sessions/${row.info.id}`, {
+        method: "DELETE",
+        credentials: "include",
+      });
+    }
   } catch {
     // Not fatal — the session might be gone already; the UI cleanup
     // below runs either way.
@@ -195,6 +276,11 @@ export function destroyRow(id: RowId): void {
   if (!row) return;
   try {
     row.ws?.close();
+  } catch {
+    // Already closed; nothing to do.
+  }
+  try {
+    row.shell?.close();
   } catch {
     // Already closed; nothing to do.
   }

--- a/crates/dd-common/Cargo.toml
+++ b/crates/dd-common/Cargo.toml
@@ -6,5 +6,11 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
+rand = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+snow = "0.10"
+x25519-dalek = { version = "2", features = ["static_secrets"] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/dd-common/src/lib.rs
+++ b/crates/dd-common/src/lib.rs
@@ -1,10 +1,14 @@
 //! Types shared between the `devopsdefender` binary (CP + agent modes)
 //! and the `bastion` binary (block-aware terminal + workload-capture).
 //!
-//! Today this is just [`BlockRecord`] — the wire shape for a single
-//! segmented event, shared so the CP (which will eventually aggregate
-//! across nodes) and bastion (which emits) can deserialize the same
-//! JSON without duplicating the type.
+//! - [`BlockRecord`] — the wire shape for a single segmented event.
+//! - [`noise_tunnel`] — Noise_IK handshake primitive used by both
+//!   browser↔bastion tunnels and CP↔agent m2m.
+//! - [`noise_static`] — persistent X25519 keypair shared as the
+//!   Noise "static" key for every long-lived identity.
+
+pub mod noise_static;
+pub mod noise_tunnel;
 
 use serde::{Deserialize, Serialize};
 

--- a/crates/dd-common/src/noise_static.rs
+++ b/crates/dd-common/src/noise_static.rs
@@ -1,0 +1,203 @@
+//! Noise handshake groundwork (Phase 2a — scaffolding only).
+//!
+//! This module owns bastion's long-term Noise static keypair. The
+//! keypair is generated once on first boot and persisted so
+//! subsequent boots (or restarts within the same VM) reuse the same
+//! pubkey. Clients that have already pinned the pubkey after an
+//! attested handshake (Phase 2d) won't see it rotate without
+//! reason.
+//!
+//! Phase 2b will add the actual Noise_KK handshake + encrypted
+//! `/api/sessions` and `/ws/*` channels; Phase 2d binds the pubkey
+//! into the TDX quote's `REPORT_DATA` so clients can verify the
+//! keypair came from a genuine attested enclave. Today we just
+//! expose the pubkey via `GET /attest` so client code can start
+//! caching it.
+
+use std::path::{Path, PathBuf};
+
+use rand::rngs::OsRng;
+use x25519_dalek::{PublicKey, StaticSecret};
+
+/// 32-byte Noise static key material persisted on disk. Passed to
+/// [`Manager::with_noise_key`](crate::Manager::with_noise_key) so
+/// HTTP handlers can expose the pubkey.
+pub struct NoiseStatic {
+    #[allow(dead_code)] // Kept for future x25519-dalek-direct uses
+    secret: StaticSecret,
+    /// Cached raw 32-byte secret — `snow::Builder::local_private_key`
+    /// wants a byte slice and x25519-dalek won't hand one out.
+    secret_cache: [u8; 32],
+    public: PublicKey,
+    source: NoiseKeySource,
+}
+
+impl std::fmt::Debug for NoiseStatic {
+    /// Never print the secret half. `{:?}` shows only the pubkey
+    /// (truncated) + the source so an accidental log line doesn't
+    /// leak the long-term identity.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let hex = self.public_hex();
+        let short = &hex[..hex.len().min(16)];
+        write!(f, "NoiseStatic({:?}, {}…)", self.source, short)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum NoiseKeySource {
+    /// Fresh random key, written to disk for the first time.
+    Generated,
+    /// Loaded from an existing on-disk key file.
+    Loaded,
+}
+
+impl NoiseStatic {
+    pub fn public(&self) -> &PublicKey {
+        &self.public
+    }
+
+    /// Raw 32-byte secret. Consumed by the Noise handshake responder
+    /// in [`crate::noise_tunnel::Responder::new`]. Never serialize
+    /// this — `Debug` deliberately hides it.
+    pub fn secret_bytes(&self) -> &[u8; 32] {
+        &self.secret_cache
+    }
+
+    /// Hex-encoded pubkey for JSON wire use.
+    pub fn public_hex(&self) -> String {
+        hex::encode(self.public.as_bytes())
+    }
+
+    pub fn source(&self) -> NoiseKeySource {
+        self.source
+    }
+
+    /// Ephemeral in-memory keypair. Used for tests and for the
+    /// standalone `bastion serve` local-dev binary where persistence
+    /// isn't meaningful across restarts.
+    pub fn ephemeral() -> Self {
+        let secret = StaticSecret::random_from_rng(OsRng);
+        let public = PublicKey::from(&secret);
+        let secret_cache = secret.to_bytes();
+        Self {
+            secret,
+            secret_cache,
+            public,
+            source: NoiseKeySource::Generated,
+        }
+    }
+
+    /// Load an existing static key from `path`, or mint a fresh one
+    /// and write it if the file doesn't exist. Always `chmod 0600`
+    /// after write — the file is the enclave's long-term identity;
+    /// only bastion should read it.
+    pub fn load_or_generate(path: impl AsRef<Path>) -> std::io::Result<Self> {
+        let path: PathBuf = path.as_ref().to_path_buf();
+        if path.exists() {
+            let bytes = std::fs::read(&path)?;
+            if bytes.len() != 32 {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!(
+                        "noise key file {} is {} bytes; expected 32",
+                        path.display(),
+                        bytes.len()
+                    ),
+                ));
+            }
+            let mut sk = [0u8; 32];
+            sk.copy_from_slice(&bytes);
+            let secret = StaticSecret::from(sk);
+            let public = PublicKey::from(&secret);
+            return Ok(Self {
+                secret,
+                secret_cache: sk,
+                public,
+                source: NoiseKeySource::Loaded,
+            });
+        }
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let s = Self::ephemeral();
+        let bytes: [u8; 32] = s.secret.to_bytes();
+        std::fs::write(&path, bytes)?;
+        chmod_0600(&path)?;
+        Ok(Self {
+            secret: s.secret,
+            secret_cache: s.secret_cache,
+            public: s.public,
+            source: NoiseKeySource::Generated,
+        })
+    }
+}
+
+fn chmod_0600(path: &Path) -> std::io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    let mut perms = std::fs::metadata(path)?.permissions();
+    perms.set_mode(0o600);
+    std::fs::set_permissions(path, perms)
+}
+
+// `hex` is pulled in transitively via existing deps; if the
+// transitive path changes, add `hex = "0.4"` to `Cargo.toml`
+// explicitly.
+mod hex {
+    pub fn encode(bytes: &[u8]) -> String {
+        let mut s = String::with_capacity(bytes.len() * 2);
+        for b in bytes {
+            s.push_str(&format!("{b:02x}"));
+        }
+        s
+    }
+}
+
+/// Module-public hex encoder so other parts of bastion (the
+/// `/noise/ws` handler's peer-pubkey log line, for instance) can
+/// format byte slices the same way `public_hex` does.
+pub fn hex_encode(bytes: &[u8]) -> String {
+    hex::encode(bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ephemeral_is_random_each_call() {
+        let a = NoiseStatic::ephemeral();
+        let b = NoiseStatic::ephemeral();
+        assert_ne!(a.public().as_bytes(), b.public().as_bytes());
+        assert_eq!(a.public_hex().len(), 64);
+    }
+
+    #[test]
+    fn load_or_generate_is_stable_across_calls() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("noise-static.key");
+        let first = NoiseStatic::load_or_generate(&path).unwrap();
+        let second = NoiseStatic::load_or_generate(&path).unwrap();
+        assert_eq!(first.public().as_bytes(), second.public().as_bytes());
+        assert!(matches!(first.source(), NoiseKeySource::Generated));
+        assert!(matches!(second.source(), NoiseKeySource::Loaded));
+    }
+
+    #[test]
+    fn load_or_generate_rejects_wrong_length() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("corrupt.key");
+        std::fs::write(&path, b"too short").unwrap();
+        let err = NoiseStatic::load_or_generate(&path).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn key_file_is_chmod_0600() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("noise-static.key");
+        let _ = NoiseStatic::load_or_generate(&path).unwrap();
+        let perms = std::fs::metadata(&path).unwrap().permissions();
+        assert_eq!(perms.mode() & 0o777, 0o600);
+    }
+}

--- a/crates/dd-common/src/noise_tunnel.rs
+++ b/crates/dd-common/src/noise_tunnel.rs
@@ -1,0 +1,240 @@
+//! Noise_IK tunnel primitive (Phase 2b).
+//!
+//! Wraps `snow` with a small state machine so the axum `/noise/ws`
+//! handler and the TS client implementation can stay focused on
+//! framing. Pattern is **Noise_IK_25519_ChaChaPoly_SHA256**:
+//!
+//! - Initiator knows responder's static pubkey up-front (fetched via
+//!   `GET /attest` in Phase 2a) — enables server auth on the first
+//!   roundtrip with no prior handshake.
+//! - Initiator's static pubkey is transmitted inside the handshake
+//!   (encrypted under the ephemeral-static DH) — server learns the
+//!   client identity after msg1, can pin or accept per policy.
+//!
+//! IK is 1-RTT: client sends msg1, server sends msg2, both sides
+//! are in transport mode. Matches a WebSocket's
+//! client-speaks-first model.
+//!
+//! Pairing / device-key registry is intentionally out of scope here
+//! — the server accepts any initiator pubkey today and logs it;
+//! Phase 3 adds a pinning layer that rejects unknown keys.
+
+use snow::{params::NoiseParams, HandshakeState, TransportState};
+use std::sync::LazyLock;
+
+pub static PARAMS: LazyLock<NoiseParams> = LazyLock::new(|| {
+    "Noise_IK_25519_ChaChaPoly_SHA256"
+        .parse()
+        .expect("valid noise params")
+});
+
+/// Established Noise session. Both sides have symmetric ciphers
+/// keyed from the handshake; `peer_pubkey` is the counterpart's
+/// long-term static (32 raw X25519 bytes).
+pub struct Transport {
+    state: TransportState,
+    peer_pubkey: [u8; 32],
+}
+
+impl Transport {
+    /// Encrypt + authenticate a payload. Returns the ciphertext to
+    /// frame on the wire.
+    pub fn send(&mut self, plain: &[u8]) -> Result<Vec<u8>, snow::Error> {
+        let mut buf = vec![0u8; plain.len() + 16];
+        let len = self.state.write_message(plain, &mut buf)?;
+        buf.truncate(len);
+        Ok(buf)
+    }
+
+    /// Decrypt + verify a ciphertext. Returns the plaintext.
+    pub fn recv(&mut self, cipher: &[u8]) -> Result<Vec<u8>, snow::Error> {
+        let mut buf = vec![0u8; cipher.len()];
+        let len = self.state.read_message(cipher, &mut buf)?;
+        buf.truncate(len);
+        Ok(buf)
+    }
+
+    pub fn peer_pubkey(&self) -> &[u8; 32] {
+        &self.peer_pubkey
+    }
+}
+
+/// Responder (server) side of a Noise_IK handshake. Owns the
+/// server's long-term static key and runs exactly one handshake
+/// roundtrip per instance.
+pub struct Responder {
+    state: HandshakeState,
+}
+
+impl Responder {
+    pub fn new(local_secret: &[u8; 32]) -> Result<Self, snow::Error> {
+        let state = snow::Builder::new(PARAMS.clone())
+            .local_private_key(local_secret)?
+            .build_responder()?;
+        Ok(Self { state })
+    }
+
+    /// Consume the initiator's first message (`-> e, es, s, ss`).
+    /// After this call the responder has the initiator's static
+    /// pubkey available via [`Responder::peer_pubkey`].
+    pub fn read_msg1(&mut self, msg: &[u8]) -> Result<Vec<u8>, snow::Error> {
+        let mut buf = vec![0u8; msg.len()];
+        let len = self.state.read_message(msg, &mut buf)?;
+        buf.truncate(len);
+        Ok(buf)
+    }
+
+    /// Produce the responder's reply (`<- e, ee, se`).
+    pub fn write_msg2(&mut self, payload: &[u8]) -> Result<Vec<u8>, snow::Error> {
+        let mut buf = vec![0u8; payload.len() + 96];
+        let len = self.state.write_message(payload, &mut buf)?;
+        buf.truncate(len);
+        Ok(buf)
+    }
+
+    /// Initiator's static pubkey, learned during [`read_msg1`]. Used
+    /// by the server for logging + (future) pinning. Returns `None`
+    /// if called before msg1 has been consumed.
+    pub fn peer_pubkey(&self) -> Option<[u8; 32]> {
+        let raw = self.state.get_remote_static()?;
+        let mut out = [0u8; 32];
+        out.copy_from_slice(raw);
+        Some(out)
+    }
+
+    /// Transition to transport mode once the handshake is complete.
+    /// Caller is responsible for having done one read + one write
+    /// in order before calling; `snow` panics otherwise.
+    pub fn into_transport(self) -> Result<Transport, snow::Error> {
+        let peer = self.peer_pubkey().ok_or(snow::Error::State(
+            snow::error::StateProblem::MissingKeyMaterial,
+        ))?;
+        let state = self.state.into_transport_mode()?;
+        Ok(Transport {
+            state,
+            peer_pubkey: peer,
+        })
+    }
+}
+
+/// Initiator (client) side. Used in tests + by CP↔agent peering;
+/// the browser implementation is in `crates/bastion/web/src/noise.ts`.
+pub struct Initiator {
+    state: HandshakeState,
+    remote_pub: [u8; 32],
+}
+
+impl Initiator {
+    pub fn new(local_secret: &[u8; 32], remote_public: &[u8; 32]) -> Result<Self, snow::Error> {
+        let state = snow::Builder::new(PARAMS.clone())
+            .local_private_key(local_secret)?
+            .remote_public_key(remote_public)?
+            .build_initiator()?;
+        Ok(Self {
+            state,
+            remote_pub: *remote_public,
+        })
+    }
+
+    pub fn write_msg1(&mut self, payload: &[u8]) -> Result<Vec<u8>, snow::Error> {
+        let mut buf = vec![0u8; payload.len() + 96];
+        let len = self.state.write_message(payload, &mut buf)?;
+        buf.truncate(len);
+        Ok(buf)
+    }
+
+    pub fn read_msg2(&mut self, msg: &[u8]) -> Result<Vec<u8>, snow::Error> {
+        let mut buf = vec![0u8; msg.len()];
+        let len = self.state.read_message(msg, &mut buf)?;
+        buf.truncate(len);
+        Ok(buf)
+    }
+
+    pub fn into_transport(self) -> Result<Transport, snow::Error> {
+        let state = self.state.into_transport_mode()?;
+        Ok(Transport {
+            state,
+            peer_pubkey: self.remote_pub,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use x25519_dalek::{PublicKey, StaticSecret};
+
+    fn fresh_keypair() -> ([u8; 32], [u8; 32]) {
+        let secret = StaticSecret::random_from_rng(rand::rngs::OsRng);
+        let public = PublicKey::from(&secret);
+        (secret.to_bytes(), *public.as_bytes())
+    }
+
+    #[test]
+    fn ik_round_trip_transport_mode() {
+        let (server_sk, server_pk) = fresh_keypair();
+        let (client_sk, client_pk) = fresh_keypair();
+
+        let mut responder = Responder::new(&server_sk).unwrap();
+        let mut initiator = Initiator::new(&client_sk, &server_pk).unwrap();
+
+        let msg1 = initiator.write_msg1(b"hello").unwrap();
+        let prologue_payload = responder.read_msg1(&msg1).unwrap();
+        assert_eq!(prologue_payload, b"hello");
+        assert_eq!(responder.peer_pubkey().unwrap(), client_pk);
+
+        let msg2 = responder.write_msg2(b"hi").unwrap();
+        let reply_payload = initiator.read_msg2(&msg2).unwrap();
+        assert_eq!(reply_payload, b"hi");
+
+        let mut server = responder.into_transport().unwrap();
+        let mut client = initiator.into_transport().unwrap();
+        assert_eq!(server.peer_pubkey(), &client_pk);
+        assert_eq!(client.peer_pubkey(), &server_pk);
+
+        // Bidirectional stream — two messages each direction to
+        // exercise nonce increment.
+        let c1 = client.send(b"ping one").unwrap();
+        assert_eq!(server.recv(&c1).unwrap(), b"ping one");
+        let c2 = client.send(b"ping two").unwrap();
+        assert_eq!(server.recv(&c2).unwrap(), b"ping two");
+        let s1 = server.send(b"pong").unwrap();
+        assert_eq!(client.recv(&s1).unwrap(), b"pong");
+    }
+
+    #[test]
+    fn mismatched_server_pubkey_rejects() {
+        let (server_sk, _server_pk) = fresh_keypair();
+        let (_other_sk, other_pk) = fresh_keypair();
+        let (client_sk, _) = fresh_keypair();
+
+        let mut responder = Responder::new(&server_sk).unwrap();
+        let mut initiator = Initiator::new(&client_sk, &other_pk).unwrap();
+
+        let msg1 = initiator.write_msg1(b"").unwrap();
+        // Server can't decrypt msg1's `s` because the initiator
+        // encrypted it against the wrong server pubkey.
+        assert!(responder.read_msg1(&msg1).is_err());
+    }
+
+    #[test]
+    fn tampered_ciphertext_rejects() {
+        let (server_sk, server_pk) = fresh_keypair();
+        let (client_sk, _) = fresh_keypair();
+
+        let mut responder = Responder::new(&server_sk).unwrap();
+        let mut initiator = Initiator::new(&client_sk, &server_pk).unwrap();
+
+        let msg1 = initiator.write_msg1(b"").unwrap();
+        responder.read_msg1(&msg1).unwrap();
+        let msg2 = responder.write_msg2(b"").unwrap();
+        initiator.read_msg2(&msg2).unwrap();
+
+        let mut server = responder.into_transport().unwrap();
+        let mut client = initiator.into_transport().unwrap();
+
+        let mut frame = client.send(b"payload").unwrap();
+        frame[0] ^= 0x01;
+        assert!(server.recv(&frame).is_err());
+    }
+}

--- a/crates/dd/Cargo.toml
+++ b/crates/dd/Cargo.toml
@@ -12,6 +12,7 @@ axum = { version = "0.8", features = ["ws", "macros"] }
 base64 = "0.22"
 bastion-term = { path = "../bastion" }
 chrono = { version = "0.4", features = ["serde"] }
+dd-common = { path = "../dd-common" }
 futures-util = "0.3"
 jsonwebtoken = "9"
 libc = "0.2"
@@ -19,8 +20,13 @@ rand = "0.8"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+sha2 = "0.10"
+tokio-tungstenite = { version = "0.28", default-features = false, features = ["connect", "rustls-tls-native-roots"] }
 sysinfo = { version = "0.33", default-features = false, features = ["system", "disk", "network"] }
 thiserror = "2"
 tokio = { version = "1", features = ["macros", "process", "rt-multi-thread", "signal", "time", "fs", "net", "io-util", "sync"] }
 urlencoding = "2"
 uuid = { version = "1", features = ["v4"] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/dd/src/agent.rs
+++ b/crates/dd/src/agent.rs
@@ -66,6 +66,13 @@ struct St {
     /// without any shared secret; anyone else is denied at claim
     /// check.
     gh: Arc<gh_oidc::Verifier>,
+    /// Long-term Noise static keypair for m2m RPC. `None` when
+    /// `DD_NOISE_KEY_DIR` isn't set or the key couldn't be loaded.
+    noise_key: Option<Arc<dd_common::noise_static::NoiseStatic>>,
+    /// CP's pinned pubkey, learned at registration and persisted on
+    /// disk. `None` during the migration window where the CP side
+    /// hasn't been given a key yet.
+    cp_noise_pubkey: Option<[u8; 32]>,
 }
 
 pub async fn run() -> Result<()> {
@@ -81,9 +88,71 @@ pub async fn run() -> Result<()> {
     let initial_token = mint_ita(&cfg, &ee).await?;
     eprintln!("agent: ITA token minted");
 
+    // Load or mint the agent's long-term Noise static keypair if a
+    // dir is configured. During the m2m migration window this is
+    // optional — an agent without a key registers as before and the
+    // CP skips pinning it.
+    let noise_key: Option<Arc<dd_common::noise_static::NoiseStatic>> =
+        match std::env::var("DD_NOISE_KEY_DIR")
+            .ok()
+            .filter(|s| !s.is_empty())
+        {
+            Some(dir) => match crate::noise_m2m::load_static(std::path::Path::new(&dir)) {
+                Ok(k) => {
+                    eprintln!(
+                        "agent: noise static key {:?} ({}…)",
+                        k.source(),
+                        &k.public_hex()[..16]
+                    );
+                    Some(k)
+                }
+                Err(e) => {
+                    eprintln!("agent: noise key load failed at {dir}: {e}");
+                    None
+                }
+            },
+            None => None,
+        };
+    let noise_pubkey_hex = noise_key.as_ref().map(|k| k.public_hex());
+
     eprintln!("agent: registering with {}", cfg.cp_url);
-    let b = register(&cfg, &initial_token).await?;
+    let b = register(&cfg, &initial_token, noise_pubkey_hex.as_deref()).await?;
     eprintln!("agent: registered as {}", b.hostname);
+
+    // Pin the CP's pubkey for future m2m handshakes. Silently ignored
+    // if the CP didn't advertise one (migration window).
+    let mut cp_noise_pubkey: Option<[u8; 32]> = None;
+    if let (Some(hex), Some(dir)) = (
+        b.cp_noise_pubkey_hex.as_deref(),
+        std::env::var("DD_NOISE_KEY_DIR")
+            .ok()
+            .filter(|s| !s.is_empty()),
+    ) {
+        match crate::noise_m2m::decode_pubkey(hex) {
+            Ok(pk) => {
+                cp_noise_pubkey = Some(pk);
+                if let Err(e) = crate::noise_m2m::save_cp_pubkey(std::path::Path::new(&dir), &pk) {
+                    eprintln!("agent: save CP noise pubkey: {e}");
+                } else {
+                    eprintln!(
+                        "agent: pinned CP noise pubkey ({}…)",
+                        &hex[..hex.len().min(16)]
+                    );
+                }
+            }
+            Err(e) => eprintln!("agent: CP noise pubkey decode: {e}"),
+        }
+    }
+    // Fall back to the on-disk cache if the CP didn't advertise one
+    // this boot but did previously.
+    if cp_noise_pubkey.is_none() {
+        if let Some(dir) = std::env::var("DD_NOISE_KEY_DIR")
+            .ok()
+            .filter(|s| !s.is_empty())
+        {
+            cp_noise_pubkey = crate::noise_m2m::load_cp_pubkey(std::path::Path::new(&dir));
+        }
+    }
 
     spawn_cloudflared(b.tunnel_token);
 
@@ -122,6 +191,8 @@ pub async fn run() -> Result<()> {
         ita_token,
         extras: Arc::new(RwLock::new(cfg.extra_ingress.clone())),
         gh,
+        noise_key,
+        cp_noise_pubkey,
     };
 
     let app = Router::new()
@@ -153,9 +224,15 @@ struct Bootstrap {
     agent_id: String,
     #[allow(dead_code)]
     cp_hostname: String,
+    /// CP's long-term Noise static pubkey (hex), advertised so the
+    /// agent can pin it for future m2m handshakes. Absent in
+    /// migration-window deployments where the CP hasn't been given
+    /// a key dir yet.
+    #[serde(default)]
+    cp_noise_pubkey_hex: Option<String>,
 }
 
-async fn register(cfg: &Cfg, ita_token: &str) -> Result<Bootstrap> {
+async fn register(cfg: &Cfg, ita_token: &str, noise_pubkey_hex: Option<&str>) -> Result<Bootstrap> {
     let http = reqwest::Client::new();
     let url = format!("{}/register", cfg.cp_url.trim_end_matches('/'));
     let extra_ingress: Vec<serde_json::Value> = cfg
@@ -169,6 +246,7 @@ async fn register(cfg: &Cfg, ita_token: &str) -> Result<Bootstrap> {
         "owner": cfg.common.owner,
         "ita_token": ita_token,
         "extra_ingress": extra_ingress,
+        "noise_pubkey_hex": noise_pubkey_hex,
     });
     // /register is CF-Access-bypassed; ITA attestation is the gate.
     let resp = http
@@ -528,6 +606,39 @@ async fn push_extra_ingress(s: &St, label: String, port: u16) -> Result<()> {
         .iter()
         .map(|(l, p)| serde_json::json!({"hostname_label": l, "port": p}))
         .collect();
+
+    // Prefer Noise RPC when both sides have pinned keys — closes out
+    // the ITA-bearer-on-every-call pattern. The HTTP+ITA path below
+    // stays live as a migration fallback for any agent/CP pair
+    // where one side doesn't have a key yet.
+    if let (Some(key), Some(pk)) = (s.noise_key.as_ref(), s.cp_noise_pubkey.as_ref()) {
+        let wss = http_to_wss(&s.cfg.cp_url) + "/noise/rpc";
+        let req = serde_json::json!({
+            "op": "ingress_replace",
+            "agent_id": s.agent_id,
+            "extras": body_extras.clone(),
+        });
+        match crate::noise_rpc::call(&wss, key, pk, req).await {
+            Ok(resp) if resp.get("ok").and_then(|v| v.as_bool()) == Some(true) => {
+                eprintln!(
+                    "agent: ingress/replace (noise) ok ({} extras total)",
+                    extras.len()
+                );
+                return Ok(());
+            }
+            Ok(resp) => {
+                let msg = resp
+                    .get("error")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("unknown");
+                eprintln!("agent: ingress/replace (noise) rejected: {msg} — falling back to HTTP");
+            }
+            Err(e) => {
+                eprintln!("agent: ingress/replace (noise) error: {e} — falling back to HTTP");
+            }
+        }
+    }
+
     let ita_token = s.ita_token.read().await.clone();
     let body = serde_json::json!({
         "agent_id": s.agent_id,
@@ -549,8 +660,23 @@ async fn push_extra_ingress(s: &St, label: String, port: u16) -> Result<()> {
             "ingress/replace {url} → {status}: {text}"
         )));
     }
-    eprintln!("agent: ingress/replace ok ({} extras total)", extras.len());
+    eprintln!(
+        "agent: ingress/replace (http) ok ({} extras total)",
+        extras.len()
+    );
     Ok(())
+}
+
+/// Convert an http(s) URL to a ws(s) URL for WebSocket upgrade. Keeps
+/// the host/port/path intact; only the scheme changes.
+fn http_to_wss(url: &str) -> String {
+    if let Some(rest) = url.strip_prefix("https://") {
+        format!("wss://{}", rest.trim_end_matches('/'))
+    } else if let Some(rest) = url.strip_prefix("http://") {
+        format!("ws://{}", rest.trim_end_matches('/'))
+    } else {
+        url.trim_end_matches('/').to_string()
+    }
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/dd/src/cp.rs
+++ b/crates/dd/src/cp.rs
@@ -48,6 +48,14 @@ struct St {
     /// GH OIDC verifier for `/api/agents` callers (CI, humans). Same
     /// audience as dd-agent, shared owner claim.
     gh: Arc<crate::gh_oidc::Verifier>,
+    /// CP's long-term Noise static keypair — exposed via `/attest`
+    /// and used to authenticate m2m connections from agents.
+    /// `None` when `--noise-key-dir` wasn't passed (local dev).
+    noise: Option<Arc<dd_common::noise_static::NoiseStatic>>,
+    /// `agent_id → pinned Noise pubkey` — populated at registration.
+    /// Future m2m endpoints (Phase 2c+) consult this before accepting
+    /// a handshake.
+    agent_pubkeys: crate::noise_m2m::AgentRegistry,
 }
 
 pub async fn run() -> Result<()> {
@@ -234,6 +242,31 @@ pub async fn run() -> Result<()> {
 
     let gh = crate::gh_oidc::Verifier::new(cfg.common.owner.clone(), "dd-agent".into());
 
+    // Load or mint the CP's long-term Noise static keypair if
+    // `DD_NOISE_KEY_DIR` is set. Optional for local dev; mandatory in
+    // prod because the fleet m2m cutover relies on it.
+    let noise: Option<Arc<dd_common::noise_static::NoiseStatic>> =
+        match std::env::var("DD_NOISE_KEY_DIR")
+            .ok()
+            .filter(|s| !s.is_empty())
+        {
+            Some(dir) => match crate::noise_m2m::load_static(std::path::Path::new(&dir)) {
+                Ok(key) => {
+                    eprintln!(
+                        "cp: noise static key {:?} ({}…)",
+                        key.source(),
+                        &key.public_hex()[..16]
+                    );
+                    Some(key)
+                }
+                Err(e) => {
+                    eprintln!("cp: noise key load failed at {dir}: {e}");
+                    None
+                }
+            },
+            None => None,
+        };
+
     let state = St {
         cfg: cfg.clone(),
         ee,
@@ -242,6 +275,8 @@ pub async fn run() -> Result<()> {
         verifier,
         cp_ita_token,
         gh,
+        noise,
+        agent_pubkeys: crate::noise_m2m::AgentRegistry::new(),
     };
 
     let app = Router::new()
@@ -255,6 +290,8 @@ pub async fn run() -> Result<()> {
         .route("/api/agents", get(api_agents))
         .route("/cp/attest", get(cp_attest))
         .route("/cp/ita", get(cp_ita))
+        .route("/cp/noise/attest", get(cp_noise_attest))
+        .route("/noise/rpc", get(noise_rpc_upgrade))
         .with_state(state);
 
     let addr = format!("0.0.0.0:{}", cfg.common.port);
@@ -326,6 +363,12 @@ struct RegisterReq {
     /// `{agent_hostname}` → `localhost:8080` dashboard rule.
     #[serde(default)]
     extra_ingress: Vec<ExtraIngress>,
+    /// Agent's long-term Noise static pubkey (hex). Optional during
+    /// the m2m migration — agents built before Phase 2b still send
+    /// only `ita_token` and fall through to the old auth path. Once
+    /// every agent carries a key, the ITA bearer paths are removed.
+    #[serde(default)]
+    noise_pubkey_hex: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -439,13 +482,43 @@ async fn register(
         );
     }
 
+    // Pin the agent's Noise pubkey if it presented one. Mismatch (the
+    // same agent_id re-registering under a fresh key) is rejected —
+    // operators must `forget` the old pin before accepting a new one.
+    if let Some(hex) = req.noise_pubkey_hex.as_deref() {
+        match crate::noise_m2m::decode_pubkey(hex) {
+            Ok(pk) => match s.agent_pubkeys.pin(&name, pk).await {
+                Ok(crate::noise_m2m::PinOutcome::Fresh) => {
+                    eprintln!(
+                        "cp: pinned noise pubkey for {} ({}…)",
+                        name,
+                        &hex.get(..16).unwrap_or(hex)
+                    );
+                }
+                Ok(crate::noise_m2m::PinOutcome::Reused) => {}
+                Err(e) => {
+                    return Err(Error::BadRequest(format!("noise pubkey: {e}")));
+                }
+            },
+            Err(e) => {
+                return Err(Error::BadRequest(format!("noise_pubkey_hex: {e}")));
+            }
+        }
+    }
+
     eprintln!("cp: registered {} as {}", req.vm_name, agent_hostname);
+
+    // Include CP's noise pubkey so the agent can pin it for future
+    // m2m handshakes. `null` during the migration window when
+    // `DD_NOISE_KEY_DIR` is unset.
+    let cp_noise_pubkey = s.noise.as_ref().map(|k| k.public_hex());
 
     Ok(Json(serde_json::json!({
         "tunnel_token": tunnel.token,
         "hostname": tunnel.hostname,
         "agent_id": name,
         "cp_hostname": s.cfg.hostname,
+        "cp_noise_pubkey_hex": cp_noise_pubkey,
     })))
 }
 
@@ -480,29 +553,41 @@ struct IngressPair {
 /// The agent forwards its full current ingress list; the CP re-PUTs
 /// the tunnel config + CNAMEs and reconciles per-workload CF Access
 /// bypass apps (creates new, deletes stale).
+///
+/// Retained alongside the new Noise RPC path so agents built before
+/// the m2m migration still work. Once every agent has a pinned
+/// pubkey, this endpoint becomes removable.
 async fn ingress_replace(
     State(s): State<St>,
     Json(req): Json<IngressReplaceReq>,
 ) -> Result<Json<serde_json::Value>> {
     // ITA is the auth — any failure → 401.
     let _claims = s.verifier.verify(&req.ita_token).await?;
+    do_ingress_replace(&s, &req.agent_id, req.extras).await
+}
 
+/// Pure ingress-replace logic with no auth check. Called by both the
+/// HTTP+ITA path (above) and the Noise RPC path (below); they each
+/// own their own auth.
+async fn do_ingress_replace(
+    s: &St,
+    agent_id: &str,
+    extras_in: Vec<IngressPair>,
+) -> Result<Json<serde_json::Value>> {
     let (tunnel_id, hostname) = {
         let store = s.store.lock().await;
-        let agent = store.get(&req.agent_id).ok_or(Error::NotFound)?;
+        let agent = store.get(agent_id).ok_or(Error::NotFound)?;
         if agent.tunnel_id.is_empty() {
             // Control-plane pseudo-entry, or an older store entry that
             // pre-dates the tunnel_id field. Either way, nothing to update.
             return Err(Error::BadRequest(format!(
-                "{} has no tunnel — runtime ingress applies only to agent tunnels",
-                req.agent_id
+                "{agent_id} has no tunnel — runtime ingress applies only to agent tunnels"
             )));
         }
         (agent.tunnel_id.clone(), agent.hostname.clone())
     };
 
-    let extras: Vec<(String, u16)> = req
-        .extras
+    let extras: Vec<(String, u16)> = extras_in
         .iter()
         .map(|e| (e.hostname_label.clone(), e.port))
         .collect();
@@ -522,21 +607,82 @@ async fn ingress_replace(
     )
     .await
     {
-        eprintln!("cp: provision_agent_access on /ingress/replace failed: {e}");
+        eprintln!("cp: provision_agent_access on ingress_replace failed: {e}");
     }
 
     {
         let mut store = s.store.lock().await;
-        if let Some(agent) = store.get_mut(&req.agent_id) {
+        if let Some(agent) = store.get_mut(agent_id) {
             agent.extras = extras;
         }
     }
 
-    eprintln!("cp: ingress/replace {} → {:?}", req.agent_id, hostnames);
+    eprintln!("cp: ingress/replace {agent_id} → {hostnames:?}");
     Ok(Json(serde_json::json!({
-        "agent_id": req.agent_id,
+        "agent_id": agent_id,
         "extra_hostnames": hostnames,
     })))
+}
+
+/// GET /noise/rpc — authenticated by the Noise_IK handshake's pinned
+/// pubkey. Currently supports one op: `ingress_replace`. Others
+/// (`api_agents`, `heartbeat`) migrate on follow-up PRs.
+async fn noise_rpc_upgrade(
+    ws: axum::extract::ws::WebSocketUpgrade,
+    State(s): State<St>,
+) -> axum::response::Response {
+    ws.on_upgrade(move |socket| noise_rpc_loop(socket, s))
+}
+
+async fn noise_rpc_loop(socket: axum::extract::ws::WebSocket, s: St) {
+    let Some(key) = s.noise.clone() else {
+        eprintln!("cp: /noise/rpc but no key configured; closing");
+        return;
+    };
+    crate::noise_rpc::serve(socket, &key, move |peer_pubkey, req| async move {
+        dispatch_m2m_rpc(&s, peer_pubkey, req).await
+    })
+    .await;
+}
+
+/// Dispatch one decrypted m2m RPC. Verifies the peer pubkey matches
+/// the pinned key for the claimed `agent_id` before doing any work.
+async fn dispatch_m2m_rpc(s: &St, peer: [u8; 32], req: serde_json::Value) -> serde_json::Value {
+    let op = req
+        .get("op")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let agent_id = req
+        .get("agent_id")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+
+    let pinned = s.agent_pubkeys.get(&agent_id).await;
+    match pinned {
+        Some(pk) if pk == peer => {}
+        Some(_) => return err("peer pubkey mismatch"),
+        None => return err(&format!("agent_id {agent_id} not enrolled")),
+    }
+
+    match op.as_str() {
+        "ingress_replace" => {
+            let extras: Vec<IngressPair> = req
+                .get("extras")
+                .and_then(|v| serde_json::from_value(v.clone()).ok())
+                .unwrap_or_default();
+            match do_ingress_replace(s, &agent_id, extras).await {
+                Ok(Json(data)) => serde_json::json!({"ok": true, "data": data}),
+                Err(e) => err(&format!("{e}")),
+            }
+        }
+        other => err(&format!("unknown op: {other}")),
+    }
+}
+
+fn err(msg: &str) -> serde_json::Value {
+    serde_json::json!({"ok": false, "error": msg})
 }
 
 /// Mint the CP's own ITA token at startup. Fatal on any failure —
@@ -934,4 +1080,53 @@ async fn cp_ita(State(s): State<St>) -> Result<Json<serde_json::Value>> {
         "token": token,
         "claims": claims,
     })))
+}
+
+/// GET /cp/noise/attest — the CP's long-term Noise static pubkey.
+/// Agents cache this on first contact and use it as the responder
+/// key for m2m Noise_IK handshakes. Matches the shape of bastion's
+/// own `/attest` so Phase 2d's TDX-quote-binds-pubkey upgrade works
+/// the same way here.
+///
+/// 404 when `DD_NOISE_KEY_DIR` wasn't set at startup (local-dev CP).
+async fn cp_noise_attest(State(s): State<St>) -> axum::response::Response {
+    let Some(key) = s.noise.as_ref() else {
+        return (
+            axum::http::StatusCode::NOT_FOUND,
+            Json(serde_json::json!({"error": "noise key not configured"})),
+        )
+            .into_response();
+    };
+
+    // Bind sha256(pubkey) into the TDX quote's REPORT_DATA. EE pads
+    // the 32-byte digest to 64 bytes internally; clients re-hash the
+    // advertised pubkey and compare after ITA verify.
+    let pk = key.public().as_bytes();
+    let digest = {
+        use sha2::{Digest, Sha256};
+        let mut h = Sha256::new();
+        h.update(pk);
+        let d = h.finalize();
+        let mut out = [0u8; 32];
+        out.copy_from_slice(&d);
+        out
+    };
+    use base64::Engine as _;
+    let report_data_b64 = base64::engine::general_purpose::STANDARD.encode(digest);
+
+    let mut body = serde_json::json!({
+        "noise_pubkey_hex": key.public_hex(),
+        "source": format!("{:?}", key.source()).to_lowercase(),
+    });
+    match s.ee.attest_with_report_data(&report_data_b64).await {
+        Ok(v) if v.get("ok").and_then(|b| b.as_bool()) == Some(true) => {
+            if let Some(q) = v.get("quote_b64").and_then(|q| q.as_str()) {
+                body["tdx_quote_b64"] = serde_json::Value::String(q.to_string());
+                body["report_data_b64"] = serde_json::Value::String(report_data_b64);
+            }
+        }
+        Ok(v) => eprintln!("cp: /cp/noise/attest EE said {v}"),
+        Err(e) => eprintln!("cp: /cp/noise/attest EE error: {e}"),
+    }
+    Json(body).into_response()
 }

--- a/crates/dd/src/ee.rs
+++ b/crates/dd/src/ee.rs
@@ -64,6 +64,19 @@ impl Ee {
             .await
     }
 
+    /// TDX attestation with caller-supplied 64-byte `REPORT_DATA`
+    /// (base64). Used to bind the Noise static pubkey into the
+    /// quote so a client can verify `sha256(noise_pubkey)` matches
+    /// the hardware-attested value. `data` must be ≤64 bytes; EE
+    /// rejects longer.
+    pub async fn attest_with_report_data(&self, data_b64: &str) -> Result<serde_json::Value> {
+        self.call(serde_json::json!({
+            "method": "attest",
+            "report_data_b64": data_b64,
+        }))
+        .await
+    }
+
     /// Deploy a workload at runtime. Spec is a workload object
     /// (`app_name`, `github_release`/`cmd`, `env`, ...) — we just set
     /// `method` and forward.

--- a/crates/dd/src/lib.rs
+++ b/crates/dd/src/lib.rs
@@ -9,4 +9,6 @@ pub mod gh_oidc;
 pub mod html;
 pub mod ita;
 pub mod metrics;
+pub mod noise_m2m;
+pub mod noise_rpc;
 pub mod stonith;

--- a/crates/dd/src/noise_m2m.rs
+++ b/crates/dd/src/noise_m2m.rs
@@ -1,0 +1,178 @@
+//! Noise_IK-backed m2m transport between CP and dd-agents.
+//!
+//! Both CP and agent own a long-term X25519 static keypair on disk.
+//! During registration they exchange pubkeys over a single Noise_IK
+//! handshake; subsequent RPCs (heartbeat, ingress/replace, agent list
+//! queries) travel through the authenticated channel instead of
+//! through ITA bearer tokens.
+//!
+//! This module owns the pubkey registry (pinned agent keys on the CP
+//! side, pinned CP key on the agent side) and a lightweight
+//! "execute one RPC" helper that runs a fresh handshake per call.
+//! We deliberately skip the connection-pool question for v1 —
+//! handshakes are cheap enough (one X25519 + one AEAD) and keeping
+//! state stateless keeps the migration small.
+//!
+//! CI callers (`dd-deploy`, `dd-logs`, `relaunch-agent`) keep using
+//! GitHub Actions OIDC tokens — ephemeral CI runners can't hold a
+//! stable device key, and OIDC *is* their attestation. Noise
+//! replaces the ITA bearer for enclave-to-enclave calls only.
+
+use dd_common::noise_static::NoiseStatic;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+/// Filename used under the data-dir for every process that owns a
+/// long-term Noise identity. Same on CP and agent — the dir changes
+/// (CP under `/var/lib/dd/cp/`, agent under `/var/lib/dd/agent/`)
+/// but the leaf name is stable so ops scripts can grep for it.
+pub const KEY_FILENAME: &str = "noise-static.key";
+
+/// Load-or-generate the local static key at `dir/noise-static.key`.
+/// Wraps [`NoiseStatic::load_or_generate`]; returns the loaded
+/// pubkey + source for the caller to log at startup.
+pub fn load_static(dir: &Path) -> std::io::Result<Arc<NoiseStatic>> {
+    let path: PathBuf = dir.join(KEY_FILENAME);
+    let key = NoiseStatic::load_or_generate(&path)?;
+    Ok(Arc::new(key))
+}
+
+/// Shared state kept on the CP: `agent_id → pinned pubkey`. Populated
+/// at registration (the first message from an agent establishes its
+/// pubkey; subsequent registrations must reuse the same one).
+#[derive(Default, Clone)]
+pub struct AgentRegistry {
+    inner: Arc<RwLock<HashMap<String, [u8; 32]>>>,
+}
+
+impl AgentRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Pin `pubkey` for `agent_id`. Returns `Err` if a different
+    /// pubkey was previously pinned — re-keying an agent requires
+    /// operator intervention (delete the entry and re-enrol) to
+    /// prevent a rogue agent from hijacking an existing agent_id
+    /// just by re-registering.
+    pub async fn pin(&self, agent_id: &str, pubkey: [u8; 32]) -> Result<PinOutcome, PinError> {
+        let mut guard = self.inner.write().await;
+        match guard.get(agent_id) {
+            Some(existing) if existing == &pubkey => Ok(PinOutcome::Reused),
+            Some(_existing) => Err(PinError::PubkeyMismatch),
+            None => {
+                guard.insert(agent_id.to_string(), pubkey);
+                Ok(PinOutcome::Fresh)
+            }
+        }
+    }
+
+    pub async fn get(&self, agent_id: &str) -> Option<[u8; 32]> {
+        self.inner.read().await.get(agent_id).copied()
+    }
+
+    pub async fn forget(&self, agent_id: &str) {
+        self.inner.write().await.remove(agent_id);
+    }
+
+    pub async fn len(&self) -> usize {
+        self.inner.read().await.len()
+    }
+
+    pub async fn is_empty(&self) -> bool {
+        self.inner.read().await.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PinOutcome {
+    /// First time we saw this agent_id — pubkey just persisted.
+    Fresh,
+    /// Agent re-registered with the same pubkey — normal on reboot.
+    Reused,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PinError {
+    /// Agent_id re-registered with a *different* pubkey. Either the
+    /// agent's disk was wiped and re-minted, or another enclave is
+    /// trying to impersonate it. CP rejects — operator must call
+    /// [`AgentRegistry::forget`] before the fresh pubkey is accepted.
+    PubkeyMismatch,
+}
+
+impl std::fmt::Display for PinError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PinError::PubkeyMismatch => f.write_str("agent pubkey changed — re-enrolment required"),
+        }
+    }
+}
+
+impl std::error::Error for PinError {}
+
+/// Helper used by the agent side: remember the CP's pubkey after the
+/// first `/attest` fetch so future handshakes pin it. Stored on disk
+/// so a bounce doesn't require a re-fetch.
+pub fn load_cp_pubkey(dir: &Path) -> Option<[u8; 32]> {
+    let bytes = std::fs::read(dir.join("cp-noise-pubkey")).ok()?;
+    if bytes.len() != 32 {
+        return None;
+    }
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&bytes);
+    Some(out)
+}
+
+pub fn save_cp_pubkey(dir: &Path, pubkey: &[u8; 32]) -> std::io::Result<()> {
+    std::fs::create_dir_all(dir)?;
+    std::fs::write(dir.join("cp-noise-pubkey"), pubkey)
+}
+
+/// Parse a 64-char lowercase-hex string into a 32-byte X25519 pubkey.
+/// Strict: rejects non-hex, wrong length, and uppercase so a bad key
+/// can't masquerade as a different valid one through normalization.
+pub fn decode_pubkey(hex: &str) -> std::result::Result<[u8; 32], String> {
+    if hex.len() != 64 {
+        return Err(format!("expected 64 hex chars, got {}", hex.len()));
+    }
+    let mut out = [0u8; 32];
+    for (i, chunk) in hex.as_bytes().chunks(2).enumerate() {
+        let s = std::str::from_utf8(chunk).map_err(|_| "non-ascii".to_string())?;
+        out[i] = u8::from_str_radix(s, 16).map_err(|e| format!("hex: {e}"))?;
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn registry_pins_first_then_rejects_mismatch() {
+        let reg = AgentRegistry::new();
+        let key_a = [1u8; 32];
+        let key_b = [2u8; 32];
+
+        assert_eq!(reg.pin("agent-1", key_a).await, Ok(PinOutcome::Fresh));
+        assert_eq!(reg.pin("agent-1", key_a).await, Ok(PinOutcome::Reused));
+        assert_eq!(
+            reg.pin("agent-1", key_b).await,
+            Err(PinError::PubkeyMismatch)
+        );
+
+        reg.forget("agent-1").await;
+        assert_eq!(reg.pin("agent-1", key_b).await, Ok(PinOutcome::Fresh));
+    }
+
+    #[test]
+    fn cp_pubkey_roundtrip_on_disk() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(load_cp_pubkey(dir.path()).is_none());
+        let key = [42u8; 32];
+        save_cp_pubkey(dir.path(), &key).unwrap();
+        assert_eq!(load_cp_pubkey(dir.path()), Some(key));
+    }
+}

--- a/crates/dd/src/noise_rpc.rs
+++ b/crates/dd/src/noise_rpc.rs
@@ -1,0 +1,223 @@
+//! CP↔agent m2m RPC over a Noise_IK-tunneled WebSocket.
+//!
+//! Replaces the ITA-bearer-over-HTTP pattern for calls where both
+//! sides have pinned static keys (set up at registration in
+//! `crate::noise_m2m::AgentRegistry`). Each call is a fresh
+//! WebSocket with a 1-RTT handshake + one request/response pair;
+//! no connection pooling. The rare-ops set (`ingress_replace`,
+//! `api_agents`, later `heartbeat`) absorbs the ~150 ms handshake
+//! cost without blinking.
+//!
+//! Auth is by pinned pubkey. The responder learns the initiator's
+//! static during the IK handshake and matches it against the
+//! registry; a mismatch or unknown pubkey → `unauthorized` response.
+//! No ITA bearer, no timestamp dance, no token rotation.
+//!
+//! Wire shape inside the encrypted tunnel is JSON:
+//!
+//! ```json
+//! // Request
+//! {"op": "ingress_replace", "agent_id": "...", "extras": [...]}
+//! // Response
+//! {"ok": true, "data": {...}}  |  {"ok": false, "error": "..."}
+//! ```
+//!
+//! The module exposes one server entry point (`serve`) and one
+//! client entry point (`call`); individual ops live in `cp.rs` /
+//! `agent.rs` where the state they need is already in scope.
+
+use dd_common::noise_static::NoiseStatic;
+use dd_common::noise_tunnel::{Initiator, Responder};
+use serde_json::Value;
+use std::sync::Arc;
+
+/// Drive one full responder session on an already-upgraded axum
+/// WebSocket. Consumes `msg1`, emits `msg2`, then reads a single
+/// encrypted request and sends a single encrypted response. Caller
+/// supplies the request dispatcher which receives the initiator's
+/// pubkey + the decoded request value.
+pub async fn serve<F, Fut>(
+    mut socket: axum::extract::ws::WebSocket,
+    noise_key: &NoiseStatic,
+    handler: F,
+) where
+    F: FnOnce([u8; 32], Value) -> Fut,
+    Fut: std::future::Future<Output = Value>,
+{
+    use axum::extract::ws::Message;
+
+    let mut responder = match Responder::new(noise_key.secret_bytes()) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("noise-rpc: responder init: {e}");
+            return;
+        }
+    };
+
+    let msg1 = match socket.recv().await {
+        Some(Ok(Message::Binary(b))) => b,
+        other => {
+            eprintln!("noise-rpc: expected binary msg1, got {other:?}");
+            return;
+        }
+    };
+    if let Err(e) = responder.read_msg1(&msg1) {
+        eprintln!("noise-rpc: msg1 read: {e}");
+        return;
+    }
+    let peer = match responder.peer_pubkey() {
+        Some(p) => p,
+        None => {
+            eprintln!("noise-rpc: missing peer pubkey after msg1");
+            return;
+        }
+    };
+    let msg2 = match responder.write_msg2(&[]) {
+        Ok(b) => b,
+        Err(e) => {
+            eprintln!("noise-rpc: msg2 write: {e}");
+            return;
+        }
+    };
+    if socket.send(Message::Binary(msg2.into())).await.is_err() {
+        return;
+    }
+    let mut transport = match responder.into_transport() {
+        Ok(t) => t,
+        Err(e) => {
+            eprintln!("noise-rpc: transport xition: {e}");
+            return;
+        }
+    };
+
+    // Single request / single response.
+    let cipher = match socket.recv().await {
+        Some(Ok(Message::Binary(b))) => b,
+        _ => return,
+    };
+    let plain = match transport.recv(&cipher) {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("noise-rpc: decrypt: {e}");
+            return;
+        }
+    };
+    let req: Value = match serde_json::from_slice(&plain) {
+        Ok(v) => v,
+        Err(e) => {
+            let _ = send_err(&mut socket, &mut transport, &format!("bad request: {e}")).await;
+            return;
+        }
+    };
+    let resp = handler(peer, req).await;
+    let Ok(out) = serde_json::to_vec(&resp) else {
+        return;
+    };
+    let Ok(ct) = transport.send(&out) else {
+        return;
+    };
+    let _ = socket.send(Message::Binary(ct.into())).await;
+}
+
+async fn send_err(
+    socket: &mut axum::extract::ws::WebSocket,
+    transport: &mut dd_common::noise_tunnel::Transport,
+    msg: &str,
+) -> std::io::Result<()> {
+    use axum::extract::ws::Message;
+    let body = serde_json::json!({"ok": false, "error": msg});
+    let Ok(bytes) = serde_json::to_vec(&body) else {
+        return Ok(());
+    };
+    let Ok(ct) = transport.send(&bytes) else {
+        return Ok(());
+    };
+    socket
+        .send(Message::Binary(ct.into()))
+        .await
+        .map_err(|e| std::io::Error::other(format!("{e}")))
+}
+
+/// Open `wss_url`, run the Noise_IK handshake as initiator, send one
+/// encrypted JSON request, read one encrypted response, close.
+///
+/// `client_static` is the agent's long-term keypair;
+/// `server_pubkey` is the CP's pinned pubkey (cached after
+/// `/cp/noise/attest`). Returns the decoded response `Value` or an
+/// error if any step fails.
+pub async fn call(
+    wss_url: &str,
+    client_static: &Arc<NoiseStatic>,
+    server_pubkey: &[u8; 32],
+    request: Value,
+) -> Result<Value, CallError> {
+    use futures_util::{SinkExt, StreamExt};
+    use tokio_tungstenite::tungstenite::protocol::Message;
+
+    let (mut ws, _resp) = tokio_tungstenite::connect_async(wss_url)
+        .await
+        .map_err(|e| CallError::Connect(format!("{e}")))?;
+
+    let mut initiator = Initiator::new(client_static.secret_bytes(), server_pubkey)
+        .map_err(|e| CallError::Handshake(format!("init: {e}")))?;
+    let msg1 = initiator
+        .write_msg1(&[])
+        .map_err(|e| CallError::Handshake(format!("msg1: {e}")))?;
+    ws.send(Message::Binary(msg1.into()))
+        .await
+        .map_err(|e| CallError::Connect(format!("send msg1: {e}")))?;
+
+    let msg2 = match ws.next().await {
+        Some(Ok(Message::Binary(b))) => b,
+        Some(Ok(other)) => return Err(CallError::Handshake(format!("msg2 wrong kind: {other:?}"))),
+        Some(Err(e)) => return Err(CallError::Connect(format!("{e}"))),
+        None => return Err(CallError::Connect("closed before msg2".into())),
+    };
+    initiator
+        .read_msg2(&msg2)
+        .map_err(|e| CallError::Handshake(format!("msg2: {e}")))?;
+    let mut transport = initiator
+        .into_transport()
+        .map_err(|e| CallError::Handshake(format!("transport: {e}")))?;
+
+    let plain = serde_json::to_vec(&request).map_err(|e| CallError::Encode(format!("{e}")))?;
+    let ct = transport
+        .send(&plain)
+        .map_err(|e| CallError::Encode(format!("encrypt: {e}")))?;
+    ws.send(Message::Binary(ct.into()))
+        .await
+        .map_err(|e| CallError::Connect(format!("send req: {e}")))?;
+
+    let resp = match ws.next().await {
+        Some(Ok(Message::Binary(b))) => b,
+        Some(Ok(other)) => return Err(CallError::Decode(format!("resp wrong kind: {other:?}"))),
+        Some(Err(e)) => return Err(CallError::Connect(format!("{e}"))),
+        None => return Err(CallError::Connect("closed before response".into())),
+    };
+    let plain_resp = transport
+        .recv(&resp)
+        .map_err(|e| CallError::Decode(format!("decrypt: {e}")))?;
+    let _ = ws.close(None).await;
+    serde_json::from_slice(&plain_resp).map_err(|e| CallError::Decode(format!("{e}")))
+}
+
+#[derive(Debug)]
+pub enum CallError {
+    Connect(String),
+    Handshake(String),
+    Encode(String),
+    Decode(String),
+}
+
+impl std::fmt::Display for CallError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CallError::Connect(s) => write!(f, "connect: {s}"),
+            CallError::Handshake(s) => write!(f, "handshake: {s}"),
+            CallError::Encode(s) => write!(f, "encode: {s}"),
+            CallError::Decode(s) => write!(f, "decode: {s}"),
+        }
+    }
+}
+
+impl std::error::Error for CallError {}


### PR DESCRIPTION
Single-commit roll-up of the whole Noise track (formerly six stacked PRs). Signed-up scope from the user: "just combine it into 1 pr". Old PRs #176–#181 all closed in favor of this one.

## What ships

**Shared primitive (dd-common)**
- `noise_static::NoiseStatic` — persistent X25519 keypair, chmod 0600, source-tracked.
- `noise_tunnel::{Responder, Initiator, Transport}` — Noise_IK on `snow` + `x25519-dalek`, 1-RTT mutual auth.

**Bastion server**
- `GET /attest` — pubkey + TDX quote whose `REPORT_DATA = sha256(noise_pubkey)`.
- `GET /noise/ws` — Noise-tunneled JSON RPC (sessions list/create/delete/ping).
- `GET /noise/shell/{id}` — Noise-tunneled PTY; 1-byte frame tag (0x01 raw / 0x02 JSON) to skip base64 overhead on stdout.
- `Manager::with_noise_key` + `Manager::with_ee_socket` wire the endpoints in.

**Browser**
- `noise.ts` — hand-rolled Noise_IK state machine on `@noble/curves` + `@noble/ciphers` + `@noble/hashes`. ~280 LoC, no wasm, +44 KB gzipped.
- `tunnel.ts` — `Tunnel` (id-correlated RPC) + `ShellTunnel` (WebSocket-shaped PTY).
- `ui.svelte.ts` caches tunnels per connector; fetch / create / kill prefer tunnel when pubkey pinned.
- `TerminalPane.svelte` uses Noise when cross-origin + pinned.
- Vitest round-trip tests (initiator + responder end-to-end).

**CF Access**
- Path-scoped bypasses for `block.{host}/attest` + `block.{host}/noise*` on every CP and agent subdomain with the admin `block` label. Noise is its own auth, so CF Access can bypass without a session cookie.

**CP ↔ agent m2m**
- `noise_m2m::AgentRegistry` — per-agent_id pubkey pin; mismatch on re-register returns 400.
- `/register` carries `noise_pubkey_hex` both directions; agent saves the CP pubkey under `DD_NOISE_KEY_DIR/cp-noise-pubkey`.
- `GET /cp/noise/attest` — pubkey + TDX quote (mirrors bastion's).
- `noise_rpc::{serve, call}` — generic one-shot Noise_IK RPC over tokio-tungstenite.
- `GET /noise/rpc` on CP; first op cut over is `ingress_replace`. Auth = pubkey pin match; no ITA bearer on the call.
- Agent's `push_extra_ingress` prefers Noise, falls back to HTTP+ITA on any failure — preserves backward compat with unmigrated nodes.

**Workloads**
- `dd-agent` + `dd-management` templates set `DD_NOISE_KEY_DIR`.

## Auth model change

`/ingress/replace`:
- Before: fresh ITA JWT every call, CP round-trips to Intel per request.
- After: pubkey pinned at registration (ITA-attested then). Subsequent calls prove ownership of the pinned private key — cryptographic, no per-call ITA round-trip.

## Test plan

- [x] `cargo test --workspace` — 39 pass
- [x] `npx vitest run` (crates/bastion/web) — 5 pass
- [x] `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`
- [x] SPA build clean (395 KB gzipped)
- [ ] Preview: sidebar multi-enclave sessions list over Noise (no CORS console errors, binary-only WS frames after handshake)
- [ ] Preview: terminal works cross-origin via `/noise/shell/{id}` (resize + block events + exit)
- [ ] Preview: `curl .../attest` + `.../cp/noise/attest` return `tdx_quote_b64` + `report_data_b64`; `sha256(pubkey)` matches the decoded report_data
- [ ] Preview: deploy a workload with `expose`; agent log shows `ingress/replace (noise) ok` instead of `(http)`

## Not in scope / follow-ups

- `/api/agents` bearer, heartbeat scraping → Noise (same pattern as ingress_replace).
- Browser-side ITA verification of the quote before pinning (belongs with Phase 3 pairing).
- Tear out the HTTP+ITA fallback once every node has keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)