### PR TITLE
fix(deploy): cap prod agent RAM at 32 GiB under VFIO discard limit

### DIFF
--- a/apps/_infra/local-agents.sh
+++ b/apps/_infra/local-agents.sh
@@ -282,11 +282,14 @@ PY
   # preview agents concurrently.
   #
   #   preview (no GPU):  RAM =  16 GiB, vCPU =  4
-  #   prod    (H100):    RAM =  98 GiB, vCPU = 16
-  #                      (RAM = VRAM + 4 = 94 + 4 = 98 per the rule)
+  #   prod    (H100):    RAM =  32 GiB, vCPU = 16
   local mem_kib vcpus
   if [ "$with_gpu" = "yes" ]; then
-    mem_kib=102760448   # 98 GiB
+    # Capped at 32 GiB to stay under the VFIO RAM-discard listener
+    # limit (16M mappings; TDX guest_memfd discards at 4 KiB, so 64 GiB
+    # is the hard ceiling and 32 GiB leaves headroom for device
+    # regions). Raise via 1 GiB hugepages on the host before bumping.
+    mem_kib=33554432    # 32 GiB
     vcpus=16
   else
     mem_kib=16777216    # 16 GiB


### PR DESCRIPTION
## Summary
- Caps the prod agent VM RAM at 32 GiB (down from 98 GiB in #188) so `virsh start` doesn't exhaust the VFIO RAM-discard listener cap on the H100 passthrough.
- Preview sizing (16 GiB, no passthrough) is unchanged.

## Why
Release on main started failing on `virsh start dd-local-prod` ([run 24751899713](https://github.com/devopsdefender/dd/actions/runs/24751899713/job/72416793231)) with:

```
vfio 0000:0d:00.0: failed to setup container for group 13: memory listener initialization failed:
Region pc.ram: vfio_ram_discard_register_listener: possibly running out of DMA mappings.
Maximum possible DMA mappings: 16777216
```

TDX `launchSecurity` uses `guest_memfd` with 4 KiB discard granularity. 98 GiB / 4 KiB ≈ 25.7M regions > the 16M VFIO listener cap. 32 GiB ≈ 8.4M regions — ~50% headroom after device BARs/ROMs also consume a slice.

Raising back toward the capacity rule needs 1 GiB hugepages reserved on the host (98 hugepage listener entries instead of 25.7M), which is a host-side change, not a repo change — out of scope here.

## Test plan
- [ ] Merge to main
- [ ] Release workflow runs on the push; `deploy-production / deploy → Relaunch dd-local-prod` now succeeds
- [ ] `Deploy hello-world` + `Deploy web-nvidia-smi` OIDC steps run against the freshly-booted agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)