### PR TITLE
ci(deploy-cp): serialize PR-preview deploys on shared tdx2 VM slot

### DIFF
--- a/.github/workflows/deploy-cp.yml
+++ b/.github/workflows/deploy-cp.yml
@@ -63,8 +63,16 @@ on:
         type: string
         default: ssh
 
+# Serialize PR-preview deploys on the `preview` bucket: all pr-*
+# runs share one libvirt domain (`dd-local-preview`) on tdx2, so
+# two concurrent deploys race — the second PR's dd-relaunch.sh
+# destroys and rebuilds the VM mid-way through the first PR's
+# register-wait, so the first PR's agent ends up registering
+# against the WRONG cp (whichever env won the rebuild) and the
+# wait times out. Keeping production in its own group so a
+# prod deploy isn't blocked by a preview queue.
 concurrency:
-  group: deploy-cp-${{ inputs.env }}
+  group: deploy-cp-${{ inputs.env == 'production' && 'production' || 'preview' }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
## Root cause

Every PR-preview deploy maps to **the same libvirt domain** on tdx2: `dd-local-preview`. One physical slot. The concurrency group was keyed on `inputs.env` (pr-202 vs pr-203), so two PRs ran their \"Relaunch dd-local-preview\" step in parallel.

The new console-stream (merged in #204) pinned the failure mode exactly:

```
11:32:51  PR#202 starts Relaunch-dd-local-preview (targeting pr-202)
11:33:03  PR#203 starts Relaunch-dd-local-preview (targeting pr-203)  ← race
11:34:19  [dd-local-preview console] agent: registering with https://pr-203.devopsdefender.com
          ↑ PR #202's VM boot ends up with PR #203's config.iso
11:43:15  PR#202's register-wait gives up: \"never registered with pr-202\"
```

PR #203's `dd-relaunch.sh` destroyed and rebuilt `dd-local-preview` pointing at `pr-203` *mid-way through PR #202's register-wait*. PR #202's agent booted with the clobbered config and registered with pr-203 instead. From the PR #202 wait script's perspective, the agent \"never registered\" — because it was registering with the wrong CP.

## Fix

Switch the concurrency group to one shared `preview` bucket for all non-production deploys. Preview deploys now queue up (`cancel-in-progress: false`) so only one owns `dd-local-preview` at a time. Production keeps its own bucket — different libvirt domain (`dd-local-prod`), different hardware (GPU) — so a prod deploy never waits behind a preview queue.

## Scope

Workflow-only, no code change. Unblocks dd#202 and dd#203 — rebase both on top of this and they should both pass cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)