### PR TITLE
chore(ci): force-cleanup-tunnels workflow (dispatch by env)

### DIFF
--- a/.github/workflows/force-cleanup-tunnels.yml
+++ b/.github/workflows/force-cleanup-tunnels.yml
@@ -1,0 +1,132 @@
+name: Force cleanup tunnels
+
+# Manually reap CF tunnels + GCE VMs for a specific dd env (e.g. `pr-182`).
+#
+# Primary use case: a PR's preview deploy has left orphan CF tunnels
+# from previous failed attempts. Those tunnels survive `kill_old_tunnels`
+# races because all the old CPs have already stopped running and no
+# new CP has self_tunnel_id matching them. This workflow nukes the
+# orphans so the next deploy has a clean CF state.
+#
+# Unlike `reap-merged-pr-previews` in cleanup.yml, this runs regardless
+# of PR open/closed state — the operator explicitly names the env.
+
+on:
+  workflow_dispatch:
+    inputs:
+      env:
+        description: 'dd env to reap (e.g. pr-182, pr-200, staging)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  force-cleanup:
+    runs-on: ubuntu-latest
+    environment: staging
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      GCP_ZONE: us-central1-c
+    steps:
+      - uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: 'projects/654815109728/locations/global/workloadIdentityPools/github-actions-pool/providers/github-provider'
+          service_account: 'easyenclave-staging-ci@eestaging.iam.gserviceaccount.com'
+      - uses: google-github-actions/setup-gcloud@v2
+      - name: Reap ${{ inputs.env }} — VMs + CF tunnels + DNS
+        env:
+          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+          CF_API_TOKEN:   ${{ secrets.DD_CP_CF_API_TOKEN }}
+          CF_ACCOUNT_ID:  ${{ secrets.DD_CP_CF_ACCOUNT_ID }}
+          CF_ZONE_ID:     ${{ secrets.DD_CP_CF_ZONE_ID }}
+          DD_DOMAIN:      ${{ vars.DD_CF_DOMAIN || 'devopsdefender.com' }}
+          TARGET_ENV:     ${{ inputs.env }}
+        run: |
+          set -euo pipefail
+          echo "Force-reaping env: $TARGET_ENV"
+
+          # VMs
+          vms=$(gcloud compute instances list \
+            --project="$GCP_PROJECT_ID" \
+            --filter="labels.devopsdefender=managed AND labels.dd_env=$TARGET_ENV" \
+            --format='value(name)')
+          if [ -n "$vms" ]; then
+            echo "Deleting VMs: $(echo "$vms" | tr '\n' ' ')"
+            # shellcheck disable=SC2086
+            gcloud compute instances delete $vms \
+              --project="$GCP_PROJECT_ID" --zone="$GCP_ZONE" --quiet
+          else
+            echo "No VMs to delete."
+          fi
+
+          # CF tunnels — named `dd-{env}-{uuid}` (cp-*, agent-*, etc.)
+          resp=$(curl -fsS \
+            -H "Authorization: Bearer $CF_API_TOKEN" \
+            "https://api.cloudflare.com/client/v4/accounts/$CF_ACCOUNT_ID/cfd_tunnel?is_deleted=false&per_page=200")
+          ids=$(echo "$resp" | jq -r --arg prefix "dd-$TARGET_ENV-" \
+            '.result[] | select(.name | startswith($prefix)) | "\(.id)\t\(.name)"')
+          if [ -n "$ids" ]; then
+            echo "Found tunnels:"
+            echo "$ids" | sed 's/^/  /'
+            echo "$ids" | while IFS=$'\t' read -r id name; do
+              echo "  deleting connections for $name ($id)"
+              curl -fsS -X DELETE \
+                -H "Authorization: Bearer $CF_API_TOKEN" \
+                "https://api.cloudflare.com/client/v4/accounts/$CF_ACCOUNT_ID/cfd_tunnel/$id/connections" \
+                >/dev/null || true
+              echo "  deleting tunnel $id"
+              curl -fsS -X DELETE \
+                -H "Authorization: Bearer $CF_API_TOKEN" \
+                "https://api.cloudflare.com/client/v4/accounts/$CF_ACCOUNT_ID/cfd_tunnel/$id" \
+                >/dev/null || true
+            done
+          else
+            echo "No tunnels to delete."
+          fi
+
+          # CF Access apps — named `dd-{env}-*`.
+          apps=$(curl -fsS \
+            -H "Authorization: Bearer $CF_API_TOKEN" \
+            "https://api.cloudflare.com/client/v4/accounts/$CF_ACCOUNT_ID/access/apps?per_page=1000" \
+            | jq -r --arg prefix "dd-$TARGET_ENV-" \
+            '.result[] | select(.name | startswith($prefix)) | "\(.id)\t\(.name)"')
+          if [ -n "$apps" ]; then
+            echo "Found Access apps:"
+            echo "$apps" | sed 's/^/  /'
+            echo "$apps" | while IFS=$'\t' read -r id name; do
+              echo "  deleting app $name ($id)"
+              curl -fsS -X DELETE \
+                -H "Authorization: Bearer $CF_API_TOKEN" \
+                "https://api.cloudflare.com/client/v4/accounts/$CF_ACCOUNT_ID/access/apps/$id" \
+                >/dev/null || true
+            done
+          else
+            echo "No Access apps to delete."
+          fi
+
+          # DNS records pointing at *.cfargotunnel.com for this env
+          # (the CP's primary hostname + any workload subdomains).
+          dns=$(curl -fsS \
+            -H "Authorization: Bearer $CF_API_TOKEN" \
+            "https://api.cloudflare.com/client/v4/zones/$CF_ZONE_ID/dns_records?per_page=500&type=CNAME" \
+            | jq -r --arg host "$TARGET_ENV.$DD_DOMAIN" --arg dash "$TARGET_ENV-" \
+            '.result[] | select((.name == $host) or (.name | startswith($dash))) | "\(.id)\t\(.name)"')
+          if [ -n "$dns" ]; then
+            echo "Found DNS records:"
+            echo "$dns" | sed 's/^/  /'
+            echo "$dns" | while IFS=$'\t' read -r id name; do
+              echo "  deleting DNS $name ($id)"
+              curl -fsS -X DELETE \
+                -H "Authorization: Bearer $CF_API_TOKEN" \
+                "https://api.cloudflare.com/client/v4/zones/$CF_ZONE_ID/dns_records/$id" \
+                >/dev/null || true
+            done
+          else
+            echo "No DNS records to delete."
+          fi
+
+          echo "Done reaping $TARGET_ENV."


### PR DESCRIPTION
Adds `workflow_dispatch` to reap CF tunnels + VMs + DNS for a named env, regardless of PR state. Fills the gap left by cleanup.yml's `reap-merged-pr-previews` which only targets *closed* PRs.

**Why now**: #182 keeps hitting a 302 on `/cp/attest` despite the PR's Rust + workload templates working fine in a local QEMU TDX boot. The failure mode (serial cuts off mid-prefetch, subsequent gcloud serial fetches return empty) suggests the new VM's tunnel is being deleted by a lingering reaper from a prior failed attempt on pr-182 — standard STONITH cross-kill pattern. No existing workflow can clean an open PR's orphans.

**Scope**: new file only. No other change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)