### PR TITLE
fix(cleanup): tolerate empty pr-* fleet in reap-stale-pr-envs

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -148,12 +148,15 @@ jobs:
             --project="$GCP_PROJECT_ID" \
             --filter='labels.devopsdefender=managed AND labels.dd_env~"^pr-" AND status=RUNNING' \
             --format='value(labels.dd_env)' | sort -u)
+          # `grep -oE` returns 1 on no matches, which trips pipefail
+          # the moment the CF account genuinely has no pr-* envs left
+          # (the happy steady state). Swallow that specific case.
           envs=$( {
             echo "$apps"    | jq -r '.result[].name // empty'
             echo "$tunnels" | jq -r '.result[].name // empty'
             echo "$dns"     | jq -r '.result[].name // empty'
             echo "$vm_envs"
-          } | grep -oE 'pr-[0-9]+' | sort -u )
+          } | grep -oE 'pr-[0-9]+' | sort -u || true )
 
           total_apps=0 total_tun=0 total_dns=0 total_vms=0 total_envs=0
 


### PR DESCRIPTION
The scheduled Cleanup workflow's \`reap-stale-pr-envs\` job has been failing every run since #200 merged.

## Root cause

\`grep -oE 'pr-[0-9]+'\` returns exit 1 on no matches. Inside \`envs=\$( ... | grep ... | sort -u )\` under \`set -euo pipefail\`, that propagates via pipefail and aborts the entire sweep — right at the point where there are no stale pr-* envs to reap, which is the happy state we want to be in 99% of the time.

## Fix

\`|| true\` on the grep pipeline. Empty input is now a no-op continuation, and the orphan-agent-hostname sweep below it runs on every 6 h tick regardless.

## Why now

Existed before #200 in \`force-cleanup-stale-prs.yml\`, but that workflow only ran on manual dispatch, so no one saw it. #200 consolidated it into the scheduled \`cleanup.yml\` cron, which surfaced the bug on the first automatic run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)