### PR TITLE
ci: line-buffer VM-console tail so boot lines stream live

### DIFF
--- a/.github/actions/relaunch-agent/action.yml
+++ b/.github/actions/relaunch-agent/action.yml
@@ -113,12 +113,18 @@ runs:
           trap 'rm -f "$key"' EXIT
           printf '%s\n' "$SSH_KEY" > "$key"
           chmod 600 "$key"
+          # `stdbuf -oL` on both ends: force tail and sed to line-buffer
+          # so each VM boot line streams into this job's log as it's
+          # written, rather than block-buffering until the pipe closes.
+          # Dropping `2>/dev/null` on tail so "cannot open" / "retrying"
+          # diagnostics surface — if the serial log file never appears,
+          # we want the reason on-screen, not a silent wait.
           ssh -i "$key" -T \
               -o StrictHostKeyChecking=accept-new \
               -o ServerAliveInterval=30 \
               tdx2@"$HOST" \
-              "sudo tail -n +1 -F /var/log/ee-local-$KIND.log 2>/dev/null || true" \
-            2>&1 | sed -u "s/^/  [$vm console] /" &
+              "sudo stdbuf -oL tail -n +1 -F /var/log/ee-local-$KIND.log || true" \
+            2>&1 | stdbuf -oL sed -u "s/^/  [$vm console] /" &
           tail_pid=$!
           # Give the tail a moment to attach so its first lines land
           # before the register wait's first status message.

--- a/.github/workflows/deploy-cp.yml
+++ b/.github/workflows/deploy-cp.yml
@@ -267,12 +267,19 @@ jobs:
           trap 'rm -f "$key"; [ -n "$tail_pid" ] && kill "$tail_pid" 2>/dev/null; exit' EXIT
           printf '%s\n' "$SSH_KEY" > "$key"
           chmod 600 "$key"
+          # `stdbuf -oL` on both ends: force tail and sed to line-buffer
+          # so each VM boot line lands in this job's log as it's written,
+          # instead of getting block-buffered until the pipe closes (which
+          # happens long after boot is over). Dropping `2>/dev/null` on
+          # tail so "cannot open log" / "retrying" diagnostics surface
+          # — if the log file never appears, we want to see why rather
+          # than stare at an apparently-silent boot.
           ssh -i "$key" -T \
               -o StrictHostKeyChecking=accept-new \
               -o ServerAliveInterval=30 \
               tdx2@"$HOST" \
-              "sudo tail -n +1 -F /var/log/ee-local-${ENV_LABEL}-cp.log 2>/dev/null || true" \
-            2>&1 | sed -u "s/^/  [dd-local-${ENV_LABEL}-cp console] /" &
+              "sudo stdbuf -oL tail -n +1 -F /var/log/ee-local-${ENV_LABEL}-cp.log || true" \
+            2>&1 | stdbuf -oL sed -u "s/^/  [dd-local-${ENV_LABEL}-cp console] /" &
           tail_pid=$!
           sleep 1
           for i in $(seq 1 60); do


### PR DESCRIPTION
## Summary
- Add `stdbuf -oL` to both ends of the `tail | sed` pipe that streams the VM serial console during CP health-wait (`deploy-cp.yml`) and during agent register-wait (`relaunch-agent/action.yml`). Without it the pipe block-buffers and boot output only appears after the pipe closes — well after the VM has finished booting.
- Drop `2>/dev/null` on `tail`, so "cannot open log" / retry diagnostics surface instead of a silent wait when the serial log file is slow to appear.

Follow-up to #204, which added the streaming but didn't address buffering or tail's own diagnostics.

## Test plan
- [ ] Trigger a preview deploy on this PR and confirm `[dd-local-preview console]` lines appear in the "Verify agent registered with CP" step as the VM boots, not all at once at the end.
- [ ] Same for `[dd-local-pr-<N>-cp console]` lines in the "Wait for CP health (SSH CP — streams serial console)" step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)