### PR TITLE
ci: tear down dd-local-pr-N-cp libvirt domains on branch-delete + sweep

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -128,9 +128,48 @@ jobs:
           CF_ZONE_ID:     ${{ secrets.DD_CP_CF_ZONE_ID }}
           DD_DOMAIN:      ${{ vars.DD_CF_DOMAIN || 'devopsdefender.com' }}
           GH_TOKEN:       ${{ github.token }}
+          # SSH into the tdx2 host so we can `virsh destroy/undefine`
+          # `dd-local-pr-N-cp` libvirt domains that `gcloud compute
+          # instances delete` can no longer reach now that PR CPs are
+          # target=ssh (b87b36c). Left alone, they accumulate forever.
+          DD_LOCAL_HOST:    ${{ secrets.DD_LOCAL_HOST }}
+          DD_LOCAL_SSH_KEY: ${{ secrets.DD_LOCAL_SSH_KEY }}
         run: |
           set -euo pipefail
           AUTH=(-H "Authorization: Bearer $CF_API_TOKEN")
+
+          # SSH key for the per-env libvirt teardown below. One key,
+          # reused across all closed envs; trap cleans it up on exit.
+          ssh_key=$(mktemp)
+          trap 'rm -f "$ssh_key"' EXIT
+          printf '%s\n' "$DD_LOCAL_SSH_KEY" > "$ssh_key"
+          chmod 600 "$ssh_key"
+          # `|| true` — if the tdx2 host is unreachable this sweep run,
+          # fall through and still do the CF/GCE cleanup. Next run
+          # catches whatever was missed.
+          teardown_libvirt_cp() {
+            ssh -i "$ssh_key" -T \
+                -o StrictHostKeyChecking=accept-new \
+                -o ServerAliveInterval=30 \
+                -o ConnectTimeout=15 \
+                tdx2@"$DD_LOCAL_HOST" bash -s -- "$1" <<'EOSSH' || true
+          set -euo pipefail
+          env="$1"
+          vm="dd-local-$env-cp"
+          # Only announce if the domain actually existed — silent
+          # no-op if the sweep had already picked this env up.
+          if virsh dominfo "$vm" >/dev/null 2>&1; then
+            virsh destroy "$vm" 2>/dev/null || true
+            virsh undefine "$vm" --managed-save --snapshots-metadata 2>/dev/null || true
+            echo "  - libvirt $vm"
+          fi
+          sudo rm -f \
+            "/var/lib/libvirt/images/$vm.qcow2" \
+            "/var/lib/libvirt/images/$vm-config.iso" \
+            "/var/log/ee-local-$env-cp.log" \
+            2>/dev/null || true
+          EOSSH
+          }
 
           echo "Fetching Access apps, tunnels, DNS CNAMEs..."
           apps=$(curl -fsS "${AUTH[@]}" \
@@ -205,13 +244,19 @@ jobs:
             total_dns=$((total_dns + d))
             total_vms=$((total_vms + v))
 
-            # VMs
+            # VMs — GCE side (legacy; pre-b87b36c previews live here).
             if [ -n "$env_vms" ]; then
               echo "  deleting VMs: $(echo "$env_vms" | tr '\n' ' ')"
               # shellcheck disable=SC2086
               gcloud compute instances delete $env_vms \
                 --project="$GCP_PROJECT_ID" --zone="$GCP_ZONE" --quiet || true
             fi
+
+            # VMs — libvirt side on tdx2. Current ssh-target previews
+            # live here (`dd-local-pr-N-cp`) and aren't counted in `v`
+            # above because that number comes from gcloud. No-op if
+            # the domain isn't defined (already torn down earlier).
+            teardown_libvirt_cp "$env"
 
             # Apps / tunnels / DNS — best-effort each; one failure
             # shouldn't abort the sweep.

--- a/.github/workflows/pr-teardown.yml
+++ b/.github/workflows/pr-teardown.yml
@@ -140,3 +140,43 @@ jobs:
               "https://api.cloudflare.com/client/v4/zones/${CF_ZONE_ID}/dns_records/${record_id}" \
               >/dev/null
           fi
+
+      # Since the CP target default flipped to `ssh` (b87b36c), PR CPs
+      # are libvirt domains on the tdx2 host (`dd-local-pr-N-cp`), not
+      # GCE VMs. The GCE delete step above finds nothing; left alone,
+      # the domain + its 160 GB sparse qcow2 overlay + config.iso +
+      # serial log accumulate forever — `dd-relaunch-cp.sh`'s
+      # destroy-then-redefine only fires on the NEXT push to the same
+      # PR, which never comes for a merged/closed PR.
+      - name: Destroy PR preview CP libvirt domain on tdx2
+        if: steps.pr.outputs.skip != 'true'
+        env:
+          DD_ENV: ${{ steps.pr.outputs.dd_env }}
+          HOST:    ${{ secrets.DD_LOCAL_HOST }}
+          SSH_KEY: ${{ secrets.DD_LOCAL_SSH_KEY }}
+        run: |
+          set -euo pipefail
+          key=$(mktemp)
+          trap 'rm -f "$key"' EXIT
+          printf '%s\n' "$SSH_KEY" > "$key"
+          chmod 600 "$key"
+          # `bash -s -- "$DD_ENV"` so the env name is passed as $1 into
+          # the quoted heredoc instead of expanding locally (avoids
+          # double-quote interpolation bugs for hypothetical shell-meta
+          # characters in env labels).
+          ssh -i "$key" -T \
+              -o StrictHostKeyChecking=accept-new \
+              -o ServerAliveInterval=30 \
+              tdx2@"$HOST" bash -s -- "$DD_ENV" <<'EOSSH'
+          set -euo pipefail
+          env="$1"
+          vm="dd-local-$env-cp"
+          virsh destroy "$vm" 2>/dev/null || true
+          virsh undefine "$vm" --managed-save --snapshots-metadata 2>/dev/null || true
+          sudo rm -f \
+            "/var/lib/libvirt/images/$vm.qcow2" \
+            "/var/lib/libvirt/images/$vm-config.iso" \
+            "/var/log/ee-local-$env-cp.log" \
+            2>/dev/null || true
+          echo "teardown-pr-cp: $vm torn down"
+          EOSSH


### PR DESCRIPTION
## Reopening the work I wrongly told you was "superseded by #208"

Empirically confirmed against pr-205's merge flow (a few minutes ago): `pr-teardown.yml` successfully reaps the CF tunnel + DNS CNAME, but the `dd-local-pr-205-cp` libvirt domain + its qcow2 + config.iso are still on tdx2, unchanged from their pre-deploy timestamp. #208's skip-hydrate prevents the *symptom* that these zombies caused (dnsmasq NXDOMAIN poisoning), but doesn't clean them up.

Without this PR, every closed/merged PR permanently leaks a libvirt domain + ~4MB of files on the tdx2 host. `virsh list --all` has ~20 zombies right now; it only grows.

## What changed (same diff as the prior PR)

- `pr-teardown.yml`: adds an SSH step after the existing GCE/CF/DNS deletes that runs `virsh destroy` + `virsh undefine` + `rm` of the backing files. One SSH call per teardown. Failure surfaces so the operator notices.
- `cleanup.yml` `reap-stale-pr-envs`: adds a `teardown_libvirt_cp` helper wired into the per-env closed-PR loop. `|| true` on the ssh so a transient tdx2-unreachable doesn't kill the CF sweep — next 6-hourly run catches whatever was missed.

Rebased on current main (post #208).

## Test plan
- [ ] Merge this, close a stale PR, confirm the `dd-local-pr-N-cp` domain and its files are gone on tdx2.
- [ ] Dispatch `cleanup.yml` manually and confirm it logs `  - libvirt dd-local-pr-N-cp` for each closed-PR env that still had a domain defined (there are ~20 sitting in `virsh list` today).
- [ ] Re-dispatch — second run should silently no-op for envs the first run already reaped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)