### PR TITLE
fix(ci): STONITH reaps GCE orphans on target=ssh deploys

### DIFF
--- a/.github/workflows/deploy-cp.yml
+++ b/.github/workflows/deploy-cp.yml
@@ -82,16 +82,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # GCP auth only configured on target=gcp. SSH deploys don't
-      # touch GCE at all — their state lives on the tdx2 baremetal
-      # (libvirt domains) and in Cloudflare (tunnels + Access apps).
+      # GCP auth configured on every deploy. target=gcp creates a GCE
+      # instance; target=ssh still needs to be able to reap any GCE
+      # instance left behind by a prior gcp-target deploy (see the
+      # STONITH step below) — so the gate lives in the step that uses
+      # the auth, not the auth setup itself. Callers are expected to
+      # always pass `workload_identity_provider` + `service_account`;
+      # release.yml does this unconditionally for both staging and
+      # production environments.
       - uses: google-github-actions/auth@v2
-        if: inputs.target == 'gcp'
         with:
           workload_identity_provider: ${{ inputs.workload_identity_provider }}
           service_account: ${{ inputs.service_account }}
       - uses: google-github-actions/setup-gcloud@v2
-        if: inputs.target == 'gcp'
 
       - name: Relaunch SSH CP VM (target=ssh)
         if: inputs.target == 'ssh'
@@ -440,37 +443,63 @@ jobs:
       # force-delete) behind the user-facing outputs (PR comment,
       # relaunched local agent).
       - name: Verify STONITH halted prior VM(s) in this env
-        if: inputs.target == 'gcp'
         env:
           GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
         run: |
-          # dd-register STONITHs the old VM on startup by deleting its
-          # CF tunnel → old cloudflared exits → old dd-register poweroffs.
-          # Scoped to this env — per-PR previews are hostname-isolated,
-          # so this only reaps prior deploys of the same env.
-          NEW_VM=$(gcloud compute instances list \
-            --project="$GCP_PROJECT_ID" \
-            --filter="labels.devopsdefender=managed AND labels.dd_env=${DD_ENV}" \
-            --format="value(name)" --sort-by=~creationTimestamp | head -1)
-          echo "new VM: $NEW_VM"
-          SURVIVORS=""
-          for i in $(seq 1 24); do
-            SURVIVORS=$(gcloud compute instances list \
+          if [ "${{ inputs.target }}" = "gcp" ]; then
+            # dd-register STONITHs the old VM on startup by deleting its
+            # CF tunnel → old cloudflared exits → old dd-register poweroffs.
+            # Scoped to this env — per-PR previews are hostname-isolated,
+            # so this only reaps prior deploys of the same env.
+            NEW_VM=$(gcloud compute instances list \
               --project="$GCP_PROJECT_ID" \
-              --filter="labels.devopsdefender=managed AND labels.dd_env=${DD_ENV} AND status=RUNNING" \
-              --format="value(name)" \
-              | grep -vx "$NEW_VM" || true)
-            if [ -z "$SURVIVORS" ]; then
-              echo "STONITH verified — only $NEW_VM running in ${DD_ENV}"
+              --filter="labels.devopsdefender=managed AND labels.dd_env=${DD_ENV}" \
+              --format="value(name)" --sort-by=~creationTimestamp | head -1)
+            echo "new VM: $NEW_VM"
+            SURVIVORS=""
+            for i in $(seq 1 24); do
+              SURVIVORS=$(gcloud compute instances list \
+                --project="$GCP_PROJECT_ID" \
+                --filter="labels.devopsdefender=managed AND labels.dd_env=${DD_ENV} AND status=RUNNING" \
+                --format="value(name)" \
+                | grep -vx "$NEW_VM" || true)
+              if [ -z "$SURVIVORS" ]; then
+                echo "STONITH verified — only $NEW_VM running in ${DD_ENV}"
+                exit 0
+              fi
+              echo "  still running besides $NEW_VM: $(echo "$SURVIVORS" | tr '\n' ' ')"
+              echo "  waiting for STONITH poweroff... (${i}/24)"
+              sleep 5
+            done
+            echo "::warning::STONITH-by-tunnel-delete timed out; force-deleting zombies:"
+            echo "$SURVIVORS"
+            # shellcheck disable=SC2086
+            gcloud compute instances delete $SURVIVORS \
+              --project="$GCP_PROJECT_ID" --zone="$GCP_ZONE" --quiet || true
+            echo "zombies reaped; $NEW_VM is the only ${DD_ENV} VM"
+          else
+            # target=ssh: the CP runs on tdx2 baremetal (libvirt), so no
+            # GCE instance should exist under these labels. Anything we
+            # find is an orphan from a prior gcp-target deploy — reap it.
+            # Includes TERMINATED instances: the attached disk still bills.
+            # Global list (no --zone filter) so orphans in unexpected
+            # zones are caught; per-instance delete uses the listed zone.
+            ORPHANS=$(gcloud compute instances list \
+              --project="$GCP_PROJECT_ID" \
+              --filter="labels.devopsdefender=managed AND labels.dd_env=${DD_ENV}" \
+              --format="value(name,zone)")
+            if [ -z "$ORPHANS" ]; then
+              echo "no GCE instances to reap for ${DD_ENV} (target=ssh)"
               exit 0
             fi
-            echo "  still running besides $NEW_VM: $(echo "$SURVIVORS" | tr '\n' ' ')"
-            echo "  waiting for STONITH poweroff... (${i}/24)"
-            sleep 5
-          done
-          echo "::warning::STONITH-by-tunnel-delete timed out; force-deleting zombies:"
-          echo "$SURVIVORS"
-          # shellcheck disable=SC2086
-          gcloud compute instances delete $SURVIVORS \
-            --project="$GCP_PROJECT_ID" --zone="$GCP_ZONE" --quiet || true
-          echo "zombies reaped; $NEW_VM is the only ${DD_ENV} VM"
+            echo "::warning::target=ssh but GCE orphans remain from a prior gcp deploy; reaping:"
+            echo "$ORPHANS"
+            echo "$ORPHANS" | while read -r name zone; do
+              [ -n "$name" ] || continue
+              # zone column is a full URL; strip to the basename.
+              zone="${zone##*/}"
+              gcloud compute instances delete "$name" \
+                --project="$GCP_PROJECT_ID" --zone="$zone" --quiet || true
+            done
+            echo "orphan reap complete for ${DD_ENV}"
+          fi


### PR DESCRIPTION
## Summary
- Closes the structural STONITH gap introduced by #188's `target: gcp|ssh` switch: `gcp → ssh` transitions (or any future target toggle) no longer leak GCE instances.
- Zero behavior change for `target=gcp` deploys — the existing "preserve newest, reap siblings" logic is byte-identical.
- One file: `.github/workflows/deploy-cp.yml`.

## Why
[Release run 24751899713](https://github.com/devopsdefender/dd/actions/runs/24751899713/job/72416793231) died before `Verify STONITH halted prior VM(s) in this env`, but even if it had reached that step the STONITH step is gated `if: inputs.target == 'gcp'`. On `target=ssh` the step is skipped entirely, so a prior production CP still running on GCE stays up — and keeps billing — forever.

## Change
1. Remove the `if: inputs.target == 'gcp'` gate on the `google-github-actions/auth@v2` + `setup-gcloud@v2` steps. `release.yml` already passes `workload_identity_provider` + `service_account` for both `staging` and `production` environments, so auth succeeds unconditionally.
2. Remove the same gate from the STONITH step. Branch inside the script:
   - `target=gcp`: existing logic unchanged.
   - `target=ssh`: no CP exists on GCE by definition, so reap **all** instances matching `labels.devopsdefender=managed AND labels.dd_env=${DD_ENV}` (any status — TERMINATED disks still bill). Global list (no `--zone` filter), per-instance delete uses the listed zone so orphans in unexpected zones are caught.

## Pre-merge check (manual, one-time)
Before merging, run the orphan query from your laptop to capture forensic state before the auto-reaper erases it:
```
gcloud compute instances list \
  --project=easyenclave \
  --filter="labels.devopsdefender=managed AND labels.dd_env=production" \
  --format="table(name,status,zone,creationTimestamp,labels)"
```
Anything older than #188's merge (2026-04-21T22:04Z) is an orphan from the gcp→ssh flip.

## Test plan
- [ ] PR #189 merged first (RAM cap so agent-relaunch succeeds)
- [ ] Manual orphan list captured + reviewed
- [ ] Merge this PR; watch the Release run on main
- [ ] STONITH step prints either "no GCE instances to reap for production (target=ssh)" or "target=ssh but GCE orphans remain...; reaping:"
- [ ] Re-run the orphan query post-merge — expect zero rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)