### PR TITLE
feat(cp): public /about landing — two-modes + taint + sats-for-compute

### DIFF
--- a/src/cf.rs
+++ b/src/cf.rs
@@ -621,6 +621,10 @@ pub async fn provision_cp_access(
 
     for (path_suffix, label) in [
         ("/health", "health"),
+        // `/about` is the public marketing landing — no login required
+        // so anyone clicking the link from external docs sees the
+        // page without bouncing through CF Access first.
+        ("/about", "about"),
         ("/api/agents", "api-agents"),
         ("/api/v1/devices/trusted", "api-devices-trusted"),
         ("/api/v1/admin/export", "api-admin-export"),

--- a/src/cp.rs
+++ b/src/cp.rs
@@ -328,6 +328,7 @@ pub async fn run() -> Result<()> {
 
     let app = Router::new()
         .route("/", get(fleet))
+        .route("/about", get(about))
         .route("/health", get(health))
         .route("/register", post(register))
         .route("/ingress/replace", post(ingress_replace))
@@ -726,6 +727,17 @@ async fn mint_cp_ita(cfg: &Cfg, ee: &Ee) -> Result<String> {
         .ok_or_else(|| Error::Upstream("EE attest returned no quote_b64".into()))?
         .to_string();
     ita::mint(&cfg.ita.base_url, &cfg.ita.api_key, &quote_b64).await
+}
+
+// ── Public landing (CF-Access-bypassed) ───────────────────────────────────
+
+/// `GET /about` — public marketing page describing the deployment
+/// model. CF-Access-bypassed (see `cf::reconcile_cp_apps`). Static
+/// content, no state — the page lives here in the CP because the CP
+/// is the only HTTP frontend with a public hostname today; if/when
+/// an apex landing at devopsdefender.com is set up, this can move.
+async fn about() -> Response {
+    Html(html::about_page()).into_response()
 }
 
 // ── Fleet dashboard ──────────────────────────────────────────────────────

--- a/src/html.rs
+++ b/src/html.rs
@@ -71,3 +71,155 @@ pub fn escape(s: &str) -> String {
         .replace('>', "&gt;")
         .replace('"', "&quot;")
 }
+
+/// Public marketing landing — the FIRST thing a non-operator sees.
+/// CF-Access-bypassed at `/about` so it works without login. Centers
+/// on the new deployment model: two product modes (customer-deploy
+/// vs confidential), the taint trust model, and the forkable
+/// Sats-for-Compute example operator.
+pub fn about_page() -> String {
+    // Standalone shell (different nav and accent vs the operator
+    // dashboard). Inline CSS overrides only what's not already in
+    // CSS so the page reads like marketing rather than ops.
+    let extra_css = r#"
+        body { font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Helvetica, Arial, sans-serif; }
+        main { max-width: 920px; }
+        h1.hero { font-size: 36px; line-height: 1.2; color: #cdd6f4; margin: 32px 0 8px; }
+        .lede { color: #a6adc8; font-size: 18px; max-width: 720px; margin-bottom: 32px; }
+        h2 { color: #89b4fa; font-size: 22px; margin: 32px 0 12px; }
+        p { color: #cdd6f4; font-size: 15px; line-height: 1.6; margin-bottom: 12px; }
+        ul { color: #cdd6f4; font-size: 15px; line-height: 1.7; margin: 0 0 16px 24px; }
+        ul li { margin-bottom: 4px; }
+        .modes { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin: 16px 0 24px; }
+        .mode { background: #181825; border: 1px solid #313244; border-radius: 8px; padding: 20px; }
+        .mode h3 { color: #cba6f7; font-size: 17px; margin-bottom: 8px; }
+        .mode .tag { display: inline-block; background: #cba6f722; color: #cba6f7; font-size: 11px; padding: 2px 8px; border-radius: 4px; margin-bottom: 12px; text-transform: uppercase; letter-spacing: 0.05em; }
+        .mode.confidential h3 { color: #fab387; }
+        .mode.confidential .tag { background: #fab38722; color: #fab387; }
+        table.taint { margin: 12px 0 24px; }
+        table.taint td { vertical-align: top; }
+        table.taint td code { white-space: nowrap; }
+        .footer { color: #585b70; font-size: 13px; margin-top: 48px; padding-top: 16px; border-top: 1px solid #313244; }
+        .footer a { color: #89b4fa; }
+        @media (max-width:640px) { .modes { grid-template-columns: 1fr; } h1.hero { font-size: 28px; } }
+    "#;
+    let body = r##"
+<h1 class="hero">Attested compute, two ways to use it.</h1>
+<p class="lede">
+DevOpsDefender hosts workloads inside Intel TDX confidential VMs. Every node ships an
+Intel-signed quote on <code>/health</code>; you can verify what's running before you trust it.
+Customers get full <code>/deploy</code> authority — or pay for a sealed oracle nobody (not even
+the operator) can change.
+</p>
+
+<h2>Two product modes</h2>
+<div class="modes">
+  <div class="mode">
+    <span class="tag">customer deploy</span>
+    <h3>Bring your own workload</h3>
+    <p>
+      The customer's GitHub OIDC identity is bound to a fresh agent via <code>POST /owner</code>.
+      They get full <code>/deploy</code>, <code>/exec</code>, <code>/logs</code>, and
+      browser-shell (<code>ttyd</code>) authority — the same surface DD ops uses, scoped to their
+      org for the duration of the claim.
+    </p>
+    <p>Right for: general-purpose compute, dev shells, GPU jobs.</p>
+  </div>
+  <div class="mode confidential">
+    <span class="tag">confidential</span>
+    <h3>Sealed oracle</h3>
+    <p>
+      The bot deploys a workload from the customer's public GitHub repo
+      (<code>workload.json</code> at root). The agent boots with
+      <code>DD_CONFIDENTIAL=true</code> — <code>/deploy</code>, <code>/exec</code>, and
+      <code>/owner</code> are <em>not registered</em> on this node. Logs and attestation stay
+      open. The TDX quote measures the boot config, so a third party can verify the workload is
+      sealed, no operator-trust needed.
+    </p>
+    <p>Right for: oracles, bot-oracles, anything where "this is the code, it hasn't changed" is the product.</p>
+  </div>
+</div>
+
+<h2>Trust model</h2>
+<p>
+A node is in one of three states. Taint is a <em>set</em> of reasons, not a boolean — third-party
+verifiers read <code>/health.taint_reasons</code> + the TDX quote and reconstruct the trust
+profile in one fetch.
+</p>
+<table class="taint">
+  <tr>
+    <td><span class="pill healthy">pristine</span></td>
+    <td>Booted from a known image. No customer has had deploy / exec / shell authority.
+        Empty <code>taint_reasons</code> set.</td>
+  </tr>
+  <tr>
+    <td><span class="pill stale">tainted</span></td>
+    <td>Customer-influenced via at least one channel. Reasons surface which:</td>
+  </tr>
+  <tr>
+    <td></td>
+    <td>
+      <ul>
+        <li><code>customer_workload_deployed</code> — a <code>/deploy</code> succeeded since boot</li>
+        <li><code>customer_owner_enabled</code> — <code>/owner</code> set a non-fleet tenant</li>
+        <li><code>arbitrary_exec_enabled</code> — node booted with <code>/deploy</code> + <code>/exec</code> registered (i.e. not confidential mode)</li>
+        <li><code>interactive_shell_enabled</code> — ttyd or equivalent in the running workload</li>
+      </ul>
+    </td>
+  </tr>
+  <tr>
+    <td><span class="pill idle">safe_mode</span></td>
+    <td>On reboot, the agent's runtime owner clears and the node returns to bot/DD control.
+        It may still be tainted; safe_mode is not the same as pristine. A tainted node is
+        rebuilt before reassignment.</td>
+  </tr>
+</table>
+
+<h2>Sats for Compute — the canonical example operator</h2>
+<p>
+Pay BTC, get attested compute. The bot creates a GitHub-issue claim, watches for a 1-conf
+payment via mempool.space, then either hands a fresh agent to the customer's GitHub org
+(customer-deploy mode) or boots a sealed oracle from their public workload repo (confidential
+mode). Code is forkable; anyone can run their own operator with their own substrate.
+</p>
+<ul>
+  <li><a href="https://github.com/satsforcompute/satsforcompute" target="_blank">satsforcompute/satsforcompute</a> — the bot</li>
+  <li><a href="https://github.com/devopsdefender/dd/blob/main/SATS_FOR_COMPUTE_SPEC.md" target="_blank">SATS_FOR_COMPUTE_SPEC.md</a> — the design doc</li>
+</ul>
+
+<h2>Run your own</h2>
+<p>
+DD is a substrate, not a service. Forking an operator means:
+</p>
+<ul>
+  <li>Stand up your own DD fleet (GCP image, libvirt on baremetal, or Azure CVM)</li>
+  <li>Pick a <code>DD_OWNER</code> trust ring (a GH org, a specific repo, an OIDC subject regex)</li>
+  <li>Run a Sats-for-Compute-style bot — or your own — that calls <code>POST /owner</code> via your operator-ops repo's GH Actions OIDC</li>
+</ul>
+<ul>
+  <li><a href="https://github.com/devopsdefender/dd" target="_blank">devopsdefender/dd</a> — the substrate</li>
+  <li><a href="https://github.com/easyenclave/easyenclave" target="_blank">easyenclave/easyenclave</a> — the TDX VM image DD nodes boot from</li>
+</ul>
+
+<div class="footer">
+  Operator dashboard: <a href="/">app.devopsdefender.com</a> (CF-Access gated).<br/>
+  Health + Noise pre-handshake bundle: <a href="/health"><code>/health</code></a> (public).
+</div>
+"##;
+
+    format!(
+        r#"<!DOCTYPE html>
+<html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>DevOpsDefender — attested compute</title>
+<style>{CSS}{extra_css}</style></head>
+<body>
+<nav><span class="brand">DevOpsDefender</span>
+<a href="/about" class="active">About</a>
+<a href="/">Dashboard</a>
+<a href="https://github.com/devopsdefender/dd" target="_blank">GitHub</a>
+<span class="spacer"></span>
+</nav>
+<main>{body}</main>
+</body></html>"#
+    )
+}


### PR DESCRIPTION
## Summary

The CP serves only operator-facing dashboards behind CF Access today; nothing public describes what DevOpsDefender does. This PR adds a marketing landing at `app.devopsdefender.com/about` (CF-Access-bypassed) centered on the new deployment model.

### What's on the page

1. **Two product modes** side-by-side
   - **Customer deploy** — customer's GH OIDC bound via `POST /owner`, full `/deploy`/`/exec`/`/logs`/ttyd authority
   - **Confidential** — bot deploys a sealed workload from a public GH repo, agent boots with `DD_CONFIDENTIAL=true`, no `/deploy`/`/exec`/`/owner` registered, no operator tamper channels
2. **Trust model**: `pristine` / `tainted` / `safe_mode` + the four taint reasons. Frames `/health.taint_reasons` + TDX quote as the way third parties verify trust.
3. **Sats for Compute** — the canonical operator. Pay BTC, get attested compute.
4. **Run your own** — links to dd + easyenclave.

### Wiring

- New `html::about_page()` — standalone shell, different nav (no operator widgets), Catppuccin palette reused.
- New `GET /about` on the CP serving it.
- `/about` added to the CP's path-scoped CF Access bypass list (`src/cf.rs`).

No new state, no new env vars. Idempotent on the next CP reconcile.

## Test plan

- [x] `cargo fmt --check` / `cargo clippy -- -D warnings` / `cargo test --workspace` — 39 tests pass
- [ ] After merge + deploy: `curl -sS https://app.devopsdefender.com/about | head -20` returns HTML, no 302 to CF Access login
- [ ] Visual check in browser at https://app.devopsdefender.com/about — two-mode cards render side-by-side, taint table reads cleanly, links work

## Follow-ups (separate PRs)

- Apex-domain handling: today the page lives at `app.devopsdefender.com/about`. Pointing `devopsdefender.com` (apex) at it via Cloudflare DNS / Pages is a separate change.
- Per-mode example workload links once `node.boot` + `dd.dispatch_owner_update` ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)