### PR TITLE
feat(ci): align dd env with easyenclave channel + auto-sync tdx2 base

### DIFF
--- a/.github/actions/relaunch-agent/action.yml
+++ b/.github/actions/relaunch-agent/action.yml
@@ -27,6 +27,14 @@ inputs:
   release-tag:
     description: 'devopsdefender release tag the local agent should download (e.g. pr-abc123, latest)'
     required: true
+  ee-channel:
+    description: 'easyenclave release channel to sync the libvirt base qcow2 from (stable | staging)'
+    required: false
+    default: 'staging'
+  ee-tag:
+    description: 'Explicit easyenclave release tag override for pre-flight testing a candidate (e.g. image-abc123456). Wins over `ee-channel`.'
+    required: false
+    default: ''
   stream-console:
     description: 'Tail /var/log/ee-local-<kind>.log from tdx2 into the CI log for the duration of the register-wait. Surfaces what the agent VM is actually doing when it fails to register.'
     required: false
@@ -59,11 +67,13 @@ runs:
         REF: ${{ inputs.ref }}
         RELEASE_TAG: ${{ inputs.release-tag }}
         DD_ITA_API_KEY: ${{ inputs.ita-api-key }}
+        DD_EE_CHANNEL: ${{ inputs.ee-channel }}
+        DD_EE_TAG: ${{ inputs.ee-tag }}
       with:
         host: ${{ inputs.host }}
         username: tdx2
         key: ${{ inputs.ssh-key }}
-        envs: KIND,URL,REF,RELEASE_TAG,DD_ITA_API_KEY
+        envs: KIND,URL,REF,RELEASE_TAG,DD_ITA_API_KEY,DD_EE_CHANNEL,DD_EE_TAG
         script: |
           /home/tdx2/src/dd/apps/_infra/dd-relaunch.sh "$KIND" "$URL" "$REF" "$RELEASE_TAG"
 

--- a/.github/actions/relaunch-cp/action.yml
+++ b/.github/actions/relaunch-cp/action.yml
@@ -39,6 +39,14 @@ inputs:
   release-tag:
     description: 'devopsdefender release tag (e.g. pr-abc123, latest)'
     required: true
+  ee-channel:
+    description: 'easyenclave release channel to sync the libvirt base qcow2 from (stable | staging)'
+    required: false
+    default: 'staging'
+  ee-tag:
+    description: 'Explicit easyenclave release tag override for pre-flight testing a candidate (e.g. image-abc123456). Wins over `ee-channel`.'
+    required: false
+    default: ''
 
 runs:
   using: composite
@@ -55,11 +63,13 @@ runs:
         CLOUDFLARE_ZONE_ID:     ${{ inputs.cf-zone-id }}
         DD_ACCESS_ADMIN_EMAIL:  ${{ inputs.admin-email }}
         DD_ITA_API_KEY:         ${{ inputs.ita-api-key }}
+        DD_EE_CHANNEL:          ${{ inputs.ee-channel }}
+        DD_EE_TAG:              ${{ inputs.ee-tag }}
       with:
         host: ${{ inputs.host }}
         username: tdx2
         key: ${{ inputs.ssh-key }}
-        envs: ENV_LABEL,CP_HOSTNAME,REF,RELEASE_TAG,CLOUDFLARE_API_TOKEN,CLOUDFLARE_ACCOUNT_ID,CLOUDFLARE_ZONE_ID,DD_ACCESS_ADMIN_EMAIL,DD_ITA_API_KEY
+        envs: ENV_LABEL,CP_HOSTNAME,REF,RELEASE_TAG,CLOUDFLARE_API_TOKEN,CLOUDFLARE_ACCOUNT_ID,CLOUDFLARE_ZONE_ID,DD_ACCESS_ADMIN_EMAIL,DD_ITA_API_KEY,DD_EE_CHANNEL,DD_EE_TAG
         script: |
           /home/tdx2/src/dd/apps/_infra/dd-relaunch-cp.sh \
             "$ENV_LABEL" "$CP_HOSTNAME" "$REF" "$RELEASE_TAG"

--- a/.github/workflows/deploy-cp.yml
+++ b/.github/workflows/deploy-cp.yml
@@ -62,6 +62,11 @@ on:
         required: false
         type: string
         default: ssh
+      ee_tag:
+        description: 'Explicit easyenclave release tag to pin this deploy to (pre-flight-test a candidate before promoting staging→stable). Empty = default to channel resolved from env.'
+        required: false
+        type: string
+        default: ''
 
 # Serialize PR-preview deploys on the `preview` bucket: all pr-*
 # runs share one libvirt domain (`dd-local-preview`) on tdx2, so
@@ -89,6 +94,26 @@ jobs:
       GCP_ZONE: us-central1-c
     steps:
       - uses: actions/checkout@v4
+
+      # Map dd env → easyenclave channel. Prod (CP and local) tracks
+      # `stable` (EE v* tags); everything else (pr-N previews) tracks
+      # `staging` (EE prereleases from main). Keeps dd prod off
+      # in-flight-main EE builds while preview deploys catch EE
+      # regressions early. Applies to both target=gcp (image family
+      # lookup) and target=ssh (release-asset sync on tdx2).
+      - name: Resolve easyenclave channel
+        id: ee
+        env:
+          ENV: ${{ inputs.env }}
+        run: |
+          case "$ENV" in
+            production) channel=stable;  family=easyenclave-stable  ;;
+            *)          channel=staging; family=easyenclave-staging ;;
+          esac
+          {
+            echo "channel=$channel"
+            echo "family=$family"
+          } >> "$GITHUB_OUTPUT"
 
       # GCP auth only on target=gcp. We used to configure it
       # unconditionally so ssh-target deploys could reap GCE orphans
@@ -120,6 +145,8 @@ jobs:
           admin-email:   ${{ vars.DD_ACCESS_ADMIN_EMAIL || secrets.DD_ACCESS_ADMIN_EMAIL }}
           ita-api-key:   ${{ secrets.DD_ITA_API_KEY }}
           release-tag:   ${{ inputs.release_tag }}
+          ee-channel:    ${{ steps.ee.outputs.channel }}
+          ee-tag:        ${{ inputs.ee_tag }}
 
       - name: Create TDX VM (boots from easyenclave, fetches dd from GitHub releases)
         if: inputs.target == 'gcp'
@@ -132,7 +159,7 @@ jobs:
           DD_ACCESS_ADMIN_EMAIL: ${{ vars.DD_ACCESS_ADMIN_EMAIL || secrets.DD_ACCESS_ADMIN_EMAIL }}
           DD_ITA_API_KEY: ${{ secrets.DD_ITA_API_KEY }}
           DD_RELEASE_TAG: ${{ inputs.release_tag }}
-          EE_IMAGE_FAMILY: easyenclave-staging
+          EE_IMAGE_FAMILY: ${{ steps.ee.outputs.family }}
           EE_IMAGE_PROJECT: easyenclave
           VM_MACHINE_TYPE: c3-standard-4
           VM_DISK_SIZE: 10GB
@@ -456,6 +483,8 @@ jobs:
           host: ${{ secrets.DD_LOCAL_HOST }}
           ita-api-key: ${{ secrets.DD_ITA_API_KEY }}
           release-tag: ${{ inputs.release_tag }}
+          ee-channel: ${{ steps.ee.outputs.channel }}
+          ee-tag: ${{ inputs.ee_tag }}
 
       # Preview only: deploy hello-world as the end-to-end canary.
       # Exercises the full GH-OIDC auth path (mint → agent verify

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,10 @@ on:
         description: 'Release tag to deploy to production (rollback tool; default: latest)'
         required: false
         default: 'latest'
+      ee_tag:
+        description: 'Pin the libvirt base qcow2 to a specific easyenclave release (e.g. image-abc123456) for pre-flight testing a candidate EE. Empty = track the env''s channel default (stable for prod, staging otherwise).'
+        required: false
+        default: ''
 
 concurrency:
   group: dd-release-${{ github.ref }}
@@ -159,6 +163,7 @@ jobs:
       release_tag: ${{ needs.build.outputs.tag }}
       comment_on_pr: true
       ref: ${{ github.event.pull_request.head.ref }}
+      ee_tag: ${{ inputs.ee_tag || '' }}
     secrets: inherit
 
   # Production deploy at app.{domain}. Fires on push-to-main OR on a
@@ -186,4 +191,5 @@ jobs:
       release_tag: ${{ inputs.release_tag || 'latest' }}
       comment_on_pr: false
       ref: main
+      ee_tag: ${{ inputs.ee_tag || '' }}
     secrets: inherit

--- a/apps/_infra/dd-relaunch-cp.sh
+++ b/apps/_infra/dd-relaunch-cp.sh
@@ -37,6 +37,18 @@ git fetch --quiet origin "$REF"
 git checkout --quiet "origin/$REF" -- apps/
 echo "dd-relaunch-cp: refreshed apps/ from origin/$REF"
 
+# Sync the libvirt base qcow2 from the easyenclave release channel
+# for this env. `production` tracks `stable` (v*); anything else
+# (pr-N, dev) tracks `staging`. `DD_EE_TAG` overrides the channel
+# default for pre-flight-testing a candidate release.
+# shellcheck source=./ee-sync.sh
+. ./apps/_infra/ee-sync.sh
+case "$ENV_LABEL" in
+  production) export DD_EE_CHANNEL="${DD_EE_CHANNEL:-stable}"  ;;
+  *)          export DD_EE_CHANNEL="${DD_EE_CHANNEL:-staging}" ;;
+esac
+sync_base /var/lib/libvirt/images/easyenclave-local.qcow2
+
 VM="dd-local-$ENV_LABEL-cp"
 
 ./apps/_infra/local-cp.sh "$ENV_LABEL" "$HOSTNAME"

--- a/apps/_infra/dd-relaunch.sh
+++ b/apps/_infra/dd-relaunch.sh
@@ -41,6 +41,19 @@ git fetch --quiet origin "$REF"
 git checkout --quiet "origin/$REF" -- apps/
 echo "dd-relaunch: refreshed apps/ from origin/$REF"
 
+# Keep the libvirt base qcow2 aligned with the easyenclave release
+# channel for this env. `prod` tracks `stable` (v*); `preview` tracks
+# `staging` (main-branch prereleases). `DD_EE_TAG` from CI pins a
+# specific release for pre-flight testing a candidate. Running VMs
+# hold the old inode via open fds, so `mv` in place is safe.
+# shellcheck source=./ee-sync.sh
+. ./apps/_infra/ee-sync.sh
+case "$KIND" in
+  prod)    export DD_EE_CHANNEL="${DD_EE_CHANNEL:-stable}"  ;;
+  preview) export DD_EE_CHANNEL="${DD_EE_CHANNEL:-staging}" ;;
+esac
+sync_base /var/lib/libvirt/images/easyenclave-local.qcow2
+
 vm="dd-local-$KIND"
 overlay="/var/lib/libvirt/images/$vm.qcow2"
 

--- a/apps/_infra/ee-sync.sh
+++ b/apps/_infra/ee-sync.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# ee-sync.sh — keep `/var/lib/libvirt/images/easyenclave-local.qcow2` on
+# the tdx2 host in sync with the right easyenclave release channel.
+#
+# Sourced by dd-relaunch.sh + dd-relaunch-cp.sh. Each relaunch:
+#   1. Resolves the desired EE tag — explicit `DD_EE_TAG` wins, else
+#      the latest release matching `DD_EE_CHANNEL` (stable | staging).
+#   2. Compares against the sidecar `.tag` file next to the qcow2.
+#   3. Downloads + atomic-renames into place if different.
+#
+# Channel mapping lives in the callers: dd `production` / `dd-local-prod`
+# track EE `stable` (v*); everything else tracks EE `staging` (image-*
+# prereleases on main). An explicit `DD_EE_TAG` overrides the channel
+# default for pre-flight-testing a candidate EE against dd before
+# promoting the prerelease.
+#
+# The sidecar tag file (`<base>.tag`) is the only persistent state
+# besides the qcow2 itself. If it drifts (operator manually SCP'd a
+# qcow2 without updating the tag), the next sync that hits a channel
+# default will pull the channel's latest and overwrite — cheaper than
+# hash-compare over a 300 MB file.
+
+# Intentionally no `set -e` here; callers already run under `set -euo`.
+# We return a non-zero code from sync_base on hard failure so the
+# caller's pipefail kills the relaunch before anything destructive.
+
+EE_REPO="${EE_REPO:-easyenclave/easyenclave}"
+EE_ASSET_PATTERN="${EE_ASSET_PATTERN:-easyenclave-*-local-tdx-qcow2.qcow2}"
+
+sync_base() {
+  local base="${1:?usage: sync_base <path-to-base-qcow2>}"
+  local channel="${DD_EE_CHANNEL:-staging}"
+  local target="${DD_EE_TAG:-}"
+
+  # Resolve target tag from channel if no explicit pin.
+  if [ -z "$target" ]; then
+    case "$channel" in
+      stable)
+        # Stable = latest non-prerelease. `--exclude-pre-releases` is a
+        # `gh release list` flag.
+        target=$(gh release list --repo "$EE_REPO" \
+                 --exclude-pre-releases --limit 1 \
+                 --json tagName -q '.[0].tagName' 2>/dev/null)
+        ;;
+      staging)
+        # Staging = newest release, prerelease or not. `gh release list`
+        # with no filter sorts newest-first.
+        target=$(gh release list --repo "$EE_REPO" \
+                 --limit 1 --json tagName -q '.[0].tagName' 2>/dev/null)
+        ;;
+      *)
+        echo "ee-sync: unknown DD_EE_CHANNEL=$channel (want stable|staging)" >&2
+        return 2
+        ;;
+    esac
+    if [ -z "$target" ]; then
+      echo "ee-sync: failed to resolve $channel tag from $EE_REPO (gh auth?)" >&2
+      return 2
+    fi
+  fi
+
+  local current=""
+  [ -f "$base.tag" ] && current=$(cat "$base.tag")
+
+  if [ "$target" = "$current" ] && [ -f "$base" ]; then
+    echo "ee-sync: $base @ $current (channel=$channel, up to date)"
+    return 0
+  fi
+
+  local tmp="$base.tmp.$$"
+  trap 'rm -f "$tmp"' RETURN
+  # Download is best-effort: if the candidate release doesn't yet carry
+  # a matching asset (e.g. a pre-merge-of-easyenclave#87 release, or a
+  # partial release-staging failure), keep the existing base rather
+  # than aborting the deploy. The tag sidecar is NOT updated in that
+  # case, so the next run retries. An existing base is always
+  # preferable to no base — worst-case we just keep running slightly
+  # stale EE until the asset reappears.
+  if ! gh release download "$target" --repo "$EE_REPO" \
+         --pattern "$EE_ASSET_PATTERN" --output "$tmp" 2>&1; then
+    if [ -f "$base" ]; then
+      echo "ee-sync: $target has no '$EE_ASSET_PATTERN' asset yet; keeping existing $base (tag=$current)" >&2
+      return 0
+    fi
+    echo "ee-sync: download failed for $target (pattern=$EE_ASSET_PATTERN), no existing $base to fall back to" >&2
+    return 3
+  fi
+
+  # Ensure libvirt can read it — qemu runs as libvirt-qemu:kvm.
+  chown libvirt-qemu:kvm "$tmp" 2>/dev/null || true
+  mv "$tmp" "$base"
+  echo "$target" > "$base.tag"
+  echo "ee-sync: $base ${current:-<none>} -> $target (channel=$channel)"
+}

--- a/apps/_infra/ee-sync.sh
+++ b/apps/_infra/ee-sync.sh
@@ -43,10 +43,16 @@ sync_base() {
                  --json tagName -q '.[0].tagName' 2>/dev/null)
         ;;
       staging)
-        # Staging = newest release, prerelease or not. `gh release list`
-        # with no filter sorts newest-first.
-        target=$(gh release list --repo "$EE_REPO" \
-                 --limit 1 --json tagName -q '.[0].tagName' 2>/dev/null)
+        # Staging = newest prerelease. NOT `--limit 1` unfiltered: the
+        # day easyenclave cuts a `v*` stable tag, that release gets a
+        # later `createdAt` than every existing prerelease, and an
+        # unfiltered newest-first query would collapse staging onto
+        # stable — defeating the whole channel-split. Explicitly keep
+        # only `isPrerelease: true` entries. The first `image-*` tag
+        # cut on main before the v* release always wins.
+        target=$(gh release list --repo "$EE_REPO" --limit 20 \
+                 --json tagName,isPrerelease \
+                 -q '[.[] | select(.isPrerelease)][0].tagName' 2>/dev/null)
         ;;
       *)
         echo "ee-sync: unknown DD_EE_CHANNEL=$channel (want stable|staging)" >&2


### PR DESCRIPTION
## Why

Today neither dd path pins or tracks easyenclave:

| dd path | dd env | EE consumed | Problem |
|---|---|---|---|
| `target=gcp` | **production** | `easyenclave-staging` (hardcoded) | dd prod boots off EE staging — a main-branch EE bug ships into dd prod on the next VM boot |
| `target=gcp` | pr-N preview | `easyenclave-staging` | correct, incidentally |
| `target=ssh` | any env | static qcow2 on tdx2 (mtime weeks old) | **no channel at all** — frozen until an operator SCPs a new file |

Two problems, one fix-shape: make `dd env → EE channel` the invariant on both paths, with an override knob for pre-flight testing a candidate EE before promotion.

## What

### Channel mapping

```
dd env              → EE channel
─────────────────────────────────
production          → stable   (v*)
dd-local-prod       → stable
any other (pr-*)    → staging  (image-{sha12} prereleases)
```

One `Resolve easyenclave channel` step in `deploy-cp.yml` computes `channel` and `family` from `DD_ENV`. The GCP create step stops hardcoding `easyenclave-staging`; the SSH path forwards `channel` + optional `ee_tag` override to both composite actions.

### Auto-sync on tdx2 (SSH path)

New `apps/_infra/ee-sync.sh` with a `sync_base` function shared between `dd-relaunch.sh` and `dd-relaunch-cp.sh`. Before each VM redefine:

1. Resolves the desired EE tag — explicit `DD_EE_TAG` wins, else the latest release matching the channel (stable = newest non-prerelease; staging = newest `isPrerelease:true`).
2. Reads `/var/lib/libvirt/images/easyenclave-local.qcow2.tag` sidecar and short-circuits if up to date.
3. Downloads the matching asset, atomic `mv` into place. Running VMs hold the old inode via open fds, so next boot sees the new base; in-flight VMs are unaffected.

**Staging filter is explicit on `isPrerelease:true`** rather than "newest release" — the day easyenclave cuts its first `v*` tag, a naive newest-first query would pull the stable release into staging and collapse the channel split. Pinning to `isPrerelease` keeps the channels separate forever.

**Soft-fallback** on asset-not-found: if the EE release doesn't yet carry a matching asset (pre-merge of easyenclave#87, or a partial release-staging failure), log + keep the existing base rather than aborting the deploy. An existing base is always preferable to no base.

### Pre-flight override

`ee_tag` workflow_dispatch input in `release.yml` threads through to `DD_EE_TAG` on tdx2. Usage:

```
gh workflow run release.yml \
  -f release_tag=<existing-dd-tag> \
  -f ee_tag=image-<candidate-sha>
```

Downloads that exact EE release regardless of channel for one deploy. Subsequent runs without a pin revert to the channel default.

## Merge order

This PR's asset pattern (`easyenclave-*-local-tdx-qcow2.qcow2`) doesn't exist on any current EE release — it needs [easyenclave#87](https://github.com/easyenclave/easyenclave/pull/87) to merge + one release to cut. Until then, `sync_base`'s soft-fallback keeps the existing (wrong-vendor) gcp qcow2 in place, so this PR is a **no-op on the auto-sync** path until #87 lands.

Safe to land first: the GCP channel fix (prod → `easyenclave-stable`) takes effect immediately regardless of #87.

## tdx2-side setup (one-time, after merge)

- `gh auth login` — already done on tdx2 (confirmed for user `posix4e`).
- Seed the sidecar tag file so the first sync doesn't pointlessly re-download the already-present qcow2:
  ```
  echo "<current-tag>" > /var/lib/libvirt/images/easyenclave-local.qcow2.tag
  ```
  (Or leave empty → first sync downloads whatever the channel resolves to.)

## Test plan

- [ ] `cargo fmt --check && cargo clippy --all-targets -- -D warnings` — clean (no Rust changes; sanity)
- [ ] `bash -n apps/_infra/{ee-sync,dd-relaunch,dd-relaunch-cp}.sh` — syntax
- [ ] YAML parse for all modified workflow/action files
- [ ] Dry-run: `DD_EE_CHANNEL=staging sync_base /tmp/fake.qcow2` resolves a prerelease tag; soft-fallback triggers when asset pattern doesn't match
- [ ] After easyenclave#87 merges + a staging release cuts: push a no-op dd PR → preview deploy log shows `ee-sync: … -> image-<sha> (channel=staging)` and the VM boots without the 30s IMDS stall
- [ ] After an EE `v*` cut: redeploy dd prod → `ee-sync: … -> v1.x.y (channel=stable)`; dd staging/preview keeps tracking the latest `image-*` prerelease (channel split intact)
- [ ] `gh workflow run release.yml -f ee_tag=image-<sha>` pins the next deploy to that exact release

🤖 Generated with [Claude Code](https://claude.com/claude-code)