### PR TITLE
fix(ci): use non-secure OVMF for local TDX

### DIFF
--- a/apps/_infra/local-agents.sh
+++ b/apps/_infra/local-agents.sh
@@ -302,6 +302,25 @@ render_domain_xml() {
   sed -i "s|$IMG_DIR/$BASE_DOMAIN.qcow2|$IMG_DIR/dd-local-$name.qcow2|g" "$out"
   sed -i "s|$IMG_DIR/$BASE_DOMAIN-config.iso|$IMG_DIR/dd-local-$name-config.iso|g" "$out"
 
+  # easyenclave init probes the config volume at /dev/vdb or /dev/sdb.
+  # Attach it as a virtio disk instead of inheriting the base template's
+  # SATA CD-ROM shape. The workload disk below remains /dev/vdc.
+  python3 - "$out" "$IMG_DIR/dd-local-$name-config.iso" <<'PY'
+import re, sys
+p, config = sys.argv[1], sys.argv[2]
+with open(p) as f: x = f.read()
+pattern = re.compile(r"\s*<disk\b[^>]*>\s*(?:(?!</disk>).)*?" + re.escape(config) + r".*?</disk>\n?", re.DOTALL)
+replacement = f"""    <disk type='file' device='disk'>
+      <driver name='qemu' type='raw'/>
+      <source file='{config}'/>
+      <target dev='vdb' bus='virtio'/>
+      <readonly/>
+    </disk>
+"""
+x = pattern.sub("\n" + replacement, x, count=1)
+with open(p, "w") as f: f.write(x)
+PY
+
   # Inject the workload disk as /dev/vdc right after the config iso
   # (vdb). podman-bootstrap waits for a `mountpoint` at
   # /data — mount-data satisfies that from

--- a/apps/_infra/local-agents.sh
+++ b/apps/_infra/local-agents.sh
@@ -329,11 +329,25 @@ PY
   sed -i "s|/var/log/ee-local\\.log|/var/log/ee-local-$name.log|g" "$out"
   sed -i "s|<model type='e1000e'/>|<model type='virtio'/>|g" "$out"
 
-  # The local-tdx-qcow2 UKI is intentionally unsigned; this host's
-  # OVMF.tdx.fd rejects it with UEFI "Access Denied". Use the non-secure
-  # TDVF build when present while keeping launchSecurity type=tdx below.
+  # The local-tdx-qcow2 UKI is intentionally unsigned; this host's secure
+  # boot OVMF rejects it with UEFI "Access Denied". Use the non-secure
+  # ROM loader when present and disable firmware auto-selection below.
   if [ -r /usr/share/ovmf/OVMF.fd ]; then
-    sed -i -E "s|<loader([^>]*)>/usr/share/ovmf/OVMF\\.tdx\\.fd</loader>|<loader\\1>/usr/share/ovmf/OVMF.fd</loader>|" "$out"
+    python3 - "$out" <<'PY'
+import re, sys
+p = sys.argv[1]
+with open(p) as f: x = f.read()
+x = re.sub(r"<os\s+firmware=['\"]efi['\"]>", "<os>", x, count=1)
+x = re.sub(r"\n\s*<firmware>.*?</firmware>", "", x, count=1, flags=re.DOTALL)
+x = re.sub(r"\n\s*<nvram[^>]*>.*?</nvram>", "", x, count=1, flags=re.DOTALL)
+x = re.sub(
+    r"<loader[^>]*>.*?</loader>",
+    "<loader readonly='yes' secure='no' type='rom'>/usr/share/ovmf/OVMF.fd</loader>",
+    x,
+    count=1,
+)
+with open(p, "w") as f: f.write(x)
+PY
   fi
 
   # CPU-only agent sizing.

--- a/apps/_infra/local-cp.sh
+++ b/apps/_infra/local-cp.sh
@@ -174,6 +174,25 @@ render_domain_xml() {
   sed -i "s|/var/log/ee-local\\.log|/var/log/ee-local-$NAME.log|g" "$out"
   sed -i "s|<model type='e1000e'/>|<model type='virtio'/>|g" "$out"
 
+  # easyenclave init probes the config volume at /dev/vdb or /dev/sdb.
+  # Attach it as a virtio disk instead of inheriting the base template's
+  # SATA CD-ROM shape.
+  python3 - "$out" "$IMG_DIR/$VM-config.iso" <<'PY'
+import re, sys
+p, config = sys.argv[1], sys.argv[2]
+with open(p) as f: x = f.read()
+pattern = re.compile(r"\s*<disk\b[^>]*>\s*(?:(?!</disk>).)*?" + re.escape(config) + r".*?</disk>\n?", re.DOTALL)
+replacement = f"""    <disk type='file' device='disk'>
+      <driver name='qemu' type='raw'/>
+      <source file='{config}'/>
+      <target dev='vdb' bus='virtio'/>
+      <readonly/>
+    </disk>
+"""
+x = pattern.sub("\n" + replacement, x, count=1)
+with open(p, "w") as f: f.write(x)
+PY
+
   # The local-tdx-qcow2 UKI is intentionally unsigned; this host's secure
   # boot OVMF rejects it with UEFI "Access Denied". Use the non-secure
   # ROM loader when present and disable firmware auto-selection below.

--- a/apps/_infra/local-cp.sh
+++ b/apps/_infra/local-cp.sh
@@ -174,11 +174,25 @@ render_domain_xml() {
   sed -i "s|/var/log/ee-local\\.log|/var/log/ee-local-$NAME.log|g" "$out"
   sed -i "s|<model type='e1000e'/>|<model type='virtio'/>|g" "$out"
 
-  # The local-tdx-qcow2 UKI is intentionally unsigned; this host's
-  # OVMF.tdx.fd rejects it with UEFI "Access Denied". Use the non-secure
-  # TDVF build when present while keeping launchSecurity type=tdx below.
+  # The local-tdx-qcow2 UKI is intentionally unsigned; this host's secure
+  # boot OVMF rejects it with UEFI "Access Denied". Use the non-secure
+  # ROM loader when present and disable firmware auto-selection below.
   if [ -r /usr/share/ovmf/OVMF.fd ]; then
-    sed -i -E "s|<loader([^>]*)>/usr/share/ovmf/OVMF\\.tdx\\.fd</loader>|<loader\\1>/usr/share/ovmf/OVMF.fd</loader>|" "$out"
+    python3 - "$out" <<'PY'
+import re, sys
+p = sys.argv[1]
+with open(p) as f: x = f.read()
+x = re.sub(r"<os\s+firmware=['\"]efi['\"]>", "<os>", x, count=1)
+x = re.sub(r"\n\s*<firmware>.*?</firmware>", "", x, count=1, flags=re.DOTALL)
+x = re.sub(r"\n\s*<nvram[^>]*>.*?</nvram>", "", x, count=1, flags=re.DOTALL)
+x = re.sub(
+    r"<loader[^>]*>.*?</loader>",
+    "<loader readonly='yes' secure='no' type='rom'>/usr/share/ovmf/OVMF.fd</loader>",
+    x,
+    count=1,
+)
+with open(p, "w") as f: f.write(x)
+PY
   fi
 
   # CP sizing.


### PR DESCRIPTION
## Summary

- render local TDX VM XML with non-secure OVMF ROM firmware
- remove libvirt EFI firmware auto-selection metadata and inherited NVRAM from derived local VM XML
- keep SMM disabled so QEMU can start TDX guests

## Local validation

Validated directly on `ns3222044` without pushing through CI:

- `bash -n apps/_infra/local-cp.sh`
- `bash -n apps/_infra/local-agents.sh`
- `git diff --check apps/_infra/local-cp.sh apps/_infra/local-agents.sh`
- created and started throwaway VM `dd-local-ci-test-cp`
- verified generated XML uses `/usr/share/ovmf/OVMF.fd`, `secure='no'`, `type='rom'`, and `<smm state='off'/>`
- destroyed/undefined the throwaway VM and removed its test disk/config files

The existing `dd-local-production-cp` domain remained running during the test.
