### PR TITLE
feat(ci): auto-bootstrap easyenclave-local libvirt template on deploy

### DIFF
--- a/apps/_infra/local-cp.sh
+++ b/apps/_infra/local-cp.sh
@@ -153,21 +153,16 @@ with open(p, "w") as f: f.write(x)
 PY
 
   # Wire QEMU's tdx-guest to host's QGS unix socket — same treatment
-  # local-agents.sh does so ITA quotes work inside the CP VM.
+  # local-agents.sh does so ITA quotes work inside the CP VM. Must use
+  # libvirt's schema-valid form: `<quoteGenerationService path='...'/>`
+  # (camelCase, path attribute). The earlier
+  # `<Quote-Generation-Service>vsock:2:4050</Quote-Generation-Service>`
+  # form is not in libvirt's RNG — `virsh define` accepts it but
+  # canonicalizes it away, leaving `<launchSecurity type='tdx'/>` with
+  # no QGS wired → guest can't produce a quote → dd-management's ITA
+  # mint fails with "Quote cannot be empty" → CP poweroffs.
   if grep -q "<launchSecurity type='tdx'/>" "$out"; then
-    # Replace the empty launchSecurity with the full form + object.
-    python3 - "$out" <<'PY'
-import sys
-p = sys.argv[1]
-with open(p) as f: x = f.read()
-x = x.replace(
-    "<launchSecurity type='tdx'/>",
-    """<launchSecurity type='tdx'>
-    <Quote-Generation-Service>vsock:2:4050</Quote-Generation-Service>
-  </launchSecurity>""",
-)
-with open(p, "w") as f: f.write(x)
-PY
+    sed -i "s|<launchSecurity type='tdx'/>|<launchSecurity type='tdx'><quoteGenerationService path='/var/run/tdx-qgs/qgs.socket'/></launchSecurity>|" "$out"
   fi
 
   cat "$out"


### PR DESCRIPTION
## Summary

Makes dd's prod / preview deploy self-healing against a wiped tdx2 libvirt state AND ensures the libvirt base template has a NIC that EE can actually use.

Two changes bundled in the single new `ensure_base_domain` helper (`apps/_infra/ee-sync.sh`), called from both `dd-relaunch.sh` and `dd-relaunch-cp.sh` right after `sync_base`:

1. **Auto-bootstrap:** if the `easyenclave-local` libvirt domain is missing (fresh host, wiped state, operator `virsh undefine` etc.), define it via `virt-install --print-xml | virsh define` — template only, never started. Fixes the original "base libvirt domain 'easyenclave-local' not defined — rebuild the EE image first" failure in `local-cp.sh:51`.

2. **Force virtio NIC + self-correct existing wrong-model templates:** EE's `image/init-templates/vendors/qemu.sh` only modprobes `virtio_net` (and siblings). virt-install's default NIC model is `e1000e`, which EE's minimal kernel doesn't autoload → `/sys/class/net` shows only `lo` → `ee_ifup` is never called → no DHCP → empty resolv.conf → every workload that resolves a hostname (e.g. cloudflared fetching its binary from GitHub's API) fatal-exits → kernel panic when init dies.

    - Verified locally on tdx2: derived VM with `model=e1000e` fails DNS identically on `v0.3.0` AND `image-9af6ce1703ea`. Derived VM with `model=virtio` (same qcow2) gets a DHCP lease, splices resolv.conf into `$NEWROOT/run/resolv.conf` (EE's #88 fix), fetches cloudflared, and the agent socket listens.
    - The function also checks an **existing** base domain for `model=virtio` and undefines + redefines if it finds anything else, so a one-time merge flips an already-defined `e1000e` template to `virtio` without manual operator intervention.

Idempotent in the steady state: second call = no-op.

### Why not reuse easyenclave/image/run-local.sh

Its `destroy_existing` runs `virsh undefine --remove-all-storage`, which would delete the qcow2 `sync_base` just downloaded. It also auto-starts the VM via `virt-install --import`. Neither is what dd wants from a template.

### Local end-to-end validation on tdx2

Base sync'd to `v0.3.0`, derived VM with virtio NIC and a real cloudflared fetch workload:

```
vendor:qemu: udhcpc on eth0
udhcpc: lease of 192.168.122.247 obtained from 192.168.122.1
vendor:qemu: dns from dhcp → /mnt/root/run/resolv.conf
easyenclave: pre-fetching cloudflared-linux-amd64 for cloudflared
easyenclave: fetched /var/lib/easyenclave/bin/cloudflared-linux-amd64
easyenclave: boot workload cloudflared -> a7a30661-...
easyenclave: listening on /var/lib/easyenclave/agent.sock
```

## Test plan

- [ ] Prod deploy on merge: `Relaunch dd-local-prod-cp` step should log the self-correcting path once (`NIC model='e1000e'; undefining to redefine with virtio` then `defining template...`) and subsequent deploys no-op
- [ ] `virsh dumpxml easyenclave-local` on tdx2 after first run shows `<model type='virtio'/>`
- [ ] `virsh net-dhcp-leases default` on tdx2 shows a lease for the running `dd-local-prod-cp`
- [ ] `/health` on app.devopsdefender.com returns 200 and CF Access gates the dashboard
- [ ] Preview deploys still fail until EE cuts a new `image-*` tag containing #88 (the resolv.conf fix) — that's an upstream EE issue, not in this PR's scope; preview is pinned-free by design

🤖 Generated with [Claude Code](https://claude.com/claude-code)