### PR TITLE
ee-sync: switch released-asset pattern to easyenclave-*-llm-cuda.qcow2

### DIFF
--- a/apps/_infra/ee-sync.sh
+++ b/apps/_infra/ee-sync.sh
@@ -27,7 +27,14 @@
 # caller's pipefail kills the relaunch before anything destructive.
 
 EE_REPO="${EE_REPO:-easyenclave/easyenclave}"
-EE_ASSET_PATTERN="${EE_ASSET_PATTERN:-easyenclave-*-local-tdx-qcow2.qcow2}"
+# Released asset name for the libvirt-backing-file qcow2. easyenclave#95
+# retired the `local-tdx-qcow2` target and made `llm-cuda` the canonical
+# qcow2 with the qemu vendor stage; the artifact is a strict superset
+# (same TDX boot path + dm-verity squashfs root + the vLLM/CUDA bake).
+# Size grows from ~50 MB to ~7 GB — the CUDA + PyTorch + vLLM stack is
+# most of it. The `easyenclave-local.qcow2` *path* on the host stays
+# the same, only the upstream asset we download into it changes.
+EE_ASSET_PATTERN="${EE_ASSET_PATTERN:-easyenclave-*-llm-cuda.qcow2}"
 
 sync_base() {
   local base="${1:?usage: sync_base <path-to-base-qcow2>}"


### PR DESCRIPTION
## Summary
- Flip the EE released-asset pattern in \`apps/_infra/ee-sync.sh\` from \`easyenclave-*-local-tdx-qcow2.qcow2\` to \`easyenclave-*-llm-cuda.qcow2\`.
- Tracks easyenclave/easyenclave#95, which retires the \`local-tdx-qcow2\` target and promotes \`llm-cuda\` as the canonical libvirt-backing-file qcow2 (same TDX boot path + qemu vendor stage + the dm-verity squashfs root + the vLLM/CUDA stack from easyenclave#91).

## What stays the same
- The \`/var/lib/libvirt/images/easyenclave-local.qcow2\` host path — domains keep pointing there. ee-sync just downloads a different upstream asset into that path.
- Sidecar \`.tag\` compare logic — the first sync after this lands sees the channel-pinned tag has the new asset and atomic-renames it in.
- libvirt domain XMLs, agent + cp launcher scripts, GPU passthrough wiring — unchanged.

## What changes operationally
- Backing qcow2 grows from ~50 MB to ~7 GB. CUDA + PyTorch + vLLM dominate the size. Initial sync downloads more; subsequent syncs only refresh on tag change.
- Boot path is unchanged on hosts that don't use the GPU — easyenclave's qemu vendor stage handles the no-passthrough case identically to local-tdx-qcow2.
- Hosts that DO want GPU passthrough (the existing \`dd-local-prod\` H100 wiring) start running NVIDIA driver + CUDA + vLLM inside the verity tree, with the rootfs hash flowing into the kernel cmdline → UKI → RTMR.

## Blocks on
[easyenclave#95](https://github.com/easyenclave/easyenclave/pull/95) — until that merges, the EE staging release still ships \`easyenclave-*-local-tdx-qcow2.qcow2\`. Once easyenclave#95 merges and a staging \`image-*\` release cuts, the next \`ee-sync\` from any of dd's relaunch flows will pull the new asset.

## Staging override (for testing this PR before easyenclave#95 merges)
The pattern is overridable via env. To test against an EE PR build that publishes the new asset early:

\`\`\`bash
export EE_ASSET_PATTERN='easyenclave-*-llm-cuda.qcow2'
export DD_EE_TAG=image-<sha12-of-easyenclave-pr-95-head>
./apps/_infra/dd-relaunch.sh dd-local-preview
\`\`\`

## Test plan
- [ ] After easyenclave#95 merges + a staging release cuts, run \`apps/_infra/dd-relaunch.sh\` for one of \`dd-local-{preview,bot,prod}\` and confirm \`/var/lib/libvirt/images/easyenclave-local.qcow2\` rotates to the llm-cuda asset
- [ ] \`virsh start\` the rotated VM, watch serial: dm-verity opens, easyenclave is PID 1, attestation backend = tdx, agent socket listening
- [ ] On \`dd-local-prod\` (H100): nvidia-bringup workload boots, vLLM serves \`/v1/models\`
- [ ] Confirm the existing TDX-boot smoke (without GPU) still passes on \`dd-local-{preview,bot}\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)