### PR TITLE
feat(bastion): Noise_IK terminal API — /attest + /noise/ws + /noise/shell/{id}

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,41 @@
 version = 4
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -118,9 +153,11 @@ dependencies = [
  "futures-util",
  "libc",
  "portable-pty",
+ "rand 0.8.5",
  "reqwest",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
  "tokio",
  "tower-http",
@@ -139,6 +176,15 @@ name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "block-buffer"
@@ -184,6 +230,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -195,6 +265,17 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -223,6 +304,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -232,8 +348,12 @@ checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 name = "dd-common"
 version = "0.1.0"
 dependencies = [
+ "rand 0.8.5",
  "serde",
  "serde_json",
+ "snow",
+ "tempfile",
+ "x25519-dalek",
 ]
 
 [[package]]
@@ -275,6 +395,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -315,6 +436,12 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "filedescriptor"
@@ -448,6 +575,16 @@ dependencies = [
  "r-efi 6.0.0",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
 ]
 
 [[package]]
@@ -723,6 +860,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "ioctl-rs"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -922,6 +1068,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -948,6 +1100,29 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
 
 [[package]]
 name = "portable-pty"
@@ -1207,6 +1382,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1392,6 +1576,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shared_library"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1446,6 +1641,23 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "snow"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "599b506ccc4aff8cf7844bc42cf783009a434c1e26c964432560fb6d6ad02d82"
+dependencies = [
+ "aes-gcm",
+ "blake2",
+ "chacha20poly1305",
+ "curve25519-dalek",
+ "getrandom 0.3.4",
+ "ring",
+ "rustc_version",
+ "sha2",
+ "subtle",
+]
 
 [[package]]
 name = "socket2"
@@ -1786,6 +1998,16 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "untrusted"
@@ -2416,6 +2638,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core 0.6.4",
+ "serde",
+ "zeroize",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2484,6 +2718,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"

--- a/crates/bastion/Cargo.toml
+++ b/crates/bastion/Cargo.toml
@@ -27,6 +27,8 @@ libc = "0.2"
 portable-pty = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+sha2 = "0.10"
+rand = "0.8"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 tokio = { version = "1", features = ["fs", "macros", "rt-multi-thread", "sync", "io-util", "net", "signal"] }
 tower-http = { version = "0.6", features = ["cors"] }

--- a/crates/bastion/src/bin/bastion.rs
+++ b/crates/bastion/src/bin/bastion.rs
@@ -8,7 +8,7 @@ use axum::Router;
 async fn main() -> std::io::Result<()> {
     let args: Vec<String> = std::env::args().collect();
     if args.get(1).map(|s| s.as_str()) != Some("serve") {
-        eprintln!("usage: bastion serve [--port N] [--bind ADDR] [--capture-socket PATH] [--ee-socket PATH] [--cp-url URL]");
+        eprintln!("usage: bastion serve [--port N] [--bind ADDR] [--capture-socket PATH] [--ee-socket PATH] [--cp-url URL] [--noise-key PATH]");
         std::process::exit(2);
     }
 
@@ -17,6 +17,7 @@ async fn main() -> std::io::Result<()> {
     let mut capture_socket: Option<String> = None;
     let mut ee_socket: Option<String> = None;
     let mut cp_url: Option<String> = None;
+    let mut noise_key_path: Option<String> = None;
     let mut i = 2;
     while i < args.len() {
         match args[i].as_str() {
@@ -42,6 +43,10 @@ async fn main() -> std::io::Result<()> {
                 cp_url = args.get(i + 1).cloned();
                 i += 2;
             }
+            "--noise-key" => {
+                noise_key_path = args.get(i + 1).cloned();
+                i += 2;
+            }
             other => {
                 eprintln!("bastion: unknown arg {other}");
                 std::process::exit(2);
@@ -57,6 +62,25 @@ async fn main() -> std::io::Result<()> {
         eprintln!("bastion: cross-node aggregator against CP {url}");
         mgr = mgr.with_cp_url(url);
     }
+    if let Some(path) = noise_key_path.as_deref().filter(|s| !s.is_empty()) {
+        // Load (or mint on first boot) the long-term Noise static
+        // keypair. Exposed via `GET /attest` so clients can pin the
+        // pubkey for Phase 2b's Noise_KK handshake.
+        match bastion::noise::NoiseStatic::load_or_generate(path) {
+            Ok(key) => {
+                eprintln!(
+                    "bastion: noise static key {:?} ({}…)",
+                    key.source(),
+                    &key.public_hex()[..16]
+                );
+                mgr = mgr.with_noise_key(key);
+            }
+            Err(e) => {
+                eprintln!("bastion: noise key load at {path}: {e}");
+                std::process::exit(1);
+            }
+        }
+    }
 
     if let Some(path) = capture_socket {
         if let Err(e) = bastion::capture::spawn_listener(&path, mgr.clone()).await {
@@ -67,14 +91,18 @@ async fn main() -> std::io::Result<()> {
         }
     }
 
-    if let Some(path) = ee_socket {
+    if let Some(path) = ee_socket.as_deref().filter(|s| !s.is_empty()) {
         // Pull-based bootstrap: on startup (and every 30s after),
         // query EE's `list` + `logs` over its unix socket and seed
         // the Manager so boot workloads render with their history.
         // Requires `inherit_token: true` in the workload spec so the
         // Tier-1 seal lets us talk to EE.
         eprintln!("bastion: ee_sync polling {path}");
-        bastion::ee_sync::start(mgr.clone(), &path);
+        bastion::ee_sync::start(mgr.clone(), path);
+        // Also remember the path so /attest can mint a TDX quote
+        // bound to the Noise pubkey (Phase 2d). Same socket, different
+        // EE method.
+        mgr = mgr.with_ee_socket(path);
     }
 
     let addr = format!("{bind}:{port}");

--- a/crates/bastion/src/ee.rs
+++ b/crates/bastion/src/ee.rs
@@ -97,4 +97,19 @@ impl EeClient {
             })
             .unwrap_or_default())
     }
+
+    /// `{"method":"attest","report_data_b64":"..."}` — TDX quote with
+    /// caller-supplied REPORT_DATA. Used by `/attest` to bind the
+    /// Noise static pubkey into the quote (Phase 2d). `data_b64` must
+    /// base64-decode to ≤64 bytes; EE rejects longer.
+    pub async fn attest_with_report_data(
+        &self,
+        data_b64: &str,
+    ) -> std::io::Result<serde_json::Value> {
+        self.call(serde_json::json!({
+            "method": "attest",
+            "report_data_b64": data_b64,
+        }))
+        .await
+    }
 }

--- a/crates/bastion/src/lib.rs
+++ b/crates/bastion/src/lib.rs
@@ -48,6 +48,12 @@ pub mod capture;
 pub mod ee;
 pub mod ee_sync;
 
+/// Re-export so `bastion::noise::NoiseStatic` + `bastion::noise_tunnel::*`
+/// continue to work after the primitives moved into `dd-common` (shared
+/// with the CP / agent m2m path).
+pub use dd_common::noise_static as noise;
+pub use dd_common::noise_tunnel;
+
 use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
 use axum::extract::{Path, State};
 use axum::response::{Html, IntoResponse};
@@ -220,6 +226,19 @@ pub struct Manager {
     /// in the fleet. Absent → single-node fallback.
     cp_url: Option<Arc<str>>,
     http: reqwest::Client,
+    /// Long-term Noise static keypair. Clients fetch the pubkey
+    /// via `GET /attest` and pin it; Phase 2b runs a Noise_KK
+    /// handshake keyed by this + a client static key. Absent in
+    /// standalone dev / local-embedder mode — `/attest` then
+    /// responds 404.
+    noise: Option<Arc<noise::NoiseStatic>>,
+    /// Path to easyenclave's unix socket. When set, `/attest`
+    /// fetches a fresh TDX quote with `REPORT_DATA = sha256(noise_pubkey)`
+    /// and includes it in the response so clients can verify the
+    /// pubkey came from a genuine enclave (Phase 2d). Absent →
+    /// `/attest` still returns the pubkey, just without an
+    /// attached quote.
+    ee_socket: Option<Arc<str>>,
 }
 
 impl Default for Manager {
@@ -234,6 +253,8 @@ impl Manager {
             inner: Arc::new(RwLock::new(Default::default())),
             cp_url: None,
             http: reqwest::Client::new(),
+            noise: None,
+            ee_socket: None,
         }
     }
 
@@ -246,6 +267,27 @@ impl Manager {
         let url = url.into();
         if !url.is_empty() {
             self.cp_url = Some(Arc::from(url));
+        }
+        self
+    }
+
+    /// Attach the persistent Noise static keypair. When set, `GET
+    /// /attest` returns `{noise_pubkey_hex}` so clients can pin it
+    /// before Phase 2b's Noise_KK handshake. Absent → `/attest`
+    /// returns 404.
+    pub fn with_noise_key(mut self, key: noise::NoiseStatic) -> Self {
+        self.noise = Some(Arc::new(key));
+        self
+    }
+
+    /// Point at easyenclave's unix socket so `/attest` can return a
+    /// TDX quote with `REPORT_DATA = sha256(noise_pubkey)`. Clients
+    /// / auditors use this to verify the advertised pubkey came from
+    /// a genuine enclave rather than a MITM serving its own key.
+    pub fn with_ee_socket(mut self, path: impl Into<String>) -> Self {
+        let p = path.into();
+        if !p.is_empty() {
+            self.ee_socket = Some(Arc::from(p));
         }
         self
     }
@@ -760,11 +802,94 @@ pub fn router(manager: Manager) -> Router {
 
     Router::new()
         .route("/", get(page))
+        .route("/attest", get(attest))
         .route("/api/sessions", get(list_sessions).post(create_session))
         .route("/api/sessions/{id}", delete(kill_session))
         .route("/ws/{id}", get(ws_upgrade))
+        .route("/noise/ws", get(noise_ws_upgrade))
+        .route("/noise/shell/{id}", get(noise_shell_upgrade))
         .layer(cors)
         .with_state(manager)
+}
+
+/// GET /attest — returns this bastion's long-term Noise static
+/// pubkey. Clients pin the returned `noise_pubkey_hex` and use it
+/// as the responder key for the Noise_IK handshake.
+///
+/// When an easyenclave socket is configured (`with_ee_socket`), the
+/// response also carries a TDX attestation quote whose REPORT_DATA
+/// is `sha256(noise_pubkey)`. Clients / auditors submit the quote
+/// to Intel Trust Authority; a successful verify proves the advertised
+/// pubkey came from a genuinely-measured enclave rather than a MITM
+/// serving its own key. Quote mint failures don't fail the endpoint
+/// — the pubkey is still useful for transport encryption even without
+/// the attestation, and callers can retry.
+///
+/// 404 when no Noise keypair is configured (standalone dev,
+/// embedders that didn't call `Manager::with_noise_key`).
+async fn attest(State(m): State<Manager>) -> impl IntoResponse {
+    let Some(key) = m.noise.as_ref() else {
+        return (
+            axum::http::StatusCode::NOT_FOUND,
+            Json(serde_json::json!({
+                "error": "noise key not configured"
+            })),
+        )
+            .into_response();
+    };
+
+    // Bind sha256(pubkey) into the TDX quote's REPORT_DATA. SHA-256
+    // is 32 bytes; EE pads to 64 internally. Client verifies by
+    // re-hashing the cached pubkey and comparing against the quote's
+    // REPORT_DATA field after ITA verification.
+    let quote = attach_noise_quote(&m, key.public().as_bytes()).await;
+
+    let mut body = serde_json::json!({
+        "noise_pubkey_hex": key.public_hex(),
+        "source": format!("{:?}", key.source()).to_lowercase(),
+    });
+    if let Some((quote_b64, report_data_b64)) = quote {
+        body["tdx_quote_b64"] = serde_json::Value::String(quote_b64);
+        body["report_data_b64"] = serde_json::Value::String(report_data_b64);
+    }
+    Json(body).into_response()
+}
+
+/// Mint a TDX quote binding `sha256(noise_pubkey)` into REPORT_DATA.
+/// Returns `(quote_b64, report_data_b64)` on success, or `None` if no
+/// EE socket is configured or the socket call failed — the caller
+/// downgrades gracefully by omitting the fields from the response.
+async fn attach_noise_quote(m: &Manager, pubkey_bytes: &[u8]) -> Option<(String, String)> {
+    let ee_path = m.ee_socket.as_ref()?;
+    // SHA-256 over the raw 32-byte pubkey. Domain separation isn't
+    // needed: REPORT_DATA is scoped to this bastion's quote and the
+    // client verifies both halves against the same pubkey.
+    let digest = {
+        use sha2::{Digest, Sha256};
+        let mut h = Sha256::new();
+        h.update(pubkey_bytes);
+        let d = h.finalize();
+        let mut out = [0u8; 32];
+        out.copy_from_slice(&d);
+        out
+    };
+    use base64::Engine as _;
+    let report_data_b64 = base64::engine::general_purpose::STANDARD.encode(digest);
+    let ee = crate::ee::EeClient::new(ee_path.as_ref());
+    match ee.attest_with_report_data(&report_data_b64).await {
+        Ok(v) if v.get("ok").and_then(|b| b.as_bool()) == Some(true) => {
+            let q = v.get("quote_b64")?.as_str()?.to_string();
+            Some((q, report_data_b64))
+        }
+        Ok(v) => {
+            eprintln!("bastion: /attest EE said {v}");
+            None
+        }
+        Err(e) => {
+            eprintln!("bastion: /attest EE error: {e}");
+            None
+        }
+    }
 }
 
 async fn page(State(m): State<Manager>) -> impl IntoResponse {
@@ -1024,6 +1149,493 @@ async fn ws_loop(mut socket: WebSocket, id: String, m: Manager) {
         _ = inbound => {},
         _ = outbound => {},
     }
+}
+
+// ---------------------------------------------------------------------
+// /noise/shell/{id} — Noise_IK-tunneled PTY streaming
+//
+// Mirrors `/ws/{id}` but every frame rides inside a Noise_IK
+// transport. Inside the encrypted tunnel we use a 1-byte type tag so
+// we don't pay base64 overhead on the high-volume stdout stream:
+//   0x01 <bytes>      — raw PTY data (stdin client→server or
+//                       stdout server→client)
+//   0x02 <json-bytes> — control frame (resize/hello/block/exit/...)
+// ---------------------------------------------------------------------
+
+const NOISE_FRAME_RAW: u8 = 0x01;
+const NOISE_FRAME_CTRL: u8 = 0x02;
+
+async fn noise_shell_upgrade(
+    ws: WebSocketUpgrade,
+    Path(id): Path<String>,
+    State(m): State<Manager>,
+) -> impl IntoResponse {
+    ws.on_upgrade(move |socket| noise_shell_loop(socket, id, m))
+}
+
+async fn noise_shell_loop(mut socket: WebSocket, id: String, m: Manager) {
+    use futures_util::StreamExt;
+
+    let Some(noise_key) = m.noise.clone() else {
+        let _ = socket
+            .send(Message::Text(
+                r#"{"error":"noise_not_configured"}"#.to_string().into(),
+            ))
+            .await;
+        return;
+    };
+
+    // Drive the IK handshake first. Same dance as /noise/ws.
+    let mut responder = match noise_tunnel::Responder::new(noise_key.secret_bytes()) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("bastion/noise-shell: responder init: {e}");
+            return;
+        }
+    };
+    let msg1 = match socket.recv().await {
+        Some(Ok(Message::Binary(b))) => b,
+        other => {
+            eprintln!("bastion/noise-shell: expected binary msg1, got {other:?}");
+            return;
+        }
+    };
+    if let Err(e) = responder.read_msg1(&msg1) {
+        eprintln!("bastion/noise-shell: msg1 read: {e}");
+        return;
+    }
+    let peer_pub = responder
+        .peer_pubkey()
+        .map(|p| format!("{}…", &crate::noise::hex_encode(&p)[..16]))
+        .unwrap_or_else(|| "?".into());
+    let msg2 = match responder.write_msg2(&[]) {
+        Ok(b) => b,
+        Err(e) => {
+            eprintln!("bastion/noise-shell: msg2 write: {e}");
+            return;
+        }
+    };
+    if socket.send(Message::Binary(msg2.into())).await.is_err() {
+        return;
+    }
+    let transport = match responder.into_transport() {
+        Ok(t) => t,
+        Err(e) => {
+            eprintln!("bastion/noise-shell: transport xition: {e}");
+            return;
+        }
+    };
+    eprintln!("bastion/noise-shell: tunnel up for session {id} (peer={peer_pub})");
+
+    // Wrap the transport + split socket eagerly so the not-found and
+    // replay paths use the same Arc<Mutex> dispatch as the hot loops.
+    let transport = Arc::new(Mutex::new(transport));
+    let (sink, mut stream) = socket.split();
+    let sink = Arc::new(Mutex::new(sink));
+
+    let Some(session) = m.get(&id).await else {
+        noise_send_ctrl(
+            &sink,
+            &transport,
+            &serde_json::json!({"type":"error","code":"not_found"}),
+        )
+        .await;
+        return;
+    };
+
+    // Replay: current ring + blocks + ready, same as ws_loop but
+    // through the encrypted channel.
+    {
+        let ring_bytes: Vec<u8> = session.ring.lock().await.iter().copied().collect();
+        if !ring_bytes.is_empty() {
+            noise_send_raw(&sink, &transport, &ring_bytes).await;
+        }
+        let blocks = session.blocks.read().await;
+        for b in blocks.iter() {
+            noise_send_ctrl(
+                &sink,
+                &transport,
+                &serde_json::json!({
+                    "type": "block",
+                    "session_id": b.session_id,
+                    "kind": b.kind,
+                    "seq": b.seq,
+                    "started_at_ms": b.started_at_ms,
+                    "ended_at_ms": b.ended_at_ms,
+                    "command": b.command,
+                    "output_b64": b.output_b64,
+                    "exit_code": b.exit_code,
+                }),
+            )
+            .await;
+        }
+        let seq = *session.next_seq.lock().await;
+        noise_send_ctrl(
+            &sink,
+            &transport,
+            &serde_json::json!({"type":"ready","seq":seq}),
+        )
+        .await;
+    }
+
+    let mut rx = session.tx.subscribe();
+    let writer = session.writer.clone();
+    let master = session.master.clone();
+    let transport_in = transport.clone();
+
+    let inbound = async move {
+        while let Some(Ok(msg)) = stream.next().await {
+            let Message::Binary(cipher) = msg else {
+                if matches!(msg, Message::Close(_)) {
+                    break;
+                }
+                // Plaintext text frames are invalid once the tunnel
+                // is up; drop them.
+                continue;
+            };
+            let plain = {
+                let mut t = transport_in.lock().await;
+                match t.recv(&cipher) {
+                    Ok(p) => p,
+                    Err(e) => {
+                        eprintln!("bastion/noise-shell: decrypt: {e}");
+                        break;
+                    }
+                }
+            };
+            if plain.is_empty() {
+                continue;
+            }
+            match plain[0] {
+                NOISE_FRAME_RAW => {
+                    let Some(w) = writer.clone() else { continue };
+                    let bytes = plain[1..].to_vec();
+                    let _ = tokio::task::spawn_blocking(move || {
+                        let mut g = w.blocking_lock();
+                        let _ = g.write_all(&bytes);
+                    })
+                    .await;
+                }
+                NOISE_FRAME_CTRL => {
+                    let Ok(msg) = serde_json::from_slice::<ClientMsg>(&plain[1..]) else {
+                        continue;
+                    };
+                    match msg {
+                        ClientMsg::Resize(r) => {
+                            let Some(m) = master.as_ref() else { continue };
+                            let g = m.lock().await;
+                            let _ = g.resize(PtySize {
+                                rows: r.rows.max(4),
+                                cols: r.cols.max(8),
+                                pixel_width: 0,
+                                pixel_height: 0,
+                            });
+                        }
+                        ClientMsg::Hello(_) => {}
+                    }
+                }
+                _ => {} // Unknown frame type — ignore.
+            }
+        }
+    };
+
+    let sink_out = sink.clone();
+    let transport_out = transport.clone();
+    let outbound = async move {
+        loop {
+            let ev = match rx.recv().await {
+                Ok(e) => e,
+                Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                Err(_) => break,
+            };
+            let ok = match ev {
+                Event::Raw(bytes) => noise_send_raw(&sink_out, &transport_out, &bytes).await,
+                Event::Block(b) => {
+                    noise_send_ctrl(
+                        &sink_out,
+                        &transport_out,
+                        &serde_json::json!({
+                            "type": "block",
+                            "session_id": b.session_id,
+                            "kind": b.kind,
+                            "seq": b.seq,
+                            "started_at_ms": b.started_at_ms,
+                            "ended_at_ms": b.ended_at_ms,
+                            "command": b.command,
+                            "output_b64": b.output_b64,
+                            "exit_code": b.exit_code,
+                        }),
+                    )
+                    .await
+                }
+                Event::Exit(code) => {
+                    noise_send_ctrl(
+                        &sink_out,
+                        &transport_out,
+                        &serde_json::json!({"type":"exit","code":code}),
+                    )
+                    .await;
+                    false
+                }
+            };
+            if !ok {
+                break;
+            }
+        }
+    };
+
+    tokio::select! {
+        _ = inbound => {},
+        _ = outbound => {},
+    }
+}
+
+/// Encrypt + send a raw-bytes frame (PTY stdout). Returns `false` if
+/// the sink has died so the caller can break its loop.
+async fn noise_send_raw(
+    sink: &Arc<Mutex<futures_util::stream::SplitSink<WebSocket, Message>>>,
+    transport: &Arc<Mutex<noise_tunnel::Transport>>,
+    bytes: &[u8],
+) -> bool {
+    let mut framed = Vec::with_capacity(bytes.len() + 1);
+    framed.push(NOISE_FRAME_RAW);
+    framed.extend_from_slice(bytes);
+    let cipher = {
+        let mut t = transport.lock().await;
+        match t.send(&framed) {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("bastion/noise-shell: encrypt raw: {e}");
+                return false;
+            }
+        }
+    };
+    use futures_util::SinkExt;
+    let mut s = sink.lock().await;
+    s.send(Message::Binary(cipher.into())).await.is_ok()
+}
+
+/// Encrypt + send a JSON control frame (block, exit, ready, ...).
+async fn noise_send_ctrl(
+    sink: &Arc<Mutex<futures_util::stream::SplitSink<WebSocket, Message>>>,
+    transport: &Arc<Mutex<noise_tunnel::Transport>>,
+    payload: &serde_json::Value,
+) -> bool {
+    let Ok(json) = serde_json::to_vec(payload) else {
+        return false;
+    };
+    let mut framed = Vec::with_capacity(json.len() + 1);
+    framed.push(NOISE_FRAME_CTRL);
+    framed.extend_from_slice(&json);
+    let cipher = {
+        let mut t = transport.lock().await;
+        match t.send(&framed) {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("bastion/noise-shell: encrypt ctrl: {e}");
+                return false;
+            }
+        }
+    };
+    use futures_util::SinkExt;
+    let mut s = sink.lock().await;
+    s.send(Message::Binary(cipher.into())).await.is_ok()
+}
+
+// ---------------------------------------------------------------------
+// /noise/ws — Noise_IK-tunneled JSON RPC
+// ---------------------------------------------------------------------
+
+/// JSON-over-Noise request/response envelope. Every request carries an
+/// `id` so the client can correlate responses on a single multiplexed
+/// tunnel. `op` discriminates the call; payload fields are flattened.
+///
+/// Phase 2b scope: `sessions.list` / `sessions.create` / `sessions.delete`
+/// only. Phase 2c will add `shell.open` / `shell.input` / `shell.resize`
+/// for tunneling the terminal WS body.
+#[derive(Debug, Deserialize)]
+struct NoiseReq {
+    id: u64,
+    #[serde(flatten)]
+    body: NoiseReqBody,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "op", rename_all = "snake_case")]
+enum NoiseReqBody {
+    SessionsList,
+    SessionsCreate {
+        title: Option<String>,
+    },
+    SessionsDelete {
+        session_id: String,
+    },
+    /// Heartbeat — response echoes the current server time. Lets the
+    /// client tell "tunnel alive" from "app hung."
+    Ping,
+}
+
+#[derive(Debug, Serialize)]
+struct NoiseResp {
+    id: u64,
+    #[serde(flatten)]
+    body: NoiseRespBody,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+enum NoiseRespBody {
+    /// Named `sessions` field so serde's `#[serde(tag)]` internal-
+    /// tagging works (it can't internally-tag a bare `Vec`).
+    Sessions {
+        sessions: Vec<SessionInfo>,
+    },
+    Session {
+        session: SessionInfo,
+    },
+    Ok,
+    Err {
+        msg: String,
+    },
+    Pong {
+        server_time_ms: u64,
+    },
+}
+
+async fn noise_ws_upgrade(ws: WebSocketUpgrade, State(m): State<Manager>) -> impl IntoResponse {
+    ws.on_upgrade(move |socket| noise_ws_loop(socket, m))
+}
+
+async fn noise_ws_loop(mut socket: WebSocket, m: Manager) {
+    let Some(noise_key) = m.noise.clone() else {
+        // No server key configured. Close with an unencrypted text
+        // frame so the client can log a sensible error rather than
+        // staring at a silent drop.
+        let _ = socket
+            .send(Message::Text(
+                r#"{"error":"noise_not_configured"}"#.to_string().into(),
+            ))
+            .await;
+        return;
+    };
+
+    // Drive the IK handshake first. Client sends msg1, server
+    // responds with msg2, both enter transport mode.
+    let mut responder = match noise_tunnel::Responder::new(noise_key.secret_bytes()) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("bastion/noise: responder init: {e}");
+            return;
+        }
+    };
+
+    let msg1 = match socket.recv().await {
+        Some(Ok(Message::Binary(b))) => b,
+        other => {
+            eprintln!("bastion/noise: expected binary msg1, got {other:?}");
+            return;
+        }
+    };
+    if let Err(e) = responder.read_msg1(&msg1) {
+        eprintln!("bastion/noise: msg1 read: {e}");
+        return;
+    }
+    let peer_pub = responder
+        .peer_pubkey()
+        .map(|p| format!("{}…", &crate::noise::hex_encode(&p)[..16]))
+        .unwrap_or_else(|| "?".into());
+    let msg2 = match responder.write_msg2(&[]) {
+        Ok(b) => b,
+        Err(e) => {
+            eprintln!("bastion/noise: msg2 write: {e}");
+            return;
+        }
+    };
+    if socket.send(Message::Binary(msg2.into())).await.is_err() {
+        return;
+    }
+    let mut transport = match responder.into_transport() {
+        Ok(t) => t,
+        Err(e) => {
+            eprintln!("bastion/noise: transport xition: {e}");
+            return;
+        }
+    };
+    eprintln!("bastion/noise: tunnel up (peer={peer_pub})");
+
+    // Serve requests on the encrypted stream. Each inbound binary
+    // frame is one decrypted JSON `NoiseReq`; response is one frame.
+    while let Some(frame) = socket.recv().await {
+        let Ok(Message::Binary(cipher)) = frame else {
+            continue;
+        };
+        let plain = match transport.recv(&cipher) {
+            Ok(p) => p,
+            Err(e) => {
+                eprintln!("bastion/noise: decrypt: {e}");
+                break;
+            }
+        };
+        let resp = dispatch_noise_req(&m, &plain).await;
+        let resp_bytes = match serde_json::to_vec(&resp) {
+            Ok(b) => b,
+            Err(e) => {
+                eprintln!("bastion/noise: encode resp: {e}");
+                break;
+            }
+        };
+        let ct = match transport.send(&resp_bytes) {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("bastion/noise: encrypt: {e}");
+                break;
+            }
+        };
+        if socket.send(Message::Binary(ct.into())).await.is_err() {
+            break;
+        }
+    }
+}
+
+async fn dispatch_noise_req(m: &Manager, plain: &[u8]) -> NoiseResp {
+    let req: NoiseReq = match serde_json::from_slice(plain) {
+        Ok(r) => r,
+        Err(e) => {
+            return NoiseResp {
+                id: 0,
+                body: NoiseRespBody::Err {
+                    msg: format!("bad request: {e}"),
+                },
+            };
+        }
+    };
+    let body = match req.body {
+        NoiseReqBody::SessionsList => NoiseRespBody::Sessions {
+            sessions: m.list().await,
+        },
+        NoiseReqBody::SessionsCreate { title } => {
+            let t = title.unwrap_or_else(|| "shell".to_string());
+            match m.create(t).await {
+                Ok(s) => NoiseRespBody::Session { session: s.info() },
+                Err(e) => NoiseRespBody::Err {
+                    msg: format!("create: {e}"),
+                },
+            }
+        }
+        NoiseReqBody::SessionsDelete { session_id } => {
+            if m.remove(&session_id).await {
+                NoiseRespBody::Ok
+            } else {
+                NoiseRespBody::Err {
+                    msg: "not_found".to_string(),
+                }
+            }
+        }
+        NoiseReqBody::Ping => NoiseRespBody::Pong {
+            server_time_ms: now_ms(),
+        },
+    };
+    NoiseResp { id: req.id, body }
 }
 
 // ---------------------------------------------------------------------

--- a/crates/dd-common/Cargo.toml
+++ b/crates/dd-common/Cargo.toml
@@ -6,5 +6,11 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
+rand = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+snow = "0.10"
+x25519-dalek = { version = "2", features = ["static_secrets"] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/dd-common/src/lib.rs
+++ b/crates/dd-common/src/lib.rs
@@ -1,10 +1,14 @@
 //! Types shared between the `devopsdefender` binary (CP + agent modes)
 //! and the `bastion` binary (block-aware terminal + workload-capture).
 //!
-//! Today this is just [`BlockRecord`] — the wire shape for a single
-//! segmented event, shared so the CP (which will eventually aggregate
-//! across nodes) and bastion (which emits) can deserialize the same
-//! JSON without duplicating the type.
+//! - [`BlockRecord`] — the wire shape for a single segmented event.
+//! - [`noise_tunnel`] — Noise_IK handshake primitive used by both
+//!   browser↔bastion tunnels and CP↔agent m2m.
+//! - [`noise_static`] — persistent X25519 keypair shared as the
+//!   Noise "static" key for every long-lived identity.
+
+pub mod noise_static;
+pub mod noise_tunnel;
 
 use serde::{Deserialize, Serialize};
 

--- a/crates/dd-common/src/noise_static.rs
+++ b/crates/dd-common/src/noise_static.rs
@@ -1,0 +1,203 @@
+//! Noise handshake groundwork (Phase 2a — scaffolding only).
+//!
+//! This module owns bastion's long-term Noise static keypair. The
+//! keypair is generated once on first boot and persisted so
+//! subsequent boots (or restarts within the same VM) reuse the same
+//! pubkey. Clients that have already pinned the pubkey after an
+//! attested handshake (Phase 2d) won't see it rotate without
+//! reason.
+//!
+//! Phase 2b will add the actual Noise_KK handshake + encrypted
+//! `/api/sessions` and `/ws/*` channels; Phase 2d binds the pubkey
+//! into the TDX quote's `REPORT_DATA` so clients can verify the
+//! keypair came from a genuine attested enclave. Today we just
+//! expose the pubkey via `GET /attest` so client code can start
+//! caching it.
+
+use std::path::{Path, PathBuf};
+
+use rand::rngs::OsRng;
+use x25519_dalek::{PublicKey, StaticSecret};
+
+/// 32-byte Noise static key material persisted on disk. Passed to
+/// [`Manager::with_noise_key`](crate::Manager::with_noise_key) so
+/// HTTP handlers can expose the pubkey.
+pub struct NoiseStatic {
+    #[allow(dead_code)] // Kept for future x25519-dalek-direct uses
+    secret: StaticSecret,
+    /// Cached raw 32-byte secret — `snow::Builder::local_private_key`
+    /// wants a byte slice and x25519-dalek won't hand one out.
+    secret_cache: [u8; 32],
+    public: PublicKey,
+    source: NoiseKeySource,
+}
+
+impl std::fmt::Debug for NoiseStatic {
+    /// Never print the secret half. `{:?}` shows only the pubkey
+    /// (truncated) + the source so an accidental log line doesn't
+    /// leak the long-term identity.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let hex = self.public_hex();
+        let short = &hex[..hex.len().min(16)];
+        write!(f, "NoiseStatic({:?}, {}…)", self.source, short)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum NoiseKeySource {
+    /// Fresh random key, written to disk for the first time.
+    Generated,
+    /// Loaded from an existing on-disk key file.
+    Loaded,
+}
+
+impl NoiseStatic {
+    pub fn public(&self) -> &PublicKey {
+        &self.public
+    }
+
+    /// Raw 32-byte secret. Consumed by the Noise handshake responder
+    /// in [`crate::noise_tunnel::Responder::new`]. Never serialize
+    /// this — `Debug` deliberately hides it.
+    pub fn secret_bytes(&self) -> &[u8; 32] {
+        &self.secret_cache
+    }
+
+    /// Hex-encoded pubkey for JSON wire use.
+    pub fn public_hex(&self) -> String {
+        hex::encode(self.public.as_bytes())
+    }
+
+    pub fn source(&self) -> NoiseKeySource {
+        self.source
+    }
+
+    /// Ephemeral in-memory keypair. Used for tests and for the
+    /// standalone `bastion serve` local-dev binary where persistence
+    /// isn't meaningful across restarts.
+    pub fn ephemeral() -> Self {
+        let secret = StaticSecret::random_from_rng(OsRng);
+        let public = PublicKey::from(&secret);
+        let secret_cache = secret.to_bytes();
+        Self {
+            secret,
+            secret_cache,
+            public,
+            source: NoiseKeySource::Generated,
+        }
+    }
+
+    /// Load an existing static key from `path`, or mint a fresh one
+    /// and write it if the file doesn't exist. Always `chmod 0600`
+    /// after write — the file is the enclave's long-term identity;
+    /// only bastion should read it.
+    pub fn load_or_generate(path: impl AsRef<Path>) -> std::io::Result<Self> {
+        let path: PathBuf = path.as_ref().to_path_buf();
+        if path.exists() {
+            let bytes = std::fs::read(&path)?;
+            if bytes.len() != 32 {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!(
+                        "noise key file {} is {} bytes; expected 32",
+                        path.display(),
+                        bytes.len()
+                    ),
+                ));
+            }
+            let mut sk = [0u8; 32];
+            sk.copy_from_slice(&bytes);
+            let secret = StaticSecret::from(sk);
+            let public = PublicKey::from(&secret);
+            return Ok(Self {
+                secret,
+                secret_cache: sk,
+                public,
+                source: NoiseKeySource::Loaded,
+            });
+        }
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let s = Self::ephemeral();
+        let bytes: [u8; 32] = s.secret.to_bytes();
+        std::fs::write(&path, bytes)?;
+        chmod_0600(&path)?;
+        Ok(Self {
+            secret: s.secret,
+            secret_cache: s.secret_cache,
+            public: s.public,
+            source: NoiseKeySource::Generated,
+        })
+    }
+}
+
+fn chmod_0600(path: &Path) -> std::io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    let mut perms = std::fs::metadata(path)?.permissions();
+    perms.set_mode(0o600);
+    std::fs::set_permissions(path, perms)
+}
+
+// `hex` is pulled in transitively via existing deps; if the
+// transitive path changes, add `hex = "0.4"` to `Cargo.toml`
+// explicitly.
+mod hex {
+    pub fn encode(bytes: &[u8]) -> String {
+        let mut s = String::with_capacity(bytes.len() * 2);
+        for b in bytes {
+            s.push_str(&format!("{b:02x}"));
+        }
+        s
+    }
+}
+
+/// Module-public hex encoder so other parts of bastion (the
+/// `/noise/ws` handler's peer-pubkey log line, for instance) can
+/// format byte slices the same way `public_hex` does.
+pub fn hex_encode(bytes: &[u8]) -> String {
+    hex::encode(bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ephemeral_is_random_each_call() {
+        let a = NoiseStatic::ephemeral();
+        let b = NoiseStatic::ephemeral();
+        assert_ne!(a.public().as_bytes(), b.public().as_bytes());
+        assert_eq!(a.public_hex().len(), 64);
+    }
+
+    #[test]
+    fn load_or_generate_is_stable_across_calls() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("noise-static.key");
+        let first = NoiseStatic::load_or_generate(&path).unwrap();
+        let second = NoiseStatic::load_or_generate(&path).unwrap();
+        assert_eq!(first.public().as_bytes(), second.public().as_bytes());
+        assert!(matches!(first.source(), NoiseKeySource::Generated));
+        assert!(matches!(second.source(), NoiseKeySource::Loaded));
+    }
+
+    #[test]
+    fn load_or_generate_rejects_wrong_length() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("corrupt.key");
+        std::fs::write(&path, b"too short").unwrap();
+        let err = NoiseStatic::load_or_generate(&path).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn key_file_is_chmod_0600() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("noise-static.key");
+        let _ = NoiseStatic::load_or_generate(&path).unwrap();
+        let perms = std::fs::metadata(&path).unwrap().permissions();
+        assert_eq!(perms.mode() & 0o777, 0o600);
+    }
+}

--- a/crates/dd-common/src/noise_tunnel.rs
+++ b/crates/dd-common/src/noise_tunnel.rs
@@ -1,0 +1,240 @@
+//! Noise_IK tunnel primitive (Phase 2b).
+//!
+//! Wraps `snow` with a small state machine so the axum `/noise/ws`
+//! handler and the TS client implementation can stay focused on
+//! framing. Pattern is **Noise_IK_25519_ChaChaPoly_SHA256**:
+//!
+//! - Initiator knows responder's static pubkey up-front (fetched via
+//!   `GET /attest` in Phase 2a) — enables server auth on the first
+//!   roundtrip with no prior handshake.
+//! - Initiator's static pubkey is transmitted inside the handshake
+//!   (encrypted under the ephemeral-static DH) — server learns the
+//!   client identity after msg1, can pin or accept per policy.
+//!
+//! IK is 1-RTT: client sends msg1, server sends msg2, both sides
+//! are in transport mode. Matches a WebSocket's
+//! client-speaks-first model.
+//!
+//! Pairing / device-key registry is intentionally out of scope here
+//! — the server accepts any initiator pubkey today and logs it;
+//! Phase 3 adds a pinning layer that rejects unknown keys.
+
+use snow::{params::NoiseParams, HandshakeState, TransportState};
+use std::sync::LazyLock;
+
+pub static PARAMS: LazyLock<NoiseParams> = LazyLock::new(|| {
+    "Noise_IK_25519_ChaChaPoly_SHA256"
+        .parse()
+        .expect("valid noise params")
+});
+
+/// Established Noise session. Both sides have symmetric ciphers
+/// keyed from the handshake; `peer_pubkey` is the counterpart's
+/// long-term static (32 raw X25519 bytes).
+pub struct Transport {
+    state: TransportState,
+    peer_pubkey: [u8; 32],
+}
+
+impl Transport {
+    /// Encrypt + authenticate a payload. Returns the ciphertext to
+    /// frame on the wire.
+    pub fn send(&mut self, plain: &[u8]) -> Result<Vec<u8>, snow::Error> {
+        let mut buf = vec![0u8; plain.len() + 16];
+        let len = self.state.write_message(plain, &mut buf)?;
+        buf.truncate(len);
+        Ok(buf)
+    }
+
+    /// Decrypt + verify a ciphertext. Returns the plaintext.
+    pub fn recv(&mut self, cipher: &[u8]) -> Result<Vec<u8>, snow::Error> {
+        let mut buf = vec![0u8; cipher.len()];
+        let len = self.state.read_message(cipher, &mut buf)?;
+        buf.truncate(len);
+        Ok(buf)
+    }
+
+    pub fn peer_pubkey(&self) -> &[u8; 32] {
+        &self.peer_pubkey
+    }
+}
+
+/// Responder (server) side of a Noise_IK handshake. Owns the
+/// server's long-term static key and runs exactly one handshake
+/// roundtrip per instance.
+pub struct Responder {
+    state: HandshakeState,
+}
+
+impl Responder {
+    pub fn new(local_secret: &[u8; 32]) -> Result<Self, snow::Error> {
+        let state = snow::Builder::new(PARAMS.clone())
+            .local_private_key(local_secret)?
+            .build_responder()?;
+        Ok(Self { state })
+    }
+
+    /// Consume the initiator's first message (`-> e, es, s, ss`).
+    /// After this call the responder has the initiator's static
+    /// pubkey available via [`Responder::peer_pubkey`].
+    pub fn read_msg1(&mut self, msg: &[u8]) -> Result<Vec<u8>, snow::Error> {
+        let mut buf = vec![0u8; msg.len()];
+        let len = self.state.read_message(msg, &mut buf)?;
+        buf.truncate(len);
+        Ok(buf)
+    }
+
+    /// Produce the responder's reply (`<- e, ee, se`).
+    pub fn write_msg2(&mut self, payload: &[u8]) -> Result<Vec<u8>, snow::Error> {
+        let mut buf = vec![0u8; payload.len() + 96];
+        let len = self.state.write_message(payload, &mut buf)?;
+        buf.truncate(len);
+        Ok(buf)
+    }
+
+    /// Initiator's static pubkey, learned during [`read_msg1`]. Used
+    /// by the server for logging + (future) pinning. Returns `None`
+    /// if called before msg1 has been consumed.
+    pub fn peer_pubkey(&self) -> Option<[u8; 32]> {
+        let raw = self.state.get_remote_static()?;
+        let mut out = [0u8; 32];
+        out.copy_from_slice(raw);
+        Some(out)
+    }
+
+    /// Transition to transport mode once the handshake is complete.
+    /// Caller is responsible for having done one read + one write
+    /// in order before calling; `snow` panics otherwise.
+    pub fn into_transport(self) -> Result<Transport, snow::Error> {
+        let peer = self.peer_pubkey().ok_or(snow::Error::State(
+            snow::error::StateProblem::MissingKeyMaterial,
+        ))?;
+        let state = self.state.into_transport_mode()?;
+        Ok(Transport {
+            state,
+            peer_pubkey: peer,
+        })
+    }
+}
+
+/// Initiator (client) side. Used in tests + by CP↔agent peering;
+/// the browser implementation is in `crates/bastion/web/src/noise.ts`.
+pub struct Initiator {
+    state: HandshakeState,
+    remote_pub: [u8; 32],
+}
+
+impl Initiator {
+    pub fn new(local_secret: &[u8; 32], remote_public: &[u8; 32]) -> Result<Self, snow::Error> {
+        let state = snow::Builder::new(PARAMS.clone())
+            .local_private_key(local_secret)?
+            .remote_public_key(remote_public)?
+            .build_initiator()?;
+        Ok(Self {
+            state,
+            remote_pub: *remote_public,
+        })
+    }
+
+    pub fn write_msg1(&mut self, payload: &[u8]) -> Result<Vec<u8>, snow::Error> {
+        let mut buf = vec![0u8; payload.len() + 96];
+        let len = self.state.write_message(payload, &mut buf)?;
+        buf.truncate(len);
+        Ok(buf)
+    }
+
+    pub fn read_msg2(&mut self, msg: &[u8]) -> Result<Vec<u8>, snow::Error> {
+        let mut buf = vec![0u8; msg.len()];
+        let len = self.state.read_message(msg, &mut buf)?;
+        buf.truncate(len);
+        Ok(buf)
+    }
+
+    pub fn into_transport(self) -> Result<Transport, snow::Error> {
+        let state = self.state.into_transport_mode()?;
+        Ok(Transport {
+            state,
+            peer_pubkey: self.remote_pub,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use x25519_dalek::{PublicKey, StaticSecret};
+
+    fn fresh_keypair() -> ([u8; 32], [u8; 32]) {
+        let secret = StaticSecret::random_from_rng(rand::rngs::OsRng);
+        let public = PublicKey::from(&secret);
+        (secret.to_bytes(), *public.as_bytes())
+    }
+
+    #[test]
+    fn ik_round_trip_transport_mode() {
+        let (server_sk, server_pk) = fresh_keypair();
+        let (client_sk, client_pk) = fresh_keypair();
+
+        let mut responder = Responder::new(&server_sk).unwrap();
+        let mut initiator = Initiator::new(&client_sk, &server_pk).unwrap();
+
+        let msg1 = initiator.write_msg1(b"hello").unwrap();
+        let prologue_payload = responder.read_msg1(&msg1).unwrap();
+        assert_eq!(prologue_payload, b"hello");
+        assert_eq!(responder.peer_pubkey().unwrap(), client_pk);
+
+        let msg2 = responder.write_msg2(b"hi").unwrap();
+        let reply_payload = initiator.read_msg2(&msg2).unwrap();
+        assert_eq!(reply_payload, b"hi");
+
+        let mut server = responder.into_transport().unwrap();
+        let mut client = initiator.into_transport().unwrap();
+        assert_eq!(server.peer_pubkey(), &client_pk);
+        assert_eq!(client.peer_pubkey(), &server_pk);
+
+        // Bidirectional stream — two messages each direction to
+        // exercise nonce increment.
+        let c1 = client.send(b"ping one").unwrap();
+        assert_eq!(server.recv(&c1).unwrap(), b"ping one");
+        let c2 = client.send(b"ping two").unwrap();
+        assert_eq!(server.recv(&c2).unwrap(), b"ping two");
+        let s1 = server.send(b"pong").unwrap();
+        assert_eq!(client.recv(&s1).unwrap(), b"pong");
+    }
+
+    #[test]
+    fn mismatched_server_pubkey_rejects() {
+        let (server_sk, _server_pk) = fresh_keypair();
+        let (_other_sk, other_pk) = fresh_keypair();
+        let (client_sk, _) = fresh_keypair();
+
+        let mut responder = Responder::new(&server_sk).unwrap();
+        let mut initiator = Initiator::new(&client_sk, &other_pk).unwrap();
+
+        let msg1 = initiator.write_msg1(b"").unwrap();
+        // Server can't decrypt msg1's `s` because the initiator
+        // encrypted it against the wrong server pubkey.
+        assert!(responder.read_msg1(&msg1).is_err());
+    }
+
+    #[test]
+    fn tampered_ciphertext_rejects() {
+        let (server_sk, server_pk) = fresh_keypair();
+        let (client_sk, _) = fresh_keypair();
+
+        let mut responder = Responder::new(&server_sk).unwrap();
+        let mut initiator = Initiator::new(&client_sk, &server_pk).unwrap();
+
+        let msg1 = initiator.write_msg1(b"").unwrap();
+        responder.read_msg1(&msg1).unwrap();
+        let msg2 = responder.write_msg2(b"").unwrap();
+        initiator.read_msg2(&msg2).unwrap();
+
+        let mut server = responder.into_transport().unwrap();
+        let mut client = initiator.into_transport().unwrap();
+
+        let mut frame = client.send(b"payload").unwrap();
+        frame[0] ^= 0x01;
+        assert!(server.recv(&frame).is_err());
+    }
+}


### PR DESCRIPTION
## Summary
- Resurrects the bastion-side half of the closed #182 stack — just the three endpoints the native `bastion-app` client needs: `GET /attest`, WS `/noise/ws` (RPC), WS `/noise/shell/{id}` (duplex PTY, `0x01` raw / `0x02` ctrl framing).
- Persistent X25519 static keypair loaded from `--noise-key PATH` (generated on first boot, chmod 0600 on disk).
- `/attest` optionally carries a TDX quote with `REPORT_DATA = sha256(pubkey)` when `--ee-socket` is configured, so clients can verify the key came from a real enclave; without EE it still ships the pubkey alone for pin-on-first-contact.
- Noise_IK via `snow` crate, same wire format the `bastion-app` Rust CLI + Tauri desktop already speak.

## What's *not* in this PR (on purpose)
| scope | why skipped |
|---|---|
| dd CP↔agent m2m over Noise | not needed to connect the desktop client |
| CF Access path-scoped bypasses | not needed on `target=ssh` deploys; separate PR if we move cloud back to noise |
| TS browser Noise client | Svelte SPA still uses `/ws/{id}` fine; `bastion-app` is the new native client |
| `apps/*` workload template + `--cp-url` wiring | deploy-side, not bastion protocol |

## Verified end-to-end

Ran `bastion serve --port 7783 --bind 127.0.0.1 --noise-key /tmp/bastion.key` against a freshly-built `bastion-app` CLI (`feat/connect-dd-enclave`):

    $ bastion add dd-enclave --label local --origin http://127.0.0.1:7783
    added 4b07a4e4-…
    $ bastion connect 4b07a4e4-…
    bastion: fetching /attest from http://127.0.0.1:7783
    bastion: pinned server pubkey bdd419217e48d0a5… (source: generated)
    bastion: creating shell session
    bastion: session 45339573879b (bastion-cli)
    bastion: opening /noise/shell/45339573879b
    tdx2@tdx2:~$ echo hello-from-noise
    hello-from-noise
    tdx2@tdx2:~$ exit
    [session exited, code=0]

## Tests
- `cargo test -p dd-common` — 7 tests on `noise_static` (file ACL, stable-across-calls, ephemeral randomness, wrong-length rejection) + `noise_tunnel` (IK round-trip, mismatched pubkey, tampered ciphertext) all pass.
- `cargo test -p bastion-term` — 2 doctests pass.
- Absent `--noise-key` the old plain `/ws/{id}` + `/api/sessions` API still serves traffic; `/attest` returns 404 instead of 200 so pin-capable clients can detect unconfigured deploys.

## Unblocks
Point `bastion-app` desktop's "add dd-enclave" at a deploy that passes `--noise-key` and you get a real Noise_IK-tunneled PTY, not the old plain WebSocket.

## Test plan
- [ ] `cargo test` green in CI.
- [ ] Preview deploy of this branch with `--noise-key /var/lib/dd/bastion.key` added to the bastion workload command line — curl `/attest`, verify JSON includes `noise_pubkey_hex`.
- [ ] `bastion connect` from the companion bastion-app repo against that deploy gets a live shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)