### PR TITLE
fix(cleanup): don't exit 1 when both orphan lists are empty

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -276,19 +276,29 @@ jobs:
             od=$(printf '%s\n' "$orphan_dns"  | grep -c . || true)
             echo "Orphan-agent: apps=$oa dns=$od"
 
-            [ -n "$orphan_apps" ] && echo "$orphan_apps" | while read -r id name; do
-              [ -z "$id" ] && continue
-              curl -fsS -X DELETE "${AUTH[@]}" \
-                "https://api.cloudflare.com/client/v4/accounts/$CF_ACCOUNT_ID/access/apps/$id" \
-                >/dev/null 2>&1 && echo "  - app $name" || echo "  ! app $name FAILED"
-            done
-            [ -n "$orphan_dns" ] && echo "$orphan_dns" | while read -r id name; do
-              [ -z "$id" ] && continue
-              curl -fsS -X DELETE "${AUTH[@]}" \
-                "https://api.cloudflare.com/client/v4/zones/$CF_ZONE_ID/dns_records/$id" \
-                >/dev/null 2>&1 && echo "  - dns $name" || echo "  ! dns $name FAILED"
-            done
+            if [ -n "$orphan_apps" ]; then
+              echo "$orphan_apps" | while read -r id name; do
+                [ -z "$id" ] && continue
+                curl -fsS -X DELETE "${AUTH[@]}" \
+                  "https://api.cloudflare.com/client/v4/accounts/$CF_ACCOUNT_ID/access/apps/$id" \
+                  >/dev/null 2>&1 && echo "  - app $name" || echo "  ! app $name FAILED"
+              done
+            fi
+            if [ -n "$orphan_dns" ]; then
+              echo "$orphan_dns" | while read -r id name; do
+                [ -z "$id" ] && continue
+                curl -fsS -X DELETE "${AUTH[@]}" \
+                  "https://api.cloudflare.com/client/v4/zones/$CF_ZONE_ID/dns_records/$id" \
+                  >/dev/null 2>&1 && echo "  - dns $name" || echo "  ! dns $name FAILED"
+              done
+            fi
           fi
+
+          # Explicit success — prior `[ -n "$x" ] && cmd` short-circuit
+          # would leave `$?=1` when both orphan lists were empty (the
+          # happy state), and `set -e` turned that into a script failure
+          # with no visible error. Trailing no-op restores exit 0.
+          echo "cleanup done."
 
   # TERMINATED GCE VMs accumulate for *open* envs (STONITH moves a
   # prior VM to TERMINATED; deploy-cp.yml's verify step force-deletes


### PR DESCRIPTION
## The bug

Every scheduled Cleanup run since #210 merged has failed (last ran 19:17Z). The failing step's last visible output:

\`\`\`
Orphan-agent: apps=0 dns=0
##[error]Process completed with exit code 1.
\`\`\`

No other error. The `[ -n "$orphan_dns" ] && echo "$orphan_dns" | while …; done` pattern short-circuits to exit 1 when \`\$orphan_dns\` is empty — which is the happy steady state. The original `cleanup.yml` masked this with a trailing \`echo "FINAL: …"\` summary line; my unification PR (#210) dropped it.

## The fix

- Convert both \`[ -n "\$x" ] && pipeline\` to plain \`if …; then … fi\` so the no-match branch exits 0 naturally.
- Add an explicit trailing \`echo "cleanup done."\` so any future late-added statement can't reintroduce the same failure mode.

## Test plan
- [ ] Merge, wait for the scheduled Cleanup at 00:00Z (or `gh workflow run cleanup.yml` immediately) — confirm it exits 0 even with no orphan agent apps/DNS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)