### PR TITLE
fix(cp): skip hydrate on fresh envs + fail-fast CI on agent fatal

### DIFF
--- a/.github/actions/relaunch-agent/action.yml
+++ b/.github/actions/relaunch-agent/action.yml
@@ -143,10 +143,16 @@ runs:
           sleep 1
         fi
         cleanup_tail() {
-          if [ -n "$tail_pid" ]; then
-            kill "$tail_pid" 2>/dev/null || true
-            wait "$tail_pid" 2>/dev/null || true
-          fi
+          # Kill every child process — the `ssh | sed | tee` pipeline
+          # plus any stragglers. `kill "$tail_pid"` alone drops tee but
+          # leaves ssh holding its remote `tail -F`, which can prevent
+          # the Actions runner from closing the step out (stdout stream
+          # still has live writers). `pkill -P $$` nukes the whole
+          # tree; a short SIGKILL chaser covers processes that ignored
+          # SIGTERM.
+          pkill -TERM -P $$ 2>/dev/null || true
+          sleep 0.3
+          pkill -KILL -P $$ 2>/dev/null || true
         }
 
         # Mint a GH OIDC token for the /api/agents bearer auth. The

--- a/.github/actions/relaunch-agent/action.yml
+++ b/.github/actions/relaunch-agent/action.yml
@@ -108,9 +108,20 @@ runs:
         # Output is prefixed so console lines are distinguishable
         # from the wait loop's own status prints.
         tail_pid=""
+        # Mirror of the tailed console, grepped by the register-wait
+        # loop below for `devopsdefender: fatal:` — the single
+        # `eprintln!` src/main.rs emits on unrecoverable error.
+        # If the agent's register retries all fail (e.g. dnsmasq
+        # negative-cached NXDOMAIN from the CP's hydrate probe), the
+        # agent exits and will never appear in `/api/agents`; without
+        # this mirror the CI loop would poll a corpse for its full
+        # 10-min budget. Always produced even when streaming is off,
+        # since the grep is what saves the budget.
+        mirror=$(mktemp)
+        trap 'rm -f "$mirror"' EXIT
         if [ "$STREAM_CONSOLE" = "true" ]; then
           key=$(mktemp)
-          trap 'rm -f "$key"' EXIT
+          trap 'rm -f "$key" "$mirror"' EXIT
           printf '%s\n' "$SSH_KEY" > "$key"
           chmod 600 "$key"
           # `stdbuf -oL` on both ends: force tail and sed to line-buffer
@@ -124,7 +135,8 @@ runs:
               -o ServerAliveInterval=30 \
               tdx2@"$HOST" \
               "sudo stdbuf -oL tail -n +1 -F /var/log/ee-local-$KIND.log || true" \
-            2>&1 | stdbuf -oL sed -u "s/^/  [$vm console] /" &
+            2>&1 | stdbuf -oL sed -u "s/^/  [$vm console] /" \
+                 | stdbuf -oL tee -a "$mirror" &
           tail_pid=$!
           # Give the tail a moment to attach so its first lines land
           # before the register wait's first status message.
@@ -162,6 +174,19 @@ runs:
             echo "$vm registered at https://$host_found"
             cleanup_tail
             exit 0
+          fi
+          # Fail fast if the agent already exited with a fatal error.
+          # The console mirror is the streaming tee of the serial log;
+          # `devopsdefender: fatal:` is main.rs's terminal eprintln
+          # and EE doesn't restart boot workloads, so once it lands in
+          # the mirror there's nothing left to wait for.
+          if [ -s "$mirror" ] && grep -q 'devopsdefender: fatal:' "$mirror"; then
+            cleanup_tail
+            echo "::group::Fatal line from $vm console"
+            grep -m1 'devopsdefender: fatal:' "$mirror" || true
+            echo "::endgroup::"
+            echo "::error::$vm agent exited fatal; not polling /api/agents further"
+            exit 1
           fi
           echo "  waiting for $vm to register with $URL... (${i}/60)"
           sleep 10

--- a/.github/workflows/deploy-cp.yml
+++ b/.github/workflows/deploy-cp.yml
@@ -265,7 +265,12 @@ jobs:
           tail_pid=""
           key=$(mktemp)
           mirror=$(mktemp)
-          trap 'rm -f "$key" "$mirror"; [ -n "$tail_pid" ] && kill "$tail_pid" 2>/dev/null; exit' EXIT
+          # pkill -P $$ on exit: kill the ENTIRE tail pipeline (ssh,
+          # sed, tee) — not just `$tail_pid` (which is tee, the last
+          # command). Without this the ssh hangs on the remote
+          # `tail -F`, stdout stays open on the runner, and the step
+          # can stall long past the script's `exit` call.
+          trap 'rm -f "$key" "$mirror"; pkill -TERM -P $$ 2>/dev/null; sleep 0.3; pkill -KILL -P $$ 2>/dev/null; exit' EXIT
           printf '%s\n' "$SSH_KEY" > "$key"
           chmod 600 "$key"
           # `stdbuf -oL` on both ends: force tail and sed to line-buffer

--- a/.github/workflows/deploy-cp.yml
+++ b/.github/workflows/deploy-cp.yml
@@ -264,7 +264,8 @@ jobs:
           # timeout into a traceable failure.
           tail_pid=""
           key=$(mktemp)
-          trap 'rm -f "$key"; [ -n "$tail_pid" ] && kill "$tail_pid" 2>/dev/null; exit' EXIT
+          mirror=$(mktemp)
+          trap 'rm -f "$key" "$mirror"; [ -n "$tail_pid" ] && kill "$tail_pid" 2>/dev/null; exit' EXIT
           printf '%s\n' "$SSH_KEY" > "$key"
           chmod 600 "$key"
           # `stdbuf -oL` on both ends: force tail and sed to line-buffer
@@ -274,12 +275,19 @@ jobs:
           # tail so "cannot open log" / "retrying" diagnostics surface
           # — if the log file never appears, we want to see why rather
           # than stare at an apparently-silent boot.
+          #
+          # `tee -a "$mirror"` so the health-poll loop can fail fast
+          # when the CP's main.rs emits its terminal
+          # `devopsdefender: fatal:` eprintln. Without this the loop
+          # would burn its full 5-min budget polling /health on a
+          # tunnel that never came up.
           ssh -i "$key" -T \
               -o StrictHostKeyChecking=accept-new \
               -o ServerAliveInterval=30 \
               tdx2@"$HOST" \
               "sudo stdbuf -oL tail -n +1 -F /var/log/ee-local-${ENV_LABEL}-cp.log || true" \
-            2>&1 | stdbuf -oL sed -u "s/^/  [dd-local-${ENV_LABEL}-cp console] /" &
+            2>&1 | stdbuf -oL sed -u "s/^/  [dd-local-${ENV_LABEL}-cp console] /" \
+                 | stdbuf -oL tee -a "$mirror" &
           tail_pid=$!
           sleep 1
           for i in $(seq 1 60); do
@@ -287,6 +295,13 @@ jobs:
             if [ "$CODE" = "200" ]; then
               echo "CP healthy at ${AGENT_URL} (HTTP 200)"
               exit 0
+            fi
+            if [ -s "$mirror" ] && grep -q 'devopsdefender: fatal:' "$mirror"; then
+              echo "::group::Fatal line from CP console"
+              grep -m1 'devopsdefender: fatal:' "$mirror" || true
+              echo "::endgroup::"
+              echo "::error::CP exited fatal; not polling /health further"
+              exit 1
             fi
             echo "  waiting for tunnel (got HTTP ${CODE})... (${i}/60)"
             sleep 5

--- a/.github/workflows/deploy-cp.yml
+++ b/.github/workflows/deploy-cp.yml
@@ -265,12 +265,18 @@ jobs:
           tail_pid=""
           key=$(mktemp)
           mirror=$(mktemp)
-          # pkill -P $$ on exit: kill the ENTIRE tail pipeline (ssh,
-          # sed, tee) — not just `$tail_pid` (which is tee, the last
+          # `rc=$?` FIRST: capture the script's actual exit status so
+          # the `exit $rc` at the end doesn't inherit `pkill`'s exit 1
+          # (which fires whenever it has no matches — i.e. a clean
+          # state). Without that, every successful run would be
+          # reported as failed.
+          #
+          # `pkill -P $$` kills the ENTIRE tail pipeline (ssh, sed,
+          # tee) — not just `$tail_pid`, which is tee (the last
           # command). Without this the ssh hangs on the remote
           # `tail -F`, stdout stays open on the runner, and the step
           # can stall long past the script's `exit` call.
-          trap 'rm -f "$key" "$mirror"; pkill -TERM -P $$ 2>/dev/null; sleep 0.3; pkill -KILL -P $$ 2>/dev/null; exit' EXIT
+          trap 'rc=$?; rm -f "$key" "$mirror"; pkill -TERM -P $$ 2>/dev/null || true; sleep 0.3; pkill -KILL -P $$ 2>/dev/null || true; exit $rc' EXIT
           printf '%s\n' "$SSH_KEY" > "$key"
           chmod 600 "$key"
           # `stdbuf -oL` on both ends: force tail and sed to line-buffer

--- a/src/cf.rs
+++ b/src/cf.rs
@@ -314,11 +314,20 @@ pub async fn delete_by_name(http: &Client, cf: &CfCreds, name: &str) {
 }
 
 pub async fn list(http: &Client, cf: &CfCreds) -> Result<Vec<serde_json::Value>> {
+    // `per_page=200` — CF's default is 20, and every caller here scans
+    // for a name-prefix match. A predecessor CP tunnel sorting off page 1
+    // silently breaks both `stonith::kill_old_tunnels` (leaks the old
+    // tunnel instead of STONITHing it) and `cp::run`'s hydrate gate
+    // (skips hydrate, losing devices + agents on a deploy). 200 is the
+    // same cap `.github/workflows/cleanup.yml` uses.
     let resp = call(
         http,
         cf,
         Method::GET,
-        &format!("/accounts/{}/cfd_tunnel?is_deleted=false", cf.account_id),
+        &format!(
+            "/accounts/{}/cfd_tunnel?is_deleted=false&per_page=200",
+            cf.account_id
+        ),
         None,
     )
     .await?;

--- a/src/cp.rs
+++ b/src/cp.rs
@@ -89,12 +89,49 @@ pub async fn run() -> Result<()> {
     // still points at the old CP's tunnel, so this GET lands on the
     // old CP. Tolerant of failure (first boot, old CP already dead,
     // stale code without `/api/v1/admin/export`).
+    //
+    // Gated on "does a predecessor CP tunnel exist for this env?"
+    // because on a *fresh* env (first PR deploy, or after cleanup
+    // reaped the old tunnel) the hostname has no CNAME, `getaddrinfo`
+    // returns NXDOMAIN, and the host's libvirt dnsmasq at
+    // 192.168.122.1 negative-caches that — with a default neg-TTL of
+    // minutes. Stage 3 below then creates the CNAME, but every VM on
+    // the default network (including the dd-local-preview agent that
+    // `release.yml` spins up right after) keeps seeing the cached
+    // NXDOMAIN until the TTL expires, blowing past the agent's
+    // register-retry budget and dying fatal. We diagnosed this by
+    // (a) the agent's `Name does not resolve` spam in its serial log
+    // while (b) the same hostname resolving from the CI runner, then
+    // (c) confirming via `dig @192.168.122.1`. The `cf::list` probe
+    // is against `api.cloudflare.com` (always resolves), so it's
+    // safe to run unconditionally — it doesn't touch the poisonable
+    // hostname at all.
     let store: Store = Arc::new(Mutex::new(HashMap::new()));
     let trust = noise_gateway::new_trust_handle();
     let devices = crate::devices::Store::load(cfg.devices_path.clone(), trust.clone())
         .await
         .map_err(|e| Error::Internal(format!("devices store load: {e}")))?;
-    hydrate_from_peer(&http, &cfg.hostname, &initial_token, &devices, &store).await;
+    let predecessor_prefix = cf::cp_prefix(&cfg.common.env_label);
+    let has_predecessor = match cf::list(&http, &cfg.cf).await {
+        Ok(tunnels) => tunnels.iter().any(|t| {
+            t["name"]
+                .as_str()
+                .is_some_and(|n| n.starts_with(&predecessor_prefix))
+        }),
+        Err(e) => {
+            // Ambiguous — CF API unreachable. Skip hydrate rather than
+            // probe-and-poison; the CP's own tunnel Stage 3 creates
+            // below doesn't depend on this branch, and a missed
+            // hydrate is strictly less bad than a poisoned dnsmasq.
+            eprintln!("cp: predecessor probe failed ({e}); skipping hydrate");
+            false
+        }
+    };
+    if has_predecessor {
+        hydrate_from_peer(&http, &cfg.hostname, &initial_token, &devices, &store).await;
+    } else {
+        eprintln!("cp: no predecessor {predecessor_prefix}* tunnel — skipping hydrate (fresh env)");
+    }
 
     // Stage 3: create our own tunnel. `cf::create` upserts the CNAME
     // for `cfg.hostname` → our tunnel id; traffic moves to us the


### PR DESCRIPTION
## The bug

Every first deploy of a new PR env hung for ~25 min and failed. Serial log from the preview agent (now visible thanks to #206):

```
[dd-agent] agent: register attempt 1/6 failed (... "failed to lookup address information: Name does not resolve") — backing off
[dd-agent] agent: register attempt 2/6 failed (... Name does not resolve ...) — backing off
...
[dd-agent] agent: register attempt 6/6 failed (... Name does not resolve ...) — backing off
[dd-agent] devopsdefender: fatal: upstream: register https://pr-N.devopsdefender.com/register: ... Name does not resolve
```

ITA mint against `api.trustauthority.intel.com` succeeded in the same boot, so VM DNS works. CF had the CNAME (CI runner hit `/health` with HTTP 200). `dig @192.168.122.1 pr-N.devopsdefender.com` from tdx2 right now returns the record. So it's cache poisoning, and now it's expired.

## Root cause

CP's Stage 2 hydrate does `GET https://$hostname/api/v1/admin/export` *before* Stage 3 creates the CNAME. On a fresh env the GET NXDOMAINs → libvirt's dnsmasq at 192.168.122.1 negative-caches that. Stage 3 then creates the CNAME. The dd-local-preview agent VM (same network, same dnsmasq) wakes up and queries the same hostname → dnsmasq serves the stale NXDOMAIN → 6 retries over 105s → fatal → never registers → CI polls a corpse for 10 min.

## Fixes

1. **`src/cp.rs`** — gate Stage 2 hydrate on predecessor existence. Probe `cf::list()` (against `api.cloudflare.com`, not poisonable) for any `dd-{env}-cp-*` tunnel. Only hit the hostname if one exists. Prod still hydrates (predecessor always present); fresh PR previews skip, removing the poison source.

2. **`src/cf.rs`** — bump `per_page` to 200. CF's default is 20 — a predecessor sorting off page 1 would silently make us skip hydrate on prod. Also closes the same latent bug in `stonith::kill_old_tunnels`.

3. **`.github/workflows/deploy-cp.yml` + `relaunch-agent/action.yml`** — fail fast on `devopsdefender: fatal:`. Tee the tailed serial console to a local mirror file; every poll iteration greps for main.rs's terminal eprintln. If the CP or agent has already exited fatal, stop polling. Turns 10-min corpse polls into sub-second failures with the exact fatal line surfaced in a collapsed `::group::`.

## Host-side hardening (deferred, not in this PR)

Setting `neg-ttl=0` on the libvirt default network's dnsmasq would also prevent this, but it's one-time host config (`virsh net-edit default`) — not something a repo change can enforce. Worth doing once.

## Test plan
- [ ] This PR is itself a fresh env (`pr-208`). If the diagnosis is right, its own deploy should succeed end-to-end.
- [ ] Check the deploy-preview job logs for the new `cp: no predecessor dd-pr-208-cp-* tunnel — skipping hydrate (fresh env)` line.
- [ ] Next push to main (prod) should still log hydrate running — predecessor exists — and CP should come up healthy.
- [ ] Induce a failure (e.g. revoke the ITA API key on a scratch branch) and confirm the CI step fails within ~2-3 min with the fatal line surfaced, not after the full 10-min budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)