### PR TITLE
fix(cp): add /owner to agent CF Access bypass list

### DIFF
--- a/src/cf.rs
+++ b/src/cf.rs
@@ -653,6 +653,7 @@ pub async fn provision_cp_access(
 ///     pre-handshake `{quote_b64, pubkey_hex}` in its response
 ///   - Bypass: `{agent}.{domain}/deploy` — GH-OIDC-gated in code
 ///   - Bypass: `{agent}.{domain}/exec` — GH-OIDC-gated in code
+///   - Bypass: `{agent}.{domain}/owner` — fleet-GH-OIDC-gated in code
 ///   - Bypass: `{agent}.{domain}/logs/*` — GH-OIDC-gated in code
 ///   - Bypass: `{agent}.{domain}/noise/ws` — Noise_IK-gated in code
 ///     against the CP-trusted paired device pubkey set
@@ -684,6 +685,7 @@ pub async fn provision_agent_access(
         ("/health", "health"),
         ("/deploy", "deploy"),
         ("/exec", "exec"),
+        ("/owner", "owner"),
         ("/logs", "logs"),
         // The in-process Noise gateway (merged into the agent's
         // router in agent.rs) lives on the same port + hostname as


### PR DESCRIPTION
## Summary
- PR #219 added `POST /owner` (fleet-OIDC-gated) but didn't register a CF Access bypass app for the path
- Without the bypass, CF Access intercepts /owner before the fleet-OIDC handler runs — workflow_dispatch callers get the HTML sign-in page where they expected JSON, and curl --fail trips on the 302
- Fix mirrors the existing /deploy and /exec entries (both also in-code GH-OIDC-gated with a CF bypass app)
- Affects `set-agent-owner.yml` (PR #226) — without this fix, no way to pin agent_owner from CI

## Test plan
- [x] `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`
- [ ] After merge: re-run `set-agent-owner.yml` against `dd-local-bot` → expect 200 with the agent's response body, not the CF sign-in page

🤖 Generated with [Claude Code](https://claude.com/claude-code)