### PR TITLE
fix(cf): add /attest + /noise/ws bypass apps for agents (symmetry with CP)

### DIFF
--- a/src/cf.rs
+++ b/src/cf.rs
@@ -631,6 +631,10 @@ pub async fn provision_cp_access(
 ///   - Bypass: `{agent}.{domain}/deploy` — GH-OIDC-gated in code
 ///   - Bypass: `{agent}.{domain}/exec` — GH-OIDC-gated in code
 ///   - Bypass: `{agent}.{domain}/logs/*` — GH-OIDC-gated in code
+///   - Bypass: `{agent}.{domain}/attest` — self-authenticating
+///     (Intel-signed TDX quote over the Noise static pubkey)
+///   - Bypass: `{agent}.{domain}/noise/ws` — Noise_IK-gated in code
+///     against the paired device pubkey set
 ///   - Bypass: `{label}.{agent}.{domain}` for other labels — workload
 ///     URLs are public by default (this is the nvidia-smi exemption).
 ///   - Any existing `*.{agent}.{domain}` app whose label is no longer
@@ -660,6 +664,19 @@ pub async fn provision_agent_access(
         ("/deploy", "deploy"),
         ("/exec", "exec"),
         ("/logs", "logs"),
+        // The in-process Noise gateway (merged into the agent's
+        // router in agent.rs) lives on the same port and hostname
+        // as /deploy + /exec, so direct client attach to an agent
+        // needs the same bypass treatment the CP hostname already
+        // gets (cp.rs's provision_cp_access). Without these, the
+        // pre-handshake `GET /attest` quote fetch and the
+        // `WS /noise/ws` upgrade both 302 to CF Access login and
+        // the handshake can't even start. In-code trust is the
+        // gate: /attest is self-authenticating (Intel-signed quote
+        // over the Noise static pubkey), /noise/ws is Noise_IK
+        // against the paired device pubkey the CP trusts.
+        ("/attest", "noise-attest"),
+        ("/noise/ws", "noise-ws"),
     ] {
         ensure_bypass_app(
             http,


### PR DESCRIPTION
## The gap you spotted

\`provision_cp_access\` already carves bypass apps for \`/attest\` and \`/noise/ws\` (cf.rs:607-608) so a client can reach the in-process Noise gateway on the CP hostname without a browser CF Access cookie.

The **agent** serves the SAME in-process Noise gateway (\`src/agent.rs\`: \`.merge(noise_gateway::router(ng_state))\`) on the same port + hostname as \`/deploy\` + \`/exec\` — but \`provision_agent_access\` only bypassed the HTTP APIs (\`/health\`, \`/deploy\`, \`/exec\`, \`/logs\`), not the Noise pair.

So a bastion-app direct-attach to an agent 302s to CF Access login on:
- \`GET /attest\` (pre-handshake quote fetch)
- \`WS /noise/ws\` (upgrade)

Handshake can't even start. CP direct-attach always worked; agent direct-attach never did.

## The fix

Add both path-scoped bypasses to \`provision_agent_access\`'s list — same shape as \`provision_cp_access\`:

- \`/attest\` — self-authenticating: Intel-signed TDX quote over the Noise static pubkey. Anyone can fetch; the quote is the auth.
- \`/noise/ws\` — Noise_IK-gated in-code against the CP-trusted paired device pubkey set. Unauthorized handshakes fail cryptographically.

Provisioning is idempotent, so this propagates to every existing agent on its next \`/register\` (agent relaunch) or \`/ingress/replace\`.

## Test plan
- [ ] Merge this, let a preview agent re-register, verify direct \`GET https://dd-pr-N-agent-UUID.devopsdefender.com/attest\` returns 200 JSON instead of 302 cloudflareaccess.com.
- [ ] bastion-app direct-attach to the agent hostname succeeds end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)