### PR TITLE
feat(noise-gw): streaming attach — raw PTY bytes after ack

### DIFF
--- a/src/noise_gateway/noise.rs
+++ b/src/noise_gateway/noise.rs
@@ -11,6 +11,13 @@
 //!      binary frame is one Noise transport message carrying a JSON
 //!      request envelope, gated by [`super::allowlist::classify`]
 //!      and forwarded to the EE agent socket.
+//!
+//! `attach` is special: after the one JSON ack frame, the session
+//! shifts into a raw bidirectional byte bridge. Client→server
+//! frames carry stdin bytes; server→client frames carry stdout/
+//! stderr bytes. Either side closing the WS ends the session. This
+//! keeps one Noise session == one PTY, which is fine — a second
+//! shell opens a second WS.
 
 use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
 use axum::extract::State;
@@ -19,11 +26,15 @@ use axum::routing::get;
 use axum::Router;
 use futures_util::StreamExt;
 use snow::{Builder, HandshakeState, TransportState};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 use super::{allowlist, State as AppState};
 
 const NOISE_PATTERN: &str = "Noise_IK_25519_ChaChaPoly_BLAKE2s";
 const MAX_NOISE_MSG: usize = 65535;
+/// Chunk size for raw PTY bytes flowing EE→client in attach mode.
+/// Under `MAX_NOISE_MSG - 16` (auth tag) with plenty of headroom.
+const ATTACH_CHUNK: usize = 4096;
 
 pub(crate) fn routes() -> Router<AppState> {
     Router::new().route("/noise/ws", get(upgrade))
@@ -89,26 +100,106 @@ async fn handle(mut socket: WebSocket, state: AppState) -> anyhow::Result<()> {
         let request: serde_json::Value = serde_json::from_slice(&plain)
             .map_err(|e| anyhow::anyhow!("decrypted frame is not JSON: {e}"))?;
 
-        let response = match allowlist::classify(&request) {
-            Ok(_method) => state.upstream.call(request).await.unwrap_or_else(|e| {
-                serde_json::json!({
-                    "error": "upstream_failed",
+        match allowlist::classify(&request) {
+            Ok(allowlist::Method::Attach) => {
+                // Streaming path. attach_stream either hands us the EE
+                // socket + ack (happy) or returns an error we surface
+                // as a normal JSON response and keep the session in
+                // one-shot mode for the next request.
+                match state.upstream.attach_stream(request).await {
+                    Ok((ack, ee_stream)) => {
+                        send_encrypted_json(&mut transport, &mut socket, &ack).await?;
+                        bridge_attach(&mut transport, &mut socket, ee_stream).await?;
+                        return Ok(());
+                    }
+                    Err(e) => {
+                        let resp = serde_json::json!({
+                            "error": "attach_failed",
+                            "detail": e.to_string(),
+                        });
+                        send_encrypted_json(&mut transport, &mut socket, &resp).await?;
+                        continue;
+                    }
+                }
+            }
+            Ok(_method) => {
+                let response = state.upstream.call(request).await.unwrap_or_else(|e| {
+                    serde_json::json!({
+                        "error": "upstream_failed",
+                        "detail": e.to_string(),
+                    })
+                });
+                send_encrypted_json(&mut transport, &mut socket, &response).await?;
+            }
+            Err(e) => {
+                let response = serde_json::json!({
+                    "error": "method_rejected",
                     "detail": e.to_string(),
-                })
-            }),
-            Err(e) => serde_json::json!({
-                "error": "method_rejected",
-                "detail": e.to_string(),
-            }),
-        };
-
-        let plain = serde_json::to_vec(&response)?;
-        let mut cipher = vec![0u8; plain.len() + 16];
-        let n = transport.write_message(&plain, &mut cipher)?;
-        cipher.truncate(n);
-        socket.send(Message::Binary(cipher.into())).await?;
+                });
+                send_encrypted_json(&mut transport, &mut socket, &response).await?;
+            }
+        }
     }
 
+    Ok(())
+}
+
+async fn send_encrypted_json(
+    transport: &mut TransportState,
+    socket: &mut WebSocket,
+    value: &serde_json::Value,
+) -> anyhow::Result<()> {
+    let plain = serde_json::to_vec(value)?;
+    send_encrypted_bytes(transport, socket, &plain).await
+}
+
+async fn send_encrypted_bytes(
+    transport: &mut TransportState,
+    socket: &mut WebSocket,
+    plain: &[u8],
+) -> anyhow::Result<()> {
+    let mut cipher = vec![0u8; plain.len() + 16];
+    let n = transport.write_message(plain, &mut cipher)?;
+    cipher.truncate(n);
+    socket.send(Message::Binary(cipher.into())).await?;
+    Ok(())
+}
+
+/// Bridge WS ↔ EE socket as raw bytes for the life of one PTY.
+/// Runs in the same future that owns the Noise `TransportState` so
+/// we don't need a mutex around it — `select!` gives us concurrent
+/// reads on both sides while serializing access to the transport.
+async fn bridge_attach(
+    transport: &mut TransportState,
+    socket: &mut WebSocket,
+    ee_stream: tokio::net::UnixStream,
+) -> anyhow::Result<()> {
+    let (mut ee_rd, mut ee_wr) = ee_stream.into_split();
+    let mut ee_buf = [0u8; ATTACH_CHUNK];
+
+    loop {
+        tokio::select! {
+            biased;
+            // EE → client: raw PTY bytes, encrypted and forwarded.
+            n = ee_rd.read(&mut ee_buf) => {
+                match n? {
+                    0 => break, // EE closed (shell exited)
+                    n => send_encrypted_bytes(transport, socket, &ee_buf[..n]).await?,
+                }
+            }
+            // Client → EE: decrypt and write stdin.
+            frame = next_binary(socket) => {
+                match frame? {
+                    Some(cipher) => {
+                        let mut plain = vec![0u8; cipher.len()];
+                        let n = transport.read_message(&cipher, &mut plain)?;
+                        ee_wr.write_all(&plain[..n]).await?;
+                    }
+                    None => break, // WS closed
+                }
+            }
+        }
+    }
     Ok(())
 }
 

--- a/src/noise_gateway/upstream.rs
+++ b/src/noise_gateway/upstream.rs
@@ -4,10 +4,15 @@
 //! is a single line of JSON (`{"method": "...", ...}`) terminated by
 //! `\n`; the response is one line of JSON. `EE_TOKEN` (if present in
 //! the process env at boot) is injected into every request envelope.
+//!
+//! `attach_stream` is the exception — EE replies with a one-line ack
+//! and then the socket carries raw PTY bytes bidirectionally until
+//! either side closes. The returned tuple is `(ack_json, socket)`
+//! and the caller is responsible for byte-bridging.
 
 use std::path::PathBuf;
 
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::net::UnixStream;
 
 pub const DEFAULT_EE_AGENT_SOCK: &str = "/var/lib/easyenclave/agent.sock";
@@ -26,11 +31,7 @@ impl EeAgent {
     /// `token` field if one was supplied at boot. Returns EE's raw
     /// response value.
     pub async fn call(&self, mut req: serde_json::Value) -> anyhow::Result<serde_json::Value> {
-        if let Some(tok) = &self.token {
-            if let Some(obj) = req.as_object_mut() {
-                obj.insert("token".to_string(), serde_json::Value::String(tok.clone()));
-            }
-        }
+        self.inject_token(&mut req);
 
         let mut stream = UnixStream::connect(&self.path).await?;
         let line = serde_json::to_vec(&req)?;
@@ -43,6 +44,53 @@ impl EeAgent {
         reader.read_line(&mut resp).await?;
         let value: serde_json::Value = serde_json::from_str(resp.trim_end())?;
         Ok(value)
+    }
+
+    /// Send an `attach`-shaped request, read the one-line ack, and
+    /// return the socket so the caller can bridge raw PTY bytes. The
+    /// ack is forwarded to the caller so the Noise-side client sees
+    /// the same `{"ok": true, ...}` it would get from EE directly.
+    ///
+    /// Returns `Err` if EE's ack is `{"ok": false}` or malformed — in
+    /// that case the caller should not start bridging and should pass
+    /// the error back to the client as a normal one-shot response.
+    pub async fn attach_stream(
+        &self,
+        mut req: serde_json::Value,
+    ) -> anyhow::Result<(serde_json::Value, UnixStream)> {
+        self.inject_token(&mut req);
+
+        let mut stream = UnixStream::connect(&self.path).await?;
+        let line = serde_json::to_vec(&req)?;
+        stream.write_all(&line).await?;
+        stream.write_all(b"\n").await?;
+        stream.flush().await?;
+
+        // Read one line of ack byte-by-byte so the buffered reader
+        // doesn't swallow subsequent raw-stream bytes.
+        let mut ack = Vec::new();
+        let mut byte = [0u8; 1];
+        loop {
+            match stream.read(&mut byte).await? {
+                0 => anyhow::bail!("EE attach: closed before ack"),
+                _ if byte[0] == b'\n' => break,
+                _ if ack.len() > 4096 => anyhow::bail!("EE attach: ack too long"),
+                _ => ack.push(byte[0]),
+            }
+        }
+        let ack_val: serde_json::Value = serde_json::from_slice(&ack)?;
+        if ack_val.get("ok").and_then(|v| v.as_bool()) != Some(true) {
+            anyhow::bail!("EE attach rejected: {ack_val}");
+        }
+        Ok((ack_val, stream))
+    }
+
+    fn inject_token(&self, req: &mut serde_json::Value) {
+        if let Some(tok) = &self.token {
+            if let Some(obj) = req.as_object_mut() {
+                obj.insert("token".to_string(), serde_json::Value::String(tok.clone()));
+            }
+        }
     }
 }
 
@@ -102,5 +150,78 @@ mod tests {
             .await
             .unwrap();
         assert!(resp["echo"].get("token").is_none());
+    }
+
+    /// Fake EE that speaks the attach protocol: read one line, reply
+    /// `{"ok": true}\n`, then echo raw bytes until the client closes.
+    async fn spawn_attach_echo(path: PathBuf) {
+        let listener = UnixListener::bind(&path).unwrap();
+        tokio::spawn(async move {
+            while let Ok((mut stream, _)) = listener.accept().await {
+                tokio::spawn(async move {
+                    let mut req = Vec::new();
+                    let mut one = [0u8; 1];
+                    while stream.read_exact(&mut one).await.is_ok() {
+                        if one[0] == b'\n' {
+                            break;
+                        }
+                        req.push(one[0]);
+                    }
+                    let _ = stream.write_all(b"{\"ok\":true}\n").await;
+                    let mut buf = [0u8; 64];
+                    while let Ok(n) = stream.read(&mut buf).await {
+                        if n == 0 {
+                            break;
+                        }
+                        if stream.write_all(&buf[..n]).await.is_err() {
+                            break;
+                        }
+                    }
+                });
+            }
+        });
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+
+    #[tokio::test]
+    async fn attach_stream_reads_ack_and_echoes() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join("ee.sock");
+        spawn_attach_echo(sock.clone()).await;
+        let agent = EeAgent::new(sock.clone(), None);
+        let (ack, mut stream) = agent
+            .attach_stream(serde_json::json!({"method": "attach", "cmd": ["bash"]}))
+            .await
+            .unwrap();
+        assert_eq!(ack["ok"], true);
+
+        stream.write_all(b"hello").await.unwrap();
+        let mut buf = [0u8; 5];
+        stream.read_exact(&mut buf).await.unwrap();
+        assert_eq!(&buf, b"hello");
+    }
+
+    #[tokio::test]
+    async fn attach_stream_rejects_ok_false_ack() {
+        // Server replies `{"ok": false, "reason": "nope"}` and closes.
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join("ee.sock");
+        let listener = UnixListener::bind(&sock).unwrap();
+        tokio::spawn(async move {
+            if let Ok((mut stream, _)) = listener.accept().await {
+                let mut discard = [0u8; 1];
+                while stream.read_exact(&mut discard).await.is_ok() && discard[0] != b'\n' {}
+                let _ = stream
+                    .write_all(b"{\"ok\":false,\"reason\":\"nope\"}\n")
+                    .await;
+            }
+        });
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        let agent = EeAgent::new(sock, None);
+        let err = agent
+            .attach_stream(serde_json::json!({"method": "attach"}))
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("rejected"), "got {err}");
     }
 }


### PR DESCRIPTION
## Summary
- `attach` was on the allowlist but fell through the one-shot request/response path in the Noise gateway, so it couldn't actually carry a live shell. Now: once the first JSON envelope classifies as `Method::Attach`, the server calls `upstream::attach_stream`, relays EE's `{\"ok\":true,...}` ack back (encrypted), then bridges the WebSocket ↔ EE unix socket as raw bytes through the existing Noise `TransportState`.
- Same future owns the transport state, so `tokio::select!` over (EE → WS) and (WS → EE) serializes access — no mutex needed.

## Files
- `src/noise_gateway/upstream.rs` — new `attach_stream(req) -> (ack, UnixStream)` reads the ack byte-by-byte (not buffered) so the post-ack raw bytes aren't swallowed. Small `inject_token` refactor to dedupe.
- `src/noise_gateway/noise.rs` — new `Method::Attach` branch + `bridge_attach` + `send_encrypted_{bytes,json}` helpers that dedupe the write path used by both one-shot responses and the new ack frame.

## Test plan
- [x] `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (35 pass, +2 new)
- [x] New tests: `attach_stream_reads_ack_and_echoes` (full round-trip against a unix-socket fake-EE), `attach_stream_rejects_ok_false_ack` (sad path).
- [ ] End-to-end test needs a bastion-app client that can call `attach`; follow-up PR over there.

## What this does NOT include
- bastion-app client. `NoiseClient` still only speaks one-shot request/response. A follow-up adds `attach()` returning bidirectional byte channels so the desktop/CLI can open a real terminal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)