### PR TITLE
feat(agent): /owner endpoint + runtime agent_owner for tenant handoff

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -71,6 +71,14 @@ struct St {
     /// without any shared secret; anyone else is denied at claim
     /// check.
     gh: Arc<gh_oidc::Verifier>,
+    /// Runtime tenant-owner set via `POST /owner`. When `Some(org)`,
+    /// `/deploy` / `/exec` / `/logs` accept GitHub OIDC from EITHER
+    /// `DD_OWNER` (fleet ops) OR this tenant org — shared admin. The
+    /// `/owner` endpoint itself is gated on fleet-only auth. Reset
+    /// to `None` on every agent boot (no persistence); the s12e bot
+    /// reapplies via `/owner` if the claim is still active after a
+    /// restart.
+    agent_owner: Arc<RwLock<Option<String>>>,
     /// TDX-quote + Noise-static-pubkey bundle. Served as
     /// `{ noise: { quote_b64, pubkey_hex } }` off `/health` so a
     /// bastion-app can bootstrap a Noise session in one fetch (used
@@ -182,6 +190,7 @@ pub async fn run() -> Result<()> {
         extras: Arc::new(RwLock::new(cfg.extra_ingress.clone())),
         gh,
         attest: attestor,
+        agent_owner: Arc::new(RwLock::new(None)),
     };
 
     let app = Router::new()
@@ -191,6 +200,7 @@ pub async fn run() -> Result<()> {
         .route("/deploy", post(deploy))
         .route("/exec", post(exec))
         .route("/logs/{app}", get(logs))
+        .route("/owner", post(set_owner))
         .fallback(log_unmatched)
         .with_state(state)
         .merge(noise_gateway::router(ng_state))
@@ -635,19 +645,36 @@ async fn workload_page(State(s): State<St>, Path(id): Path<String>) -> Result<Re
     .into_response())
 }
 
-/// Extract + verify a GitHub Actions OIDC bearer token. The /deploy
-/// and /exec endpoints are CF-Access-bypassed; this is the real gate.
-async fn require_gh_oidc(s: &St, headers: &HeaderMap) -> Result<gh_oidc::Claims> {
+/// Extract the `Authorization: Bearer <jwt>` header and return the
+/// trimmed token body. Shared by fleet-only and fleet-or-agent auth
+/// paths so the Bearer-parsing shape stays consistent.
+fn bearer_token(headers: &HeaderMap) -> Result<&str> {
     let auth = headers
         .get(axum::http::header::AUTHORIZATION)
         .and_then(|v| v.to_str().ok())
         .ok_or(Error::Unauthorized)?;
-    let token = auth
-        .strip_prefix("Bearer ")
+    auth.strip_prefix("Bearer ")
         .or_else(|| auth.strip_prefix("bearer "))
         .map(str::trim)
         .filter(|t| !t.is_empty())
-        .ok_or(Error::Unauthorized)?;
+        .ok_or(Error::Unauthorized)
+}
+
+/// Workload-control auth (`/deploy`, `/exec`, `/logs`): accept a
+/// GitHub Actions OIDC token whose `repository_owner` matches
+/// EITHER the fleet owner (`DD_OWNER`) OR the agent's runtime
+/// `agent_owner`. Shared admin — ops and the active tenant both
+/// have deploy/exec/logs authority.
+async fn require_gh_oidc(s: &St, headers: &HeaderMap) -> Result<gh_oidc::Claims> {
+    let token = bearer_token(headers)?;
+    let agent_owner = s.agent_owner.read().await.clone();
+    s.gh.verify_allowing(token, agent_owner.as_deref()).await
+}
+
+/// Fleet-only auth. Used by `/owner`, which re-assigns the tenant:
+/// only ops (`DD_OWNER`) may call it, never the tenant themselves.
+async fn require_fleet_oidc(s: &St, headers: &HeaderMap) -> Result<gh_oidc::Claims> {
+    let token = bearer_token(headers)?;
     s.gh.verify(token).await
 }
 
@@ -789,4 +816,59 @@ async fn exec(
 ) -> Result<Json<serde_json::Value>> {
     let _ = require_gh_oidc(&s, &headers).await?;
     Ok(Json(s.ee.exec(&req.cmd, req.timeout_secs).await?))
+}
+
+#[derive(Debug, Deserialize)]
+struct OwnerReq {
+    /// New tenant org (GitHub user or org login). Empty string clears
+    /// the runtime owner — after which `/deploy`/`/exec`/`/logs`
+    /// accept only the fleet owner again.
+    agent_owner: String,
+    /// Opaque ID from the caller's claim system (e.g. the s12e bot's
+    /// claim issue). Logged for audit; the agent doesn't interpret it.
+    #[serde(default)]
+    claim_id: String,
+}
+
+/// POST /owner — set (or clear) the agent's runtime tenant owner.
+/// Fleet-gated: only `DD_OWNER` can reassign a node. Runtime-only
+/// state: resets to `None` on reboot, so a crash/restart is self-
+/// healing (the bot re-applies if the claim is still active).
+async fn set_owner(
+    State(s): State<St>,
+    headers: HeaderMap,
+    Json(req): Json<OwnerReq>,
+) -> Result<Json<serde_json::Value>> {
+    let claims = require_fleet_oidc(&s, &headers).await?;
+    let new_owner = {
+        let trimmed = req.agent_owner.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        }
+    };
+    let previous = {
+        let mut guard = s.agent_owner.write().await;
+        let prev = guard.clone();
+        *guard = new_owner.clone();
+        prev
+    };
+    eprintln!(
+        "agent: /owner {} -> {} (by sub={}, claim_id={})",
+        previous.as_deref().unwrap_or("<none>"),
+        new_owner.as_deref().unwrap_or("<none>"),
+        claims.sub,
+        if req.claim_id.is_empty() {
+            "<none>"
+        } else {
+            req.claim_id.as_str()
+        },
+    );
+    Ok(Json(serde_json::json!({
+        "agent_id": s.agent_id,
+        "agent_owner": new_owner,
+        "previous_owner": previous,
+        "claim_id": req.claim_id,
+    })))
 }

--- a/src/gh_oidc.rs
+++ b/src/gh_oidc.rs
@@ -72,9 +72,37 @@ impl Verifier {
         })
     }
 
-    /// Verify a JWT, check the signature, issuer, audience, and
-    /// `repository_owner` claim. Returns decoded claims on success.
+    /// Verify a JWT and require `repository_owner == DD_OWNER` (the
+    /// fleet owner). Use this for endpoints only the fleet should
+    /// reach — e.g. `/owner`, which re-assigns an agent to a tenant.
     pub async fn verify(&self, token: &str) -> Result<Claims> {
+        self.verify_allowing(token, None).await
+    }
+
+    /// Verify a JWT and accept the caller if `repository_owner`
+    /// matches EITHER the fleet owner (`DD_OWNER`) OR the passed
+    /// `extra_owner` (typically the agent's runtime `agent_owner`,
+    /// set by the Sats-for-Compute bot via `POST /owner` when a
+    /// claim activates). Use this for workload-control endpoints
+    /// (`/deploy`, `/exec`, `/logs`) that should accept either ops
+    /// or the active tenant.
+    pub async fn verify_allowing(&self, token: &str, extra_owner: Option<&str>) -> Result<Claims> {
+        let claims = self.decode_and_validate(token).await?;
+        let ok = claims.repository_owner == self.owner
+            || extra_owner
+                .filter(|o| !o.is_empty())
+                .is_some_and(|o| o == claims.repository_owner);
+        if !ok {
+            return Err(Error::Unauthorized);
+        }
+        Ok(claims)
+    }
+
+    /// JWT decode + signature/issuer/audience validation, without
+    /// any owner check. Extracted so `verify` and `verify_allowing`
+    /// share identical crypto/claim-parsing behaviour and only
+    /// differ in the final authorization gate.
+    async fn decode_and_validate(&self, token: &str) -> Result<Claims> {
         let header = jsonwebtoken::decode_header(token)
             .map_err(|e| Error::BadRequest(format!("gh oidc header: {e}")))?;
         if !ALLOWED_ALGS.contains(&header.alg) {
@@ -107,7 +135,7 @@ impl Verifier {
             .map_err(|e| Error::BadRequest(format!("gh oidc verify: {e}")))?;
 
         let raw = data.claims;
-        let claims = Claims {
+        Ok(Claims {
             exp: raw.get("exp").and_then(|x| x.as_i64()).unwrap_or(0),
             iat: raw.get("iat").and_then(|x| x.as_i64()).unwrap_or(0),
             iss: raw.get("iss").and_then(|x| x.as_str()).unwrap_or("").into(),
@@ -128,12 +156,7 @@ impl Verifier {
                 .and_then(|x| x.as_str())
                 .unwrap_or("")
                 .into(),
-        };
-
-        if claims.repository_owner != self.owner {
-            return Err(Error::Unauthorized);
-        }
-        Ok(claims)
+        })
     }
 
     async fn lookup(&self, kid: &str) -> Option<DecodingKey> {
@@ -190,5 +213,16 @@ mod tests {
             Error::BadRequest(m) => assert!(m.contains("alg")),
             e => panic!("expected BadRequest, got {e:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn verify_allowing_rejects_bad_alg() {
+        // verify_allowing shares the decode_and_validate path with verify,
+        // so the alg-rejection behaviour should hold regardless of the
+        // extra_owner argument.
+        let token = "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.e30.";
+        let v = Verifier::new("fleet".into(), "dd-agent".into());
+        let err = v.verify_allowing(token, Some("tenant")).await.unwrap_err();
+        assert!(matches!(err, Error::BadRequest(_)));
     }
 }


### PR DESCRIPTION
## Summary

First dd platform piece for Sats for Compute (and any future tenant-assignment system). A node can now accept workload-control traffic from BOTH the fleet owner (ops) AND a runtime-assigned tenant org at the same time.

### What changes

- **New `POST /owner` endpoint** on dd-agent. Fleet-gated — only `DD_OWNER` can call it. Sets a runtime-only `agent_owner: Option<String>` on the agent's state.
- **`/deploy`, `/exec`, `/logs`** now accept GitHub Actions OIDC from EITHER `DD_OWNER` OR the current `agent_owner` (shared admin). Before: only `DD_OWNER`.
- **No persistence.** A reboot clears `agent_owner`; the tenant-assignment bot reapplies `/owner` if the claim is still active. Self-healing across crashes.

Body / response:

```json
POST /owner
{ "agent_owner": "alice", "claim_id": "claim_123" }

200
{ "agent_id": "dd-agent-7", "agent_owner": "alice", "previous_owner": null, "claim_id": "claim_123" }
```

Empty string in `agent_owner` clears the field.

### Why this shape

- **Runtime-only** matches the spec's `v0 Customer Ownership Model` — no reconciliation problem, the bot owns reapplying state.
- **Fleet-OR-agent** means ops retains /deploy authority for support without the bot having to re-grant ops each time. Also means ops can override a misbehaving tenant without waiting for a `/owner` clear.
- **Fleet-only `/owner`** prevents a tenant from reassigning themselves or transferring to someone else.

### Diff shape

- `src/gh_oidc.rs` — split `verify` into `decode_and_validate` (no owner check) + `verify` (fleet-strict, same semantics as before) + new `verify_allowing(token, extra_owner)`. One test added.
- `src/agent.rs` — `agent_owner` field on `St`, rewritten `require_gh_oidc` to use `verify_allowing`, new `require_fleet_oidc`, new `set_owner` handler, new route.

No new env vars; `DD_OWNER` stays the fleet-owner config.

### Test plan

- [x] `cargo fmt` / `cargo clippy -- -D warnings` / `cargo test --workspace` all green locally
- [ ] Preview deploy: confirm `/owner` is reachable, returns 401 without a Bearer token
- [ ] Preview deploy: confirm `/deploy` still works from `DD_OWNER` OIDC when `agent_owner` is unset (regression check)
- [ ] Once merged + deployed to prod: smoke `POST /owner` from `gh workflow run` with a fleet token, confirm `/deploy` from a tenant OIDC then accepts

Follow-up PRs (not this one):
- Expose `agent_owner` + taint-reason set in `/health` JSON so the bot doesn't need to keep its own mirror
- Add `DD_CONFIDENTIAL_MODE` flag gating `/deploy` + `/exec` entirely (required by confidential-mode product)
- Taint-reason enum + `customer_owner_enabled` taint set on `/owner` success

🤖 Generated with [Claude Code](https://claude.com/claude-code)