### PR TITLE
chore(ci): bump EE pin v0.3.0 → v0.3.1; unify preview + prod on same pin

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ on:
         required: false
         default: 'latest'
       ee_tag:
-        description: 'Pin the libvirt base qcow2 to a specific easyenclave release (e.g. v0.3.0 or image-abc123456) for pre-flight testing a candidate EE. Empty = workflow default (production pinned in deploy-production block below; preview tracks the staging channel).'
+        description: 'Pin the libvirt base qcow2 to a specific easyenclave release (e.g. v0.3.1 or image-abc123456) for pre-flight testing a candidate EE. Empty = workflow default (prod + preview both pinned to the same v-tag in their with: blocks below).'
         required: false
         default: ''
 
@@ -163,7 +163,13 @@ jobs:
       release_tag: ${{ needs.build.outputs.tag }}
       comment_on_pr: true
       ref: ${{ github.event.pull_request.head.ref }}
-      ee_tag: ${{ inputs.ee_tag || '' }}
+      # Preview used to track the `staging` channel (newest image-*
+      # prerelease on EE main) for early regression signal, but an
+      # unreleasable EE main snapshot blocked every dd PR's CI until
+      # EE shipped a fix. Pin preview to the same tag as prod — one
+      # bump, one PR — so dd development isn't coupled to EE main's
+      # release health. Bump in lockstep with the prod pin below.
+      ee_tag: ${{ inputs.ee_tag || 'v0.3.1' }}
     secrets: inherit
 
   # Production deploy at app.{domain}. Fires on push-to-main OR on a
@@ -196,5 +202,5 @@ jobs:
       # pinning is the whole point — prod should never silently pick
       # up whatever EE shipped most recently. Preview still tracks
       # the staging channel (see deploy-preview block above).
-      ee_tag: ${{ inputs.ee_tag || 'v0.3.0' }}
+      ee_tag: ${{ inputs.ee_tag || 'v0.3.1' }}
     secrets: inherit

--- a/apps/_infra/ee-sync.sh
+++ b/apps/_infra/ee-sync.sh
@@ -8,12 +8,13 @@
 #   2. Compares against the sidecar `.tag` file next to the qcow2.
 #   3. Downloads + atomic-renames into place if different.
 #
-# Channel mapping lives in the callers. Preview (pr-*) envs track EE
-# `staging` (newest image-* prerelease on main) so PRs catch EE
-# regressions early. Production passes an explicit `DD_EE_TAG` pin
-# (set in release.yml's deploy-production block) — it does NOT track
-# a channel, so production's base image only moves when the pin is
-# bumped in a PR. `DD_EE_TAG` always wins over `DD_EE_CHANNEL` below.
+# Both prod and preview pass an explicit `DD_EE_TAG` pin from
+# release.yml's deploy-production / deploy-preview `with:` blocks.
+# Neither env tracks a channel dynamically — the pin only moves when
+# release.yml is updated in a PR. `DD_EE_TAG` always wins over
+# `DD_EE_CHANNEL` below; the channel-resolver fallback is kept only
+# for the workflow_dispatch-with-blank-ee_tag rollback escape-hatch
+# and for the (currently unused) GCP image-family path.
 #
 # The sidecar tag file (`<base>.tag`) is the only persistent state
 # besides the qcow2 itself. If it drifts (operator manually SCP'd a


### PR DESCRIPTION
## Summary

Two changes:

1. **Bump prod `ee_tag` default**: `v0.3.0` → `v0.3.1`. Picks up easyenclave/easyenclave#89's CI cleanup work; bootable qcow2 is identical to v0.3.0 (version-label roll, not a code update).

2. **Pin preview to the same tag as prod**. Removes the `staging`-channel rolling-tracker on preview. The channel model coupled every dd PR's CI to EE main's release health — a single unreleasable EE snapshot was enough to block every dd PR (exactly what happened earlier today with `image-9af6ce1703ea` and the WestUS3 cores-quota blowout). Symmetric pinning: one version, one PR to bump, no upstream surprise.

Doc follow-through: the `ee_tag` dispatch-input description and `apps/_infra/ee-sync.sh` header rewritten so "staging channel" isn't named as a live-path (it's now only reachable via workflow_dispatch with blank `ee_tag` as a rollback escape-hatch, plus the currently-unused GCP image-family lookup).

## Trade-off

Loses the "preview catches EE regressions early before we promote to prod" signal. If we want that back, a better shape than auto-channel is a **manual advance-preview-pin** cadence (one-line tick to validate a new EE tag) — same mechanical cost as the prod bump, zero upstream coupling.

## Test plan

- [ ] Wait for EE `v0.3.1` release: [run 24907978127](https://github.com/easyenclave/easyenclave/actions/runs/24907978127)
- [ ] PR preview CI goes green with `ee_tag=v0.3.1` (logs should show `ee-sync: ... -> v0.3.1 (channel=stable)` — channel label says stable because DD_EE_TAG wins; the channel var is still `staging` but unused)
- [ ] Merge triggers `deploy-production`; on tdx2: `cat /var/lib/libvirt/images/easyenclave-local.qcow2.tag` prints `v0.3.1`
- [ ] `/health` on app.devopsdefender.com returns 200, CF Access gates root
- [ ] Next trivial PR after this merges: preview deploys using v0.3.1 (proves the preview pin is live and not dangling on a workflow-cache)

🤖 Generated with [Claude Code](https://claude.com/claude-code)