### PR TITLE
feat(apps): vllm workload + generic deploy-workload dispatch

### DIFF
--- a/.github/workflows/deploy-workload.yml
+++ b/.github/workflows/deploy-workload.yml
@@ -1,0 +1,55 @@
+name: Deploy workload
+
+# Generic workload deployer — run any `apps/*/workload.json{,.tmpl}`
+# on the production GPU agent (or any other DD agent you have access
+# to) via the existing `dd-deploy` composite action.
+#
+# The agent's `/deploy` endpoint is gated by GitHub Actions OIDC, so
+# deploying a new workload HAS to originate from a workflow run; you
+# can't hit it from your laptop. This workflow is that entry point —
+# one dispatchable for the whole apps tree, not a separate workflow
+# per app.
+#
+# Usage:
+#   gh workflow run deploy-workload.yml \
+#     -f workload=apps/vllm/workload.json \
+#     -f vm-name=dd-local-prod
+
+on:
+  workflow_dispatch:
+    inputs:
+      workload:
+        description: 'Path to workload JSON (e.g. apps/vllm/workload.json)'
+        required: true
+        type: string
+      vm-name:
+        description: 'Target agent vm_name as seen on /api/agents'
+        required: false
+        type: string
+        default: dd-local-prod
+      cp-url:
+        description: 'CP URL the dd-deploy action discovers the agent through'
+        required: false
+        type: string
+        default: https://app.devopsdefender.com
+      wait-seconds:
+        description: 'Seconds to wait for the deployment to show up in /health'
+        required: false
+        type: string
+        default: '600'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Deploy ${{ inputs.workload }} to ${{ inputs.vm-name }}
+        uses: ./.github/actions/dd-deploy
+        with:
+          cp-url: ${{ inputs.cp-url }}
+          vm-name: ${{ inputs.vm-name }}
+          workload: ${{ inputs.workload }}
+          wait-for-deployment-seconds: ${{ inputs.wait-seconds }}

--- a/apps/vllm/workload.json
+++ b/apps/vllm/workload.json
@@ -1,0 +1,8 @@
+{
+  "app_name": "vllm",
+  "expose": { "hostname_label": "vllm", "port": 8000 },
+  "cmd": [
+    "/bin/busybox", "sh", "-c",
+    "until [ -x /var/lib/easyenclave/bin/podman ]; do sleep 2; done\nexec /var/lib/easyenclave/bin/podman run --rm --name vllm --network=host --ipc=host --device=/dev/nvidia0 --device=/dev/nvidiactl --device=/dev/nvidia-uvm --device=/dev/nvidia-uvm-tools docker.io/vllm/vllm-openai:latest --model Qwen/Qwen2.5-0.5B-Instruct --host 0.0.0.0 --port 8000 --gpu-memory-utilization 0.6 --max-model-len 4096"
+  ]
+}


### PR DESCRIPTION
Two complementary pieces:

## 1. `apps/vllm/workload.json`
vllm/vllm-openai:latest serving `Qwen/Qwen2.5-0.5B-Instruct` on `vllm.<agent-base>.devopsdefender.com:8000`. Mirrors `apps/web-nvidia-smi`: `--network=host` + the four `/dev/nvidia*` devices. Depends on the `nv` boot workload.

## 2. `deploy-workload.yml` — one dispatchable for any workload
Agent's `/deploy` endpoint requires GH Actions OIDC (verified in-code against GitHub's JWKS with owner match). Deploys have to originate from a workflow run — can't curl from a laptop.

Instead of one workflow per app, this is a **generic** dispatch that takes `workload` as an input. Future apps just dispatch with a different path — no new PR.

## Usage after merge

```
gh workflow run deploy-workload.yml -f workload=apps/vllm/workload.json -f vm-name=dd-local-prod
```

## Verification

- `curl https://<agent-base>-vllm.devopsdefender.com/v1/models`
- OpenAI-compatible chat: POST /v1/chat/completions with the Qwen model name