### PR TITLE
ci: stream VM console during boot + 10-min agent register wait

### DIFF
--- a/.github/actions/relaunch-agent/action.yml
+++ b/.github/actions/relaunch-agent/action.yml
@@ -65,10 +65,21 @@ runs:
 
     # Block until the freshly-booted agent VM registers with the CP.
     # This is the "I can see the local agent deployment worked"
-    # signal that gates the whole release. 30 attempts × 10s = 5 min
-    # covers a cold VM boot (~60s) + cloudflared tunnel (~30s) +
-    # agent startup + register. This is a JSON-body predicate poll —
-    # no off-the-shelf action, so it's kept as a tight loop.
+    # signal that gates the whole release.
+    #
+    # Budget: cold VM boot ~60s + EE pre-fetch of the dd binary
+    # from GitHub releases (can be 60s+ on a cold cache) +
+    # cloudflared tunnel ~30s + agent ITA mint (one round-trip to
+    # Intel) + register with the CP's 6-retry backoff path
+    # (~105s cumulative if CF edge is still propagating). Worst
+    # case is ~7 min end-to-end, so 5 min was too tight — preview
+    # deploys were flaking here even when the agent eventually
+    # came up. 60 × 10s = 10 min covers it with headroom.
+    #
+    # On failure we dump the last /api/agents payload so the CI
+    # log shows what the CP actually saw (stale registration
+    # without a fresh last_seen, wrong vm_name, empty array…)
+    # instead of the previous opaque "never registered" message.
     - name: Verify agent registered with CP
       shell: bash
       env:
@@ -87,18 +98,25 @@ runs:
         oidc=$(curl -fsSL \
           -H "Authorization: Bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
           "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=dd-agent" | jq -r .value)
-        for i in $(seq 1 30); do
-          host=$(curl -fsS --max-time 10 -H "Authorization: Bearer ${oidc}" \
-            "$URL/api/agents" 2>/dev/null \
-            | jq -r --arg since "$since" --arg vm "$vm" '
+        last_payload=""
+        for i in $(seq 1 60); do
+          payload=$(curl -fsS --max-time 10 -H "Authorization: Bearer ${oidc}" \
+            "$URL/api/agents" 2>/dev/null || true)
+          if [ -n "$payload" ]; then
+            last_payload="$payload"
+          fi
+          host=$(echo "$payload" | jq -r --arg since "$since" --arg vm "$vm" '
                 [.[] | select(.vm_name==$vm and .status=="healthy" and .last_seen > $since)]
-                | sort_by(.last_seen) | reverse | .[0].hostname // empty' || true)
+                | sort_by(.last_seen) | reverse | .[0].hostname // empty' 2>/dev/null || true)
           if [ -n "$host" ]; then
             echo "$vm registered at https://$host"
             exit 0
           fi
-          echo "  waiting for $vm to register with $URL... (${i}/30)"
+          echo "  waiting for $vm to register with $URL... (${i}/60)"
           sleep 10
         done
-        echo "::error::$vm never registered with $URL within 5 min"
+        echo "::group::Last /api/agents payload"
+        echo "$last_payload" | jq . 2>/dev/null || echo "$last_payload"
+        echo "::endgroup::"
+        echo "::error::$vm never registered with $URL within 10 min (since=$since)"
         exit 1

--- a/.github/actions/relaunch-agent/action.yml
+++ b/.github/actions/relaunch-agent/action.yml
@@ -27,6 +27,10 @@ inputs:
   release-tag:
     description: 'devopsdefender release tag the local agent should download (e.g. pr-abc123, latest)'
     required: true
+  stream-console:
+    description: 'Tail /var/log/ee-local-<kind>.log from tdx2 into the CI log for the duration of the register-wait. Surfaces what the agent VM is actually doing when it fails to register.'
+    required: false
+    default: 'true'
 
 runs:
   using: composite
@@ -76,22 +80,62 @@ runs:
     # deploys were flaking here even when the agent eventually
     # came up. 60 × 10s = 10 min covers it with headroom.
     #
-    # On failure we dump the last /api/agents payload so the CI
-    # log shows what the CP actually saw (stale registration
-    # without a fresh last_seen, wrong vm_name, empty array…)
-    # instead of the previous opaque "never registered" message.
+    # Simultaneously we tail the VM's serial console log from
+    # /var/log/ee-local-<kind>.log on tdx2 so every `eprintln!`
+    # the agent prints (mint failures, register errors, EE boot
+    # issues) lands in the CI log in real time. Previously the
+    # only visibility was "never registered" — now the cause is
+    # in the same job log as the wait.
+    #
+    # On failure we also dump the last /api/agents payload so
+    # the CP-side view is captured alongside the VM-side view.
     - name: Verify agent registered with CP
       shell: bash
       env:
-        URL: ${{ inputs.url }}
-        KIND: ${{ inputs.kind }}
+        URL:             ${{ inputs.url }}
+        KIND:            ${{ inputs.kind }}
+        HOST:            ${{ inputs.host }}
+        SSH_KEY:         ${{ inputs.ssh-key }}
+        STREAM_CONSOLE:  ${{ inputs.stream-console }}
       run: |
+        set -uo pipefail
         vm="dd-local-$KIND"
         since=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+        # Start the serial-console tail first so the boot messages
+        # that arrive during the register wait all show up in-line.
+        # `tail -F` follows rotation; `ssh -T` suppresses the pty.
+        # Output is prefixed so console lines are distinguishable
+        # from the wait loop's own status prints.
+        tail_pid=""
+        if [ "$STREAM_CONSOLE" = "true" ]; then
+          key=$(mktemp)
+          trap 'rm -f "$key"' EXIT
+          printf '%s\n' "$SSH_KEY" > "$key"
+          chmod 600 "$key"
+          ssh -i "$key" -T \
+              -o StrictHostKeyChecking=accept-new \
+              -o ServerAliveInterval=30 \
+              tdx2@"$HOST" \
+              "sudo tail -n +1 -F /var/log/ee-local-$KIND.log 2>/dev/null || true" \
+            2>&1 | sed -u "s/^/  [$vm console] /" &
+          tail_pid=$!
+          # Give the tail a moment to attach so its first lines land
+          # before the register wait's first status message.
+          sleep 1
+        fi
+        cleanup_tail() {
+          if [ -n "$tail_pid" ]; then
+            kill "$tail_pid" 2>/dev/null || true
+            wait "$tail_pid" 2>/dev/null || true
+          fi
+        }
+
         # Mint a GH OIDC token for the /api/agents bearer auth. The
         # calling job must grant `id-token: write` in its
         # permissions block.
         if [ -z "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}" ]; then
+          cleanup_tail
           echo "::error::id-token not available — caller needs 'permissions: id-token: write'"
           exit 1
         fi
@@ -105,16 +149,18 @@ runs:
           if [ -n "$payload" ]; then
             last_payload="$payload"
           fi
-          host=$(echo "$payload" | jq -r --arg since "$since" --arg vm "$vm" '
+          host_found=$(echo "$payload" | jq -r --arg since "$since" --arg vm "$vm" '
                 [.[] | select(.vm_name==$vm and .status=="healthy" and .last_seen > $since)]
                 | sort_by(.last_seen) | reverse | .[0].hostname // empty' 2>/dev/null || true)
-          if [ -n "$host" ]; then
-            echo "$vm registered at https://$host"
+          if [ -n "$host_found" ]; then
+            echo "$vm registered at https://$host_found"
+            cleanup_tail
             exit 0
           fi
           echo "  waiting for $vm to register with $URL... (${i}/60)"
           sleep 10
         done
+        cleanup_tail
         echo "::group::Last /api/agents payload"
         echo "$last_payload" | jq . 2>/dev/null || echo "$last_payload"
         echo "::endgroup::"

--- a/.github/workflows/deploy-cp.yml
+++ b/.github/workflows/deploy-cp.yml
@@ -246,16 +246,35 @@ jobs:
           tail -80 /tmp/serial.log | sed 's/^/[serial] /'
           exit 1
 
-      - name: Wait for CP health (SSH CP — no serial stream, just poll)
+      - name: Wait for CP health (SSH CP — streams serial console)
         if: inputs.target == 'ssh'
         env:
           AGENT_URL: https://${{ inputs.hostname }}
+          ENV_LABEL: ${{ inputs.env }}
+          HOST:      ${{ secrets.DD_LOCAL_HOST }}
+          SSH_KEY:   ${{ secrets.DD_LOCAL_SSH_KEY }}
         run: |
+          set -uo pipefail
           # SSH CP boot fires asynchronously via `virsh start` on the
-          # tdx2 host. We only own the outside view here — poll for a
-          # real 200 on /health (not a CF Access 302 false-positive).
-          # Serial console lives at /var/log/ee-local-${env}-cp.log
-          # on the tdx2 host if you need to tail it manually.
+          # tdx2 host. We own the outside view (poll /health for a
+          # real 200) and tail the inside view — the serial console
+          # at /var/log/ee-local-${env}-cp.log — so every boot-time
+          # eprintln! lands in this job's log in real time. Both views
+          # together turn "CP not healthy within 5 min" from an opaque
+          # timeout into a traceable failure.
+          tail_pid=""
+          key=$(mktemp)
+          trap 'rm -f "$key"; [ -n "$tail_pid" ] && kill "$tail_pid" 2>/dev/null; exit' EXIT
+          printf '%s\n' "$SSH_KEY" > "$key"
+          chmod 600 "$key"
+          ssh -i "$key" -T \
+              -o StrictHostKeyChecking=accept-new \
+              -o ServerAliveInterval=30 \
+              tdx2@"$HOST" \
+              "sudo tail -n +1 -F /var/log/ee-local-${ENV_LABEL}-cp.log 2>/dev/null || true" \
+            2>&1 | sed -u "s/^/  [dd-local-${ENV_LABEL}-cp console] /" &
+          tail_pid=$!
+          sleep 1
           for i in $(seq 1 60); do
             CODE=$(curl -s -o /dev/null -w '%{http_code}' "${AGENT_URL}/health" || echo "000")
             if [ "$CODE" = "200" ]; then


### PR DESCRIPTION
## Why

Recent PR deploys (#202, #203) have flaked 5× in a row on \"dd-local-preview never registered within 5 min\" with zero visibility into what the VM is actually doing. Two changes:

### 1. Stream the VM serial console during the register-wait

`/var/log/ee-local-<kind>.log` on tdx2 captures every `eprintln!` from `devopsdefender agent` — mint_ita round-trip, EE health check, register attempts + error chain, noise_pubkey, configfs-tsm availability. Previously invisible from the CI log.

In-step: after trapping the SSH key to a temp file, the step spins up `ssh -T tdx2 'sudo tail -F /var/log/ee-local-$KIND.log'` in the background, piped through `sed -u` with a `[dd-local-<kind> console]` prefix. The wait loop runs alongside it; both success and failure paths kill the tail via a small cleanup helper. New `stream-console` input defaults to `true`.

### 2. 5 min → 10 min + dump `/api/agents` on failure

Worst-case startup is ~7 min (cold VM + EE binary pre-fetch + cloudflared + Intel round-trip + agent's 6-retry register backoff). 5 min was leaving no headroom. 60 × 10s = 10 min covers it. On failure we also dump the last `/api/agents` payload so the CP-side view is captured alongside the VM-side view.

## Scope

Workflow-only. No code change. Safe to rebase #202 / #203 on top once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)