### PR TITLE
feat(ci): pin production to easyenclave v0.3.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ on:
         required: false
         default: 'latest'
       ee_tag:
-        description: 'Pin the libvirt base qcow2 to a specific easyenclave release (e.g. image-abc123456) for pre-flight testing a candidate EE. Empty = track the env''s channel default (stable for prod, staging otherwise).'
+        description: 'Pin the libvirt base qcow2 to a specific easyenclave release (e.g. v0.3.0 or image-abc123456) for pre-flight testing a candidate EE. Empty = workflow default (production pinned in deploy-production block below; preview tracks the staging channel).'
         required: false
         default: ''
 
@@ -191,5 +191,10 @@ jobs:
       release_tag: ${{ inputs.release_tag || 'latest' }}
       comment_on_pr: false
       ref: main
-      ee_tag: ${{ inputs.ee_tag || '' }}
+      # Production EE base image pin. Bump this (single-line PR) when
+      # we want prod to move to a newer easyenclave release. Static
+      # pinning is the whole point — prod should never silently pick
+      # up whatever EE shipped most recently. Preview still tracks
+      # the staging channel (see deploy-preview block above).
+      ee_tag: ${{ inputs.ee_tag || 'v0.3.0' }}
     secrets: inherit

--- a/apps/_infra/ee-sync.sh
+++ b/apps/_infra/ee-sync.sh
@@ -8,11 +8,12 @@
 #   2. Compares against the sidecar `.tag` file next to the qcow2.
 #   3. Downloads + atomic-renames into place if different.
 #
-# Channel mapping lives in the callers: dd `production` / `dd-local-prod`
-# track EE `stable` (v*); everything else tracks EE `staging` (image-*
-# prereleases on main). An explicit `DD_EE_TAG` overrides the channel
-# default for pre-flight-testing a candidate EE against dd before
-# promoting the prerelease.
+# Channel mapping lives in the callers. Preview (pr-*) envs track EE
+# `staging` (newest image-* prerelease on main) so PRs catch EE
+# regressions early. Production passes an explicit `DD_EE_TAG` pin
+# (set in release.yml's deploy-production block) — it does NOT track
+# a channel, so production's base image only moves when the pin is
+# bumped in a PR. `DD_EE_TAG` always wins over `DD_EE_CHANNEL` below.
 #
 # The sidecar tag file (`<base>.tag`) is the only persistent state
 # besides the qcow2 itself. If it drifts (operator manually SCP'd a


### PR DESCRIPTION
## Summary

Builds on #215. Switches production from "resolve the stable channel at deploy time" to an **explicit pin**: `release.yml`'s `deploy-production` block defaults `ee_tag` to the literal string `v0.3.0`.

- **Why:** the channel resolver runs `gh release list --exclude-pre-releases --limit 1` at deploy time, so two back-to-back prod deploys could boot off different EE bases depending on whatever EE tagged newest. Prod's base image should only move when a human opens a PR to bump the pin.
- **Bumping prod EE** = one-line PR to the literal in `release.yml`'s deploy-production block.
- Preview (`pr-*`) still tracks the `staging` channel. `workflow_dispatch` `ee_tag` still overrides either path.
- Doc follow-through: updated the `ee_tag` dispatch-input description and `ee-sync.sh`'s header docblock — both previously claimed "prod tracks the stable channel", which is no longer true.

## Test plan

- [ ] Merge triggers `deploy-production` → `Relaunch dd-local-prod` logs `ee-sync: ... -> v0.3.0 (channel=stable)` (or "up to date")
- [ ] On tdx2 after: `cat /var/lib/libvirt/images/easyenclave-local.qcow2.tag` prints `v0.3.0`
- [ ] Next PR's preview deploy still logs a `staging` `image-*` tag (channel split intact for preview)

🤖 Generated with [Claude Code](https://claude.com/claude-code)