### PR TITLE
feat(deploy): enable --noise-key on the bastion workload

### DIFF
--- a/apps/bastion/workload.json.tmpl
+++ b/apps/bastion/workload.json.tmpl
@@ -20,6 +20,8 @@
     "--ee-socket",
     "/var/lib/easyenclave/agent.sock",
     "--cp-url",
-    "http://127.0.0.1:8080"
+    "http://127.0.0.1:8080",
+    "--noise-key",
+    "/data/bastion-noise.key"
   ]
 }


### PR DESCRIPTION
## Summary
One-line workload.json.tmpl addition so every production bastion deploy passes `--noise-key /data/bastion-noise.key` — stacks on #191, which introduces that flag. Together the two PRs take main from \"bastion has a noise API but no key configured\" to \"desktop client can connect to a deploy on first boot.\"

## Why /data
The /data mount is the persistent ext4 vdc we already mkfs in `local-agents.sh` and wire via the `mount-data` boot workload. That gives us:
- key survives VM restarts → pubkey doesn't rotate on reboot → pinned clients don't have to re-trust.
- chmod 0600 (set by bastion on first mint) is respected since it's a real filesystem not tmpfs.
- easyenclave agent rootfs is ephemeral, so anywhere else would regenerate on every boot.

## Test plan
- [ ] Merge #191 first.
- [ ] Merge this.
- [ ] Watch one preview deploy serial log for `noise static key Generated (…)` on first boot.
- [ ] `curl https://block.<pr>.devopsdefender.com/attest` returns `{noise_pubkey_hex, source: \"generated\"}`.
- [ ] Tear down + redeploy same PR — `source: \"loaded\"` next time, same pubkey.
- [ ] Local bastion-app CLI connects end-to-end.

## Rollback
Reverting this single-line change disables noise on subsequent deploys; existing clients fall back to the plain `/ws/{id}` path since the SPA still uses it. Safe to revert without touching #191.

🤖 Generated with [Claude Code](https://claude.com/claude-code)