### PR TITLE
refactor: fold /attest into /health

### DIFF
--- a/.github/workflows/deploy-cp.yml
+++ b/.github/workflows/deploy-cp.yml
@@ -332,37 +332,38 @@ jobs:
         env:
           AGENT_URL: https://${{ inputs.hostname }}
         run: |
-          # /attest is CF-Access-bypassed and served by the in-process
-          # Noise gateway. The response is `{ quote_b64, pubkey_hex }`
-          # where `quote_b64` is an Intel-signed TDX quote whose
+          # The Noise pre-handshake bundle used to live at `/attest`;
+          # it's now served inline on `/health` as `.noise.quote_b64`
+          # + `.noise.pubkey_hex` so a bastion-app can bootstrap in
+          # one fetch. `quote_b64` is an Intel-signed TDX quote whose
           # `report_data` (first 32 bytes) equals the raw Noise static
           # pubkey. MRTD = 48 bytes at offset 184 in TDX quote v4;
           # non-zero means attestation worked.
           for attempt in $(seq 1 60); do
             BODY=$(curl -s -w '\n%{http_code}' \
-              "${AGENT_URL}/attest" || echo $'\n000')
+              "${AGENT_URL}/health" || echo $'\n000')
             CODE=$(echo "$BODY" | tail -n1)
             JSON=$(echo "$BODY" | sed '$d')
             if [ "$CODE" = "200" ]; then
-              QUOTE_B64=$(echo "$JSON" | jq -r '.quote_b64 // empty')
+              QUOTE_B64=$(echo "$JSON" | jq -r '.noise.quote_b64 // empty')
               if [ -n "$QUOTE_B64" ] && [ "$QUOTE_B64" != "null" ]; then
                 MRTD=$(echo "$QUOTE_B64" | base64 -d \
                   | dd bs=1 skip=184 count=48 status=none | xxd -p -c 48)
                 if [ -n "$MRTD" ] && [ "$MRTD" != "$(printf '00%.0s' {1..48})" ]; then
-                  PUBKEY=$(echo "$JSON" | jq -r '.pubkey_hex // empty')
+                  PUBKEY=$(echo "$JSON" | jq -r '.noise.pubkey_hex // empty')
                   echo "NEW VM verified — MRTD: $MRTD, noise_pubkey: $PUBKEY"
                   exit 0
                 fi
-                echo "  /attest 200 but MRTD empty/zero, retrying... (${attempt}/60)"
+                echo "  /health .noise 200 but MRTD empty/zero, retrying... (${attempt}/60)"
               else
-                echo "  /attest 200 but no quote_b64, retrying... (${attempt}/60)"
+                echo "  /health 200 but no .noise.quote_b64, retrying... (${attempt}/60)"
               fi
             else
-              echo "  /attest returned HTTP ${CODE}, retrying... (${attempt}/60)"
+              echo "  /health returned HTTP ${CODE}, retrying... (${attempt}/60)"
             fi
             sleep 10
           done
-          echo "::error::/attest never returned a valid quote — stale tunnel or new VM never came up"
+          echo "::error::/health never returned a valid .noise.quote_b64 — stale tunnel or new VM never came up"
           exit 1
 
       - name: Verify dashboard is fronted by CF Access

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -26,6 +26,7 @@ use axum::http::HeaderMap;
 use axum::response::{Html, IntoResponse, Response};
 use axum::routing::{get, post};
 use axum::{Json, Router};
+use base64::Engine as _;
 use serde::Deserialize;
 use tokio::sync::RwLock;
 
@@ -70,6 +71,13 @@ struct St {
     /// without any shared secret; anyone else is denied at claim
     /// check.
     gh: Arc<gh_oidc::Verifier>,
+    /// TDX-quote + Noise-static-pubkey bundle. Served as
+    /// `{ noise: { quote_b64, pubkey_hex } }` off `/health` so a
+    /// bastion-app can bootstrap a Noise session in one fetch (used
+    /// to be a separate `/attest` endpoint — folded in here). Shared
+    /// `Arc` with the Noise gateway module's handshake responder;
+    /// one keypair / one quote per boot.
+    attest: Arc<noise_gateway::attest::Attestor>,
 }
 
 pub async fn run() -> Result<()> {
@@ -115,10 +123,12 @@ pub async fn run() -> Result<()> {
         });
     }
 
-    // Noise gateway runs in-process too: this agent serves `/attest`
-    // + `/noise/ws` on the same port 8080 as everything else, so
-    // bastion-app CLIs can attach directly to the agent's EE
-    // instance without going through the CP.
+    // Noise gateway runs in-process too: this agent serves the
+    // pre-handshake bundle inline on /health (`.noise.quote_b64` +
+    // `.noise.pubkey_hex`) and the Noise_IK responder on /noise/ws,
+    // both on the same port 8080 as everything else, so bastion-app
+    // CLIs can attach directly to the agent's EE instance without
+    // going through the CP.
     let trust = noise_gateway::new_trust_handle();
 
     // Background poll for the device trust list. Mutates `trust`
@@ -155,7 +165,7 @@ pub async fn run() -> Result<()> {
         ee_token,
     ));
     let ng_state = noise_gateway::State {
-        attest: attestor,
+        attest: attestor.clone(),
         trust,
         upstream,
     };
@@ -171,6 +181,7 @@ pub async fn run() -> Result<()> {
         ita_token,
         extras: Arc::new(RwLock::new(cfg.extra_ingress.clone())),
         gh,
+        attest: attestor,
     };
 
     let app = Router::new()
@@ -463,6 +474,17 @@ async fn health(State(s): State<St>) -> Json<serde_json::Value> {
         "system_uptime_secs": m.uptime_secs,
         "ita_token": ita_token,
         "extra_ingress": extra_ingress,
+        // Pre-Noise-handshake bundle — stable per boot. Used to be a
+        // standalone `GET /attest` endpoint. Keeping it here lets a
+        // bastion-app bootstrap with one fetch and drops a CF Access
+        // bypass-app per env × per service. `quote_b64` binds the
+        // raw Noise pubkey into its TDX `report_data`; clients verify
+        // the Intel signature and pin the pubkey from the quote — no
+        // TOFU needed.
+        "noise": {
+            "quote_b64": base64::engine::general_purpose::STANDARD.encode(s.attest.quote()),
+            "pubkey_hex": hex::encode(s.attest.public_key()),
+        },
     }))
 }
 

--- a/src/cf.rs
+++ b/src/cf.rs
@@ -600,6 +600,25 @@ pub async fn provision_cp_access(
             }
         }
     }
+    // One-shot reap: any prior deploy left behind a
+    // `dd-{env}-cp-noise-attest` bypass app fronting `{hostname}/attest`.
+    // The attest route is gone, so the bypass has no job. The workload
+    // sweep above is subdomain-scoped and won't catch path-bypass apps,
+    // so delete it explicitly here. Lookup-by-domain is idempotent;
+    // no-op once the app is gone.
+    if let Ok(Some(stale)) = find_app_by_domain(http, cf, &format!("{hostname}/attest")).await {
+        if let Some(id) = stale["id"].as_str() {
+            let _ = call(
+                http,
+                cf,
+                Method::DELETE,
+                &format!("/accounts/{}/access/apps/{id}", cf.account_id),
+                None,
+            )
+            .await;
+        }
+    }
+
     for (path_suffix, label) in [
         ("/health", "health"),
         ("/api/agents", "api-agents"),

--- a/src/cf.rs
+++ b/src/cf.rs
@@ -510,9 +510,10 @@ fn is_admin_label(label: &str) -> bool {
 /// Apps created:
 ///   - Human: `{hostname}` — GitHub org or admin email (dashboard, /agent/*, /cp/*)
 ///   - Human: `term.{hostname}` — ttyd shell, org members only
-///   - Bypass: `{hostname}/health` — public (read-only fleet health)
-///   - Bypass: `{hostname}/cp/attest` — TDX quote is self-authenticating
+///   - Bypass: `{hostname}/health` — public (read-only fleet health;
+///     also carries the Noise pre-handshake `{quote_b64, pubkey_hex}`)
 ///   - Bypass: `{hostname}/api/agents` — read-only agent list
+///   - Bypass: `{hostname}/noise/ws` — Noise_IK-gated in code
 ///   - Bypass: `{hostname}/register` — ITA-gated in code
 ///   - Bypass: `{hostname}/ingress/replace` — ITA-gated in code
 pub async fn provision_cp_access(
@@ -604,7 +605,9 @@ pub async fn provision_cp_access(
         ("/api/agents", "api-agents"),
         ("/api/v1/devices/trusted", "api-devices-trusted"),
         ("/api/v1/admin/export", "api-admin-export"),
-        ("/attest", "noise-attest"),
+        // The Noise pre-handshake bundle (`quote_b64` + `pubkey_hex`)
+        // now rides on `/health` — `/attest` was deleted. Only the
+        // handshake itself still needs its own bypass.
         ("/noise/ws", "noise-ws"),
         ("/register", "register"),
         ("/ingress/replace", "ingress"),
@@ -627,10 +630,13 @@ pub async fn provision_cp_access(
 ///   - Human: `{agent}.{domain}` — browser dashboard only
 ///   - Human: `<admin-label>.{agent}.{domain}` for labels in
 ///     `ADMIN_LABELS` (ttyd et al) — org members only
-///   - Bypass: `{agent}.{domain}/health` — public
+///   - Bypass: `{agent}.{domain}/health` — public; carries the Noise
+///     pre-handshake `{quote_b64, pubkey_hex}` in its response
 ///   - Bypass: `{agent}.{domain}/deploy` — GH-OIDC-gated in code
 ///   - Bypass: `{agent}.{domain}/exec` — GH-OIDC-gated in code
 ///   - Bypass: `{agent}.{domain}/logs/*` — GH-OIDC-gated in code
+///   - Bypass: `{agent}.{domain}/noise/ws` — Noise_IK-gated in code
+///     against the CP-trusted paired device pubkey set
 ///   - Bypass: `{label}.{agent}.{domain}` for other labels — workload
 ///     URLs are public by default (this is the nvidia-smi exemption).
 ///   - Any existing `*.{agent}.{domain}` app whose label is no longer
@@ -660,6 +666,15 @@ pub async fn provision_agent_access(
         ("/deploy", "deploy"),
         ("/exec", "exec"),
         ("/logs", "logs"),
+        // The in-process Noise gateway (merged into the agent's
+        // router in agent.rs) lives on the same port + hostname as
+        // /deploy + /exec, so a direct bastion-app attach needs the
+        // same bypass treatment the CP hostname already gets. The
+        // pre-handshake quote bundle is served by /health above
+        // (collapsed from the old /attest), so only the handshake
+        // WebSocket needs its own entry here. Noise_IK against the
+        // paired device pubkey set is the gate.
+        ("/noise/ws", "noise-ws"),
     ] {
         ensure_bypass_app(
             http,

--- a/src/cp.rs
+++ b/src/cp.rs
@@ -50,6 +50,13 @@ struct St {
     /// Paired device pubkeys. Mutations persist to disk and emit a
     /// runtime view for the local ee-proxy workload.
     devices: Arc<crate::devices::Store>,
+    /// TDX-quote + Noise-static-pubkey bundle. Surfaced by `/health`
+    /// as `{ noise: { quote_b64, pubkey_hex } }` so a bastion-app
+    /// bootstraps in one fetch (the former standalone `/attest`
+    /// endpoint was folded in). Shared `Arc` with the Noise gateway
+    /// module's handshake responder — one keypair / one quote per
+    /// boot.
+    attest: Arc<noise_gateway::attest::Attestor>,
 }
 
 pub async fn run() -> Result<()> {
@@ -174,8 +181,10 @@ pub async fn run() -> Result<()> {
     // Stage 4: provision CF Access apps for our own tunnel. Workload
     // labels (e.g. `block` for ttyd) get the human policy; the
     // paths in the bypass list (`/register`, `/api/agents`,
-    // `/api/v1/devices/trusted`, `/api/v1/admin/export`, `/attest`,
-    // `/noise/ws`, …) are CF-bypassed with in-code gating.
+    // `/api/v1/devices/trusted`, `/api/v1/admin/export`, `/noise/ws`,
+    // `/health`, …) are CF-bypassed with in-code gating. `/health`
+    // also carries the Noise pre-handshake quote + pubkey (the former
+    // `/attest` — now inlined to save a bootstrap round-trip).
     let cp_labels: Vec<String> = cp_extras.iter().map(|(l, _)| l.clone()).collect();
     if let Err(e) = cf::provision_cp_access(
         &http,
@@ -300,7 +309,7 @@ pub async fn run() -> Result<()> {
         ee_token,
     ));
     let ng_state = noise_gateway::State {
-        attest: attestor,
+        attest: attestor.clone(),
         trust: trust.clone(),
         upstream,
     };
@@ -314,6 +323,7 @@ pub async fn run() -> Result<()> {
         cp_ita_token,
         gh,
         devices,
+        attest: attestor,
     };
 
     let app = Router::new()
@@ -460,6 +470,7 @@ async fn health(
     State(s): State<St>,
     Query(q): Query<HashMap<String, String>>,
 ) -> Json<serde_json::Value> {
+    use base64::Engine as _;
     let agents = s.store.lock().await;
     let mut body = serde_json::json!({
         "ok": true,
@@ -469,11 +480,21 @@ async fn health(
         "uptime_secs": s.started.elapsed().as_secs(),
         "agent_count": agents.len(),
         "healthy_count": agents.values().filter(|a| a.status == "healthy").count(),
+        // Pre-Noise-handshake bundle — the former `GET /attest`
+        // endpoint folded in here so bastion-app bootstraps in one
+        // fetch and we drop a CF Access bypass-app per env × per
+        // service. Stable per boot; `Arc` clones are effectively free
+        // per request. `quote_b64` binds the raw Noise pubkey into
+        // TDX `report_data`, self-authenticating via ITA.
+        "noise": {
+            "quote_b64": base64::engine::general_purpose::STANDARD.encode(s.attest.quote()),
+            "pubkey_hex": hex::encode(s.attest.public_key()),
+        },
     });
     // `?verbose=1` folds in the CP's current ITA token so operators
     // can inspect the CP VM's TDX measurement without a second route
     // (the old `/cp/ita` + `/cp/attest` paths were removed; the
-    // Noise gateway's `/attest` is the public quote surface).
+    // TDX quote for the Noise pubkey is also above, unconditionally).
     if q.get("verbose").map(|v| v.as_str()) == Some("1") {
         if let Some(obj) = body.as_object_mut() {
             obj.insert(
@@ -1114,7 +1135,7 @@ async fn agent_detail(State(s): State<St>, Path(id): Path<String>) -> Response {
     let term_host = html::escape(&cf::label_hostname(&a.hostname, "block"));
     let extra = if is_cp {
         format!(
-            r#"<p><a href="https://{term_host}/" target="_blank">Terminal ↗</a> · <a href="/attest">attest</a> · <a href="/health?verbose=1">ita</a></p>"#
+            r#"<p><a href="https://{term_host}/" target="_blank">Terminal ↗</a> · <a href="/health">health (incl. noise quote)</a> · <a href="/health?verbose=1">health?verbose=1 (incl. ita)</a></p>"#
         )
     } else {
         format!(

--- a/src/noise_gateway/attest.rs
+++ b/src/noise_gateway/attest.rs
@@ -3,21 +3,22 @@
 //! On boot we either load an existing 32-byte X25519 private key from
 //! disk (tmpfs — `/run/devopsdefender/noise.key`) or mint a fresh one.
 //! The corresponding public key is embedded in a TDX quote's
-//! `report_data` field (low 32 bytes; high 32 bytes zero). Clients
-//! fetch `GET /attest` over plain HTTPS, verify the quote via ITA,
-//! extract the Noise static pubkey from `report_data`, and trust
-//! that key for the handshake. No X.509 certs in the loop.
+//! `report_data` field (low 32 bytes; high 32 bytes zero). The quote +
+//! pubkey bundle is surfaced by the containing service's `/health`
+//! endpoint (see `agent::health` and `cp::health`); clients verify
+//! the quote via ITA, extract the Noise static pubkey from
+//! `report_data`, and trust that key for the handshake. No X.509
+//! certs in the loop.
+//!
+//! There used to be a dedicated `GET /attest` route here. It was
+//! collapsed into `/health` so a bastion-app bootstrap does one
+//! request instead of two, and so the CF Access bypass list shrinks
+//! by one app per env × per service. The Noise quote is stable per
+//! boot — just an `Arc<Attestor>` clone on each `/health` hit.
 
 use std::path::{Path, PathBuf};
 
-use axum::extract::State;
-use axum::response::Json;
-use axum::routing::get;
-use axum::Router;
-use base64::engine::general_purpose::STANDARD as B64;
-use base64::Engine as _;
 use rand::rngs::OsRng;
-use serde::Serialize;
 use x25519_dalek::{PublicKey, StaticSecret};
 
 pub struct Attestor {
@@ -74,23 +75,6 @@ impl Attestor {
     pub fn quote(&self) -> &[u8] {
         &self.quote
     }
-}
-
-pub(crate) fn routes() -> Router<super::State> {
-    Router::new().route("/attest", get(attest))
-}
-
-#[derive(Serialize)]
-struct AttestResponse {
-    quote_b64: String,
-    pubkey_hex: String,
-}
-
-async fn attest(State(s): State<super::State>) -> Json<AttestResponse> {
-    Json(AttestResponse {
-        quote_b64: B64.encode(s.attest.quote()),
-        pubkey_hex: hex::encode(s.attest.public_key()),
-    })
 }
 
 async fn persist_key(key_file: &Path, bytes: &[u8; 32]) -> anyhow::Result<()> {

--- a/src/noise_gateway/mod.rs
+++ b/src/noise_gateway/mod.rs
@@ -1,15 +1,19 @@
 //! # Noise_IK attested gateway to EE's agent socket.
 //!
-//! Routes exposed alongside DD's normal HTTP surface (same port):
-//!   - `GET /attest`   — `{ quote_b64, pubkey_hex }`. TDX quote's
-//!     `report_data` = the raw 32-byte X25519 Noise static pubkey.
-//!     Clients verify via ITA and trust that pubkey for the handshake.
+//! Route exposed alongside DD's normal HTTP surface (same port):
 //!   - `GET /noise/ws` — WebSocket upgrade; server runs Noise_IK
 //!     responder. Initiator's static pubkey must be in the local
 //!     trust set. After the handshake every decrypted binary frame
 //!     is one JSON request envelope gated by [`allowlist::classify`],
 //!     forwarded to EE's unix agent socket with the `EE_TOKEN`
 //!     (when available) injected server-side.
+//!
+//! The pre-handshake TDX quote + Noise pubkey bundle is served by the
+//! containing service's `/health` endpoint, not by this module — see
+//! `agent::health` / `cp::health` for `{ noise: { quote_b64,
+//! pubkey_hex } }`. Clients do one `/health` fetch, verify the quote
+//! against ITA, pin the pubkey from `report_data`, and open this
+//! WebSocket.
 //!
 //! This module used to live in `crates/ee-proxy/`; folded in here
 //! so the trust list can be a shared in-memory set (not a file
@@ -44,8 +48,5 @@ pub struct State {
 }
 
 pub fn router(state: State) -> Router {
-    Router::new()
-        .merge(attest::routes())
-        .merge(noise::routes())
-        .with_state(state)
+    Router::new().merge(noise::routes()).with_state(state)
 }


### PR DESCRIPTION
## Why

`/attest` is a dedicated public GET that returns the service's Noise static pubkey + TDX quote so a bastion-app client can pin the responder key before the Noise_IK handshake. Every boot, every env, on both CP and agents — the quote is bound to the pubkey in TDX `report_data`, which is all the client actually needs to pin.

The problem is it duplicates `/health`: same request shape, same public bypass requirement, same consumer. Two routes instead of one means:

- Two `curl` hops per client bootstrap instead of one.
- Two CF Access bypass apps to provision on every env (`{hostname}/health` + `{hostname}/attest` on CP, same pattern if we extend to agents).
- Two failure modes the operator has to keep exempted from Access policy rot.

The Noise quote is stable per-boot and `Arc<Attestor>` clones are free, so folding it onto `/health` is free. This PR does that.

Supersedes #213, which came from the same observation (the agent `/attest` wasn't in the agent bypass list even though the CP one was, so direct-to-agent attach 302'd on the pre-handshake fetch). #213 tried to fix the asymmetry by **adding** the agent bypass. This PR deletes the route on both sides instead, so the asymmetry can't come back.

## What

**Server — `/attest` goes away.**
- `noise_gateway::attest` keeps the `Attestor` struct + key/quote accessors; drops the axum route, handler, and `AttestResponse`.
- `noise_gateway::router` no longer merges `attest::routes()`.

**Server — `/health` grows a `noise` field.**
- Both `cp::health` and `agent::health` embed `{ noise: { quote_b64, pubkey_hex } }` on every hit. Unconditional — no `?verbose=1` gating — because the overhead is one `base64::encode` + one `hex::encode` of pre-computed bytes held in an `Arc`.

**CF Access provisioning.**
- `provision_cp_access`: `/attest` removed from the bypass list.
- `provision_cp_access`: explicit one-shot `DELETE` of any surviving `{hostname}/attest` bypass app. The existing stale-apps sweep is subdomain-scoped (`{base}-{label}.{tld}`) and wouldn't catch path-bypass apps, so without this the old Access app lingers post-deploy.
- `provision_agent_access`: `/noise/ws` added to the bypass list so a direct client attach to an agent doesn't 302 on the handshake upgrade. (CP already had this; agent didn't — that's the same asymmetry #213 was fixing from the opposite direction.)

**CI.**
- `deploy-cp.yml` verify step now `GET /health` and `jq`-parses `.noise.quote_b64` / `.noise.pubkey_hex` instead of hitting `/attest`.

Client-side fold lives in [`devopsdefender/bastion-app#16`](https://github.com/devopsdefender/bastion-app/pull/16) (commit `bac6e63`). Its fetcher sends `GET /health?verbose=1`; this PR emits the `noise` field unconditionally so the flag is a no-op today, but the client keeps sending it in case we ever want to gate.

## Merge order

Land this first. Pre-fold dd returns no `noise` field and the bastion-app fetcher has an explicit "upgrade the server" error for that case, so the bastion-app side is safe to land second.

## Test plan

- [ ] `cargo fmt --check && cargo clippy --all-targets -- -D warnings && cargo test` — clean locally
- [ ] Preview deploy succeeds; the workflow's `/health` probe parses `.noise.quote_b64` + `.noise.pubkey_hex`
- [ ] `curl -sf https://pr-214.devopsdefender.com/health | jq -e '.noise.quote_b64 and .noise.pubkey_hex'` on CP
- [ ] Same on an agent hostname after register
- [ ] `curl -s -o /dev/null -w '%{http_code}' https://pr-214.devopsdefender.com/attest` → `404` (not `302` — confirms CF Access isn't re-intercepting a non-existent route)
- [ ] After the deploy settles: `gh` / `cf api` check that no `dd-pr-214-cp-noise-attest` Access app survives

🤖 Generated with [Claude Code](https://claude.com/claude-code)