### PR TITLE
Rewrite website for crypto technical audience

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,249 +3,251 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>DevOpsDefender &mdash; sealed compute, verifiable from outside</title>
-  <meta name="description" content="Run an oracle whose code can't be changed by the operator. TDX-attested workloads with a public, cryptographic seal you verify yourself.">
+  <title>DevOpsDefender — attested execution for crypto systems</title>
+  <meta name="description" content="Run verifiable crypto oracles, keepers, bots, and confidential agents on Intel TDX. EasyEnclave provides the measured runtime; DevOpsDefender adds fleet routing, attestation, and terminal access controls.">
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
 
-<div class="hex-band" aria-hidden="true">
-  <span>49 6e 74 65 6c 20 54 44 58 20 51 75 6f 74 65 20 76 34 20 4d 52 54 44 20 30 78 7b 7d 7d 20 76 65 72 69 66 69 65 64 20 62 79 20 49 6e 74 65 6c 2d 73 69 67 6e 65 64 20 4a 57 54 20 6f 6e 20 2f 68 65 61 6c 74 68</span>
-</div>
-
 <header>
-  <a href="/" class="brand">
-    <span class="dot">&bull;</span> devopsdefender
-  </a>
+  <a href="/" class="brand"><span class="mark">dd</span> devopsdefender</a>
   <nav>
-    <a href="#seal">the&nbsp;seal</a>
-    <a href="#how">how</a>
     <a href="#verify">verify</a>
-    <a href="#trust">trust</a>
-    <a href="#operators">operators</a>
+    <a href="#runtime">runtime</a>
+    <a href="#workloads">workloads</a>
+    <a href="#shell">shell</a>
+    <a href="#model">model</a>
     <a href="https://github.com/devopsdefender/dd" target="_blank">github</a>
   </nav>
 </header>
 
-<section class="hero">
-  <h1>
-    Code nobody&nbsp;can&nbsp;change.<br>
-    <span class="accent">Verifiable from outside.</span>
-  </h1>
-  <p class="lede">
-    Sealed oracle workloads on Intel TDX hardware. The seal is provable
-    from outside &mdash; you don&apos;t trust the operator, you verify
-    the quote.
-  </p>
-  <div class="cta">
-    <a href="#how" class="btn primary">Ship a verifiable oracle &nbsp;&rarr;</a>
-    <a href="https://github.com/satsforcompute/satsforcompute" class="btn ghost" target="_blank">Pay BTC &amp; go</a>
-  </div>
-  <p class="proof">
-    <span class="muted">last verified attestation:</span>
-    <code>MRTD 0x4a86&hellip;c91d</code> &middot;
-    <span class="ok">Intel-signed</span> &middot;
-    <span class="muted">via</span> <code>/health</code>
-  </p>
-</section>
-
-<section id="seal">
-  <h2>What &ldquo;sealed&rdquo; means.</h2>
-  <p>
-    Intel TDX seals the guest&rsquo;s memory against the host. That part
-    is table stakes: every confidential-compute platform claims it.
-  </p>
-  <p>
-    DD adds a stronger property on top: <strong>sealed against the
-    operator&nbsp;too</strong>. A confidential-mode agent boots with
-    <code>DD_CONFIDENTIAL=true</code>, which means
-    <code>/deploy</code>, <code>/exec</code>, and <code>/owner</code>
-    are not registered as routes. Nobody &mdash; not the customer, not
-    DD ops, not the bot &mdash; has a channel to mutate the running
-    workload post-boot. Logs and attestation stay open. The TDX quote
-    measures the boot config, so the absence of mutation channels is
-    visible from outside.
-  </p>
-
-  <div class="compare">
-    <div class="col bad">
-      <h4>Without confidential mode</h4>
-      <ul>
-        <li><code>POST /deploy</code> &middot; live workload swap</li>
-        <li><code>POST /exec</code> &middot; arbitrary command run</li>
-        <li><code>ttyd</code> shell &middot; interactive access</li>
-        <li><code>POST /owner</code> &middot; reassign tenant</li>
-      </ul>
-      <p class="note">All four channels exist. Trust = trust the operator&rsquo;s policy not to push them.</p>
+<main>
+  <section class="hero">
+    <div class="hero-copy">
+      <p class="eyebrow">Intel TDX · EasyEnclave · GitHub OIDC · Noise</p>
+      <h1>Attested execution for crypto systems that cannot rely on operator trust.</h1>
+      <p class="lede">
+        DevOpsDefender runs protocol oracles, keepers, co-signers, settlement bots,
+        and confidential coding agents inside measured TDX VMs. The public API
+        exposes enough evidence for an external verifier to bind code, config,
+        runtime state, and the agent Noise key before trusting a result.
+      </p>
+      <div class="actions">
+        <a class="btn primary" href="#verify">Read the verification path</a>
+        <a class="btn" href="https://github.com/devopsdefender/dd" target="_blank">Inspect the code</a>
+      </div>
     </div>
-    <div class="col good">
-      <h4>Confidential mode</h4>
-      <ul>
-        <li><code class="strike">POST /deploy</code> &middot; <span class="ok">404</span></li>
-        <li><code class="strike">POST /exec</code> &middot; <span class="ok">404</span></li>
-        <li><code class="strike">ttyd</code> &middot; <span class="ok">not in workload</span></li>
-        <li><code class="strike">POST /owner</code> &middot; <span class="ok">404</span></li>
-      </ul>
-      <p class="note">Zero channels. Trust = verify the TDX quote covers a config disk that omits them.</p>
-    </div>
-  </div>
-</section>
 
-<section id="how">
-  <h2>Three steps to a sealed oracle.</h2>
-  <ol class="steps">
-    <li>
-      <span class="num">01</span>
-      <div>
-        <h3>Publish a <code>workload.json</code></h3>
+    <div class="proof-card" aria-label="Attestation data example">
+      <div class="proof-head">
+        <span>GET /health</span>
+        <span class="ok">verifiable</span>
+      </div>
+      <pre>{
+  "confidential_mode": true,
+  "taint_reasons": [
+    "customer_workload_deployed"
+  ],
+  "noise": {
+    "quote_b64": "tdx_quote...",
+    "pubkey_hex": "8f0b...a91e"
+  },
+  "deployments": ["btc-usd-oracle"]
+}</pre>
+    </div>
+  </section>
+
+  <section id="verify">
+    <div class="section-head">
+      <p class="eyebrow">External verification</p>
+      <h2>Do not trust the operator. Verify the machine.</h2>
+    </div>
+
+    <div class="flow">
+      <div class="node">
+        <span class="num">01</span>
+        <h3>Fetch public evidence</h3>
+        <p><code>/health</code> returns the TDX quote, Noise public key, workload list, mode, and taint reasons.</p>
+      </div>
+      <div class="edge"></div>
+      <div class="node">
+        <span class="num">02</span>
+        <h3>Verify the TDX quote</h3>
+        <p>Intel Trust Authority or an equivalent verifier checks the quote signature and measured boot.</p>
+      </div>
+      <div class="edge"></div>
+      <div class="node">
+        <span class="num">03</span>
+        <h3>Bind the transport</h3>
+        <p>The quote report data commits to the agent Noise key, preventing a clean quote from authenticating another endpoint.</p>
+      </div>
+    </div>
+
+    <pre class="code"><span class="comment"># Evidence is public. No CF Access, no operator session.</span>
+curl -fsSL https://&lt;agent&gt;.devopsdefender.com/health \
+  | jq <span class="str">'{confidential_mode, taint_reasons, noise}'</span>
+
+<span class="comment"># Sealed oracle expectation:</span>
+<span class="comment"># confidential_mode == true</span>
+<span class="comment"># taint_reasons == ["customer_workload_deployed"]</span></pre>
+  </section>
+
+  <section id="runtime">
+    <div class="section-head">
+      <p class="eyebrow">Runtime substrate</p>
+      <h2>EasyEnclave is the small measured base.</h2>
+    </div>
+
+    <div class="grid two">
+      <article>
+        <h3>What EasyEnclave replaces</h3>
         <p>
-          Public GitHub repo, file at root. The bot will fetch it at a
-          specified commit and deploy as-is. No build step inside the
-          enclave; binaries come from your own GitHub release assets
-          via <code>github_release</code> entries. Same shape DD&rsquo;s
-          existing apps already use.
+          EasyEnclave is a Linux distribution replacement for confidential VMs:
+          one Rust PID 1, a small Unix socket API, no systemd, no package
+          manager, and no runtime network stack in the enclave supervisor.
         </p>
-        <pre class="code">{
-  "app_name": "my-oracle",
-  "github_release": { "repo": "alice/my-oracle", "asset": "my-oracle" },
-  "cmd": ["/var/lib/easyenclave/bin/my-oracle"],
+      </article>
+      <article>
+        <h3>What DD adds</h3>
+        <p>
+          DevOpsDefender layers fleet registration, Cloudflare tunnel routing,
+          GitHub OIDC authorization, Intel attestation refresh, workload logs,
+          and shell access controls on top of that measured base.
+        </p>
+      </article>
+    </div>
+
+    <div class="stack">
+      <div><span>protocol client</span><strong>verifies quote + Noise key</strong></div>
+      <div><span>DD agent</span><strong>routes, reports health, enforces auth</strong></div>
+      <div><span>EasyEnclave</span><strong>measured PID 1 + workload supervisor</strong></div>
+      <div><span>Intel TDX</span><strong>memory isolation + signed quote</strong></div>
+    </div>
+  </section>
+
+  <section id="workloads">
+    <div class="section-head">
+      <p class="eyebrow">Workload model</p>
+      <h2>Release assets in. Attested behavior out.</h2>
+    </div>
+
+    <p>
+      Workloads are JSON specs, not mutable servers. A crypto oracle can be
+      pinned to a GitHub release asset and a commit-level workload spec, then
+      deployed into confidential mode where mutation routes are absent.
+    </p>
+
+    <pre class="code">{
+  "app_name": "btc-usd-oracle",
+  "github_release": {
+    "repo": "example/proof-oracle",
+    "asset": "oracle-linux-amd64",
+    "rename": "oracle"
+  },
+  "cmd": ["/var/lib/easyenclave/bin/oracle"],
   "expose": { "hostname_label": "oracle", "port": 8080 }
 }</pre>
-      </div>
-    </li>
-    <li>
-      <span class="num">02</span>
+
+    <div class="grid three">
+      <article>
+        <h3>Oracles</h3>
+        <p>Publish signed prices, reserves, attestations, or proof status from code whose deployment state is externally checkable.</p>
+      </article>
+      <article>
+        <h3>Keepers</h3>
+        <p>Run liquidation, settlement, rebalance, or bridge-monitoring jobs with public health and operator-taint evidence.</p>
+      </article>
+      <article>
+        <h3>Confidential agents</h3>
+        <p>Run Codex, Claude, or custom bots with encrypted terminal history and reconnectable sessions when read-write access is intended.</p>
+      </article>
+    </div>
+  </section>
+
+  <section id="shell">
+    <div class="section-head">
+      <p class="eyebrow">Operational access</p>
+      <h2>Terminal access is capability-scoped.</h2>
+    </div>
+
+    <div class="compare">
       <div>
-        <h3>Pay or run your own operator</h3>
+        <h3>Read-only workload terminals</h3>
         <p>
-          Pay BTC at the canonical operator
-          (<a href="https://github.com/satsforcompute/satsforcompute" target="_blank">satsforcompute</a>),
-          or fork the example operator and run your own bot against your
-          own DD fleet. Either way, the bot creates a GitHub-issue
-          claim, watches mempool.space for payment, then deploys the
-          workload onto a fresh agent in confidential mode.
+          Oracle observers can view workload logs through the xterm interface
+          without stdin, resize, close, or signal controls. This is for
+          protocols where visibility is useful and interference is not.
         </p>
       </div>
-    </li>
-    <li>
-      <span class="num">03</span>
       <div>
-        <h3>Verify the seal yourself</h3>
+        <h3>Read-write PTY sessions</h3>
         <p>
-          Pull the agent&rsquo;s <code>/health</code> JSON. Check the
-          TDX quote was Intel-signed. Confirm
-          <code>taint_reasons</code> contains exactly
-          <code>["customer_workload_deployed"]</code> &mdash; no exec,
-          no shell, no owner-set. The absence of those channels is the
-          proof, and it&rsquo;s cryptographic.
+          Operator shells and confidential coding agents get real PTYs,
+          reconnectable sessions, encrypted transcript history, and
+          WezTerm-style notification escape support.
         </p>
       </div>
-    </li>
-  </ol>
-</section>
-
-<section id="verify">
-  <h2>Verifying the seal.</h2>
-  <p>
-    There&rsquo;s no &ldquo;DD trust me&rdquo; step. Three commands
-    against any agent&rsquo;s public hostname:
-  </p>
-  <pre class="code"><span class="comment"># 1. Fetch the TDX quote (Noise pre-handshake bundle on /health).</span>
-curl -fsSL https://&lt;agent&gt;.devopsdefender.com/health \
-  | jq <span class="str">'.noise.quote_b64, .noise.pubkey_hex'</span>
-
-<span class="comment"># 2. Verify the quote with Intel Trust Authority (or any TDX verifier).</span>
-<span class="comment">#    The quote's report_data binds the agent's Noise pubkey,</span>
-<span class="comment">#    and the MRTD is the measured boot.</span>
-
-<span class="comment"># 3. Confirm the running workload is sealed.</span>
-curl -fsSL https://&lt;agent&gt;.devopsdefender.com/health \
-  | jq <span class="str">'{ confidential_mode, taint_reasons }'</span>
-
-<span class="comment"># Expected for a sealed oracle:</span>
-<span class="comment">#   { "confidential_mode": true,</span>
-<span class="comment">#     "taint_reasons": ["customer_workload_deployed"] }</span></pre>
-  <p class="footnote">
-    The <code>/health</code> endpoint is CF-Access-bypassed and
-    public. Anyone can verify any agent at any time without operator
-    cooperation.
-  </p>
-</section>
-
-<section id="trust">
-  <h2>Trust state machine.</h2>
-  <p>
-    Taint is a <em>set</em> of reasons, not a boolean. Each reason
-    points to a concrete mechanism that gave somebody influence over
-    the node. A sealed oracle&rsquo;s set is small and known.
-  </p>
-  <table class="trust">
-    <tr>
-      <td><span class="state pristine">pristine</span></td>
-      <td>Booted from a known image. <code>taint_reasons = []</code>. No customer has had any authority since boot.</td>
-    </tr>
-    <tr>
-      <td><span class="state tainted">tainted</span></td>
-      <td>One or more reasons in the set:</td>
-    </tr>
-    <tr><td></td><td><code>customer_workload_deployed</code> &middot; a <code>/deploy</code> succeeded since boot</td></tr>
-    <tr><td></td><td><code>customer_owner_enabled</code> &middot; <code>/owner</code> set a non-fleet tenant</td></tr>
-    <tr><td></td><td><code>arbitrary_exec_enabled</code> &middot; node booted with <code>/deploy</code> + <code>/exec</code> registered</td></tr>
-    <tr><td></td><td><code>interactive_shell_enabled</code> &middot; <code>ttyd</code> or equivalent in the running workload</td></tr>
-    <tr>
-      <td><span class="state safe">safe_mode</span></td>
-      <td>On reboot, the runtime owner clears and the node returns to bot/DD control. May still be tainted &mdash; tainted nodes are rebuilt before reassignment.</td>
-    </tr>
-  </table>
-  <p class="callout">
-    A sealed oracle ships with exactly <code>{customer_workload_deployed}</code>
-    in the set. The absence of <code>arbitrary_exec_enabled</code>
-    and <code>interactive_shell_enabled</code> is the cryptographic
-    signal that the operator has no tamper channel.
-  </p>
-</section>
-
-<section id="operators">
-  <h2>Two paths to attested compute.</h2>
-  <div class="paths">
-    <div class="path">
-      <span class="path-label">path 1</span>
-      <h3>Sats for Compute</h3>
-      <p>The canonical operator. Pay BTC, get a fresh attested node bound to your GitHub identity &mdash; or a sealed oracle from your public workload repo. State lives in GitHub issues. Forkable.</p>
-      <a href="https://github.com/satsforcompute/satsforcompute" target="_blank">github &rarr;</a>
     </div>
-    <div class="path">
-      <span class="path-label">path 2</span>
-      <h3>Run your own</h3>
-      <p>Stand up a DD fleet. Pick your own <code>DD_OWNER</code> trust ring. Run a Sats-for-Compute-style bot &mdash; or your own &mdash; that calls <code>POST /owner</code> via <em>your</em> operator-ops repo&rsquo;s GitHub Actions OIDC. MIT.</p>
-      <a href="https://github.com/devopsdefender/dd" target="_blank">github &rarr;</a>
-    </div>
-  </div>
-</section>
 
-<section class="cta-section">
-  <h2>Ship a verifiable oracle.</h2>
-  <p>The substrate is open source. The seal is cryptographic. The proof is one <code>curl</code> away.</p>
-  <div class="cta">
-    <a href="https://github.com/satsforcompute/satsforcompute" class="btn primary" target="_blank">Pay BTC &amp; go &nbsp;&rarr;</a>
-    <a href="https://github.com/devopsdefender/dd/blob/main/SATS_FOR_COMPUTE_SPEC.md" class="btn ghost" target="_blank">Read the spec</a>
-  </div>
-</section>
+    <pre class="code"><span class="comment"># Long-running agent can notify the browser or mobile web shell.</span>
+printf <span class="str">'\033]777;notify;%s;%s\033\\'</span> \
+  <span class="str">'keeper'</span> <span class="str">'settlement window open'</span></pre>
+  </section>
+
+  <section id="model">
+    <div class="section-head">
+      <p class="eyebrow">Trust model</p>
+      <h2>Taint is explicit state, not vibes.</h2>
+    </div>
+
+    <table>
+      <tr>
+        <th>State</th>
+        <th>Verifier meaning</th>
+      </tr>
+      <tr>
+        <td><code>[]</code></td>
+        <td>Pristine boot. No customer deploy, owner reassignment, arbitrary exec, or shell access has occurred.</td>
+      </tr>
+      <tr>
+        <td><code>customer_workload_deployed</code></td>
+        <td>Expected sealed-oracle state after the workload is installed. Mutation routes should still be absent.</td>
+      </tr>
+      <tr>
+        <td><code>arbitrary_exec_enabled</code></td>
+        <td>The node booted with deploy/exec surfaces available. Useful for operators, not a sealed oracle.</td>
+      </tr>
+      <tr>
+        <td><code>interactive_shell_enabled</code></td>
+        <td>Read-write shell access is enabled. Treat as operator-interactive infrastructure.</td>
+      </tr>
+    </table>
+
+    <div class="callout">
+      <strong>Non-goal:</strong> DD does not make a dishonest oracle algorithm
+      honest. It makes the running code, configuration, transport key, and
+      operator access state inspectable enough that a protocol can decide
+      whether to consume the result.
+    </div>
+  </section>
+
+  <section class="final">
+    <h2>Build crypto infrastructure that can explain itself to verifiers.</h2>
+    <p>
+      The source is open, the runtime is measured, and the public health surface
+      is designed for machines, not screenshots.
+    </p>
+    <div class="actions">
+      <a class="btn primary" href="https://github.com/devopsdefender/dd" target="_blank">Open the repository</a>
+      <a class="btn" href="https://github.com/easyenclave/easyenclave" target="_blank">EasyEnclave</a>
+      <a class="btn" href="https://github.com/satsforcompute/satsforcompute" target="_blank">Sats for Compute</a>
+    </div>
+  </section>
+</main>
 
 <footer>
-  <div class="hex-band footer-band" aria-hidden="true">
-    <span>74 64 78 2d 71 75 6f 74 65 2d 76 65 72 69 66 69 65 64 20 7c 20 6d 72 74 64 2d 6d 65 61 73 75 72 65 64 20 7c 20 73 65 61 6c 65 64 2d 61 67 61 69 6e 73 74 2d 6f 70 65 72 61 74 6f 72</span>
-  </div>
-  <div class="foot-row">
-    <span class="brand"><span class="dot">&bull;</span> devopsdefender</span>
-    <span class="links">
-      <a href="https://github.com/devopsdefender/dd" target="_blank">dd</a>
-      <a href="https://github.com/easyenclave/easyenclave" target="_blank">easyenclave</a>
-      <a href="https://github.com/satsforcompute/satsforcompute" target="_blank">satsforcompute</a>
-      <a href="https://app.devopsdefender.com" target="_blank">dashboard</a>
-    </span>
-    <span class="muted">MIT &middot; built on Intel TDX</span>
-  </div>
+  <span>devopsdefender</span>
+  <span>MIT · Intel TDX · EasyEnclave</span>
 </footer>
 
 </body>

--- a/style.css
+++ b/style.css
@@ -1,375 +1,143 @@
-/*
- * devopsdefender.com — sealed compute, verifiable from outside
- *
- * Design: monochrome cryptographic. Near-black background, off-white
- * foreground, single mint-green accent ("verified"). Monospace
- * everywhere; the typography IS the visual identity. No icons, no
- * gradients, no shadows beyond a subtle hairline rule. Structure
- * comes from the typography hierarchy + a hex-band motif evoking
- * raw quote bytes.
- */
-
 :root {
-  --bg:        #08080d;       /* near-black, distinct from the operator-dashboard #1e1e2e */
-  --bg-rise:  #0d0d14;       /* one notch lighter, used for code blocks + cards */
-  --fg:        #e8e8ec;
-  --fg-dim:   #8a8a9c;
-  --fg-mute:  #50505e;
-  --line:      rgba(255, 255, 255, 0.07);
-  --line-strong: rgba(255, 255, 255, 0.14);
-  --accent:   #00d68f;        /* mint green: the single "verified" hue */
-  --accent-soft: rgba(0, 214, 143, 0.10);
-  --warn:     #f4a361;        /* peach: tainted state */
-  --bad:      #ef6c75;        /* coral: stricken-through items */
-  --mono:     "JetBrains Mono", "SF Mono", ui-monospace, "Cascadia Mono", "Fira Code", monospace;
+  color-scheme: dark;
+  --bg: #08090d;
+  --panel: #11131a;
+  --text: #eceff4;
+  --muted: #a1a8b6;
+  --line: #2a2f3a;
+  --accent: #67e8b9;
+  --warn: #f7c56b;
+  --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  --sans: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
 
-* { box-sizing: border-box; margin: 0; padding: 0; }
+* { box-sizing: border-box; }
 html { scroll-behavior: smooth; }
 body {
+  margin: 0;
   background: var(--bg);
-  color: var(--fg);
-  font-family: var(--mono);
-  font-size: 15px;
-  line-height: 1.7;
-  font-feature-settings: "calt" 1, "ss01" 1;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
-
-a { color: var(--accent); text-decoration: none; border-bottom: 1px dotted var(--accent-soft); }
-a:hover { border-bottom-color: var(--accent); }
-
-code {
-  font-family: var(--mono);
-  font-size: 0.9em;
-  background: var(--bg-rise);
-  border: 1px solid var(--line);
-  padding: 1px 6px;
-  border-radius: 3px;
-  color: var(--fg);
-}
-code.strike { text-decoration: line-through; color: var(--bad); }
-
-em { font-style: italic; color: var(--fg); }
-strong { color: var(--accent); font-weight: 600; }
-
-.muted { color: var(--fg-mute); }
-.ok    { color: var(--accent); }
-
-/* ─────────── hex-band motif ─────────── */
-
-.hex-band {
-  font-size: 11px;
-  color: var(--fg-mute);
-  letter-spacing: 0.04em;
-  white-space: nowrap;
-  overflow: hidden;
-  border-bottom: 1px solid var(--line);
-  padding: 6px 24px;
-  user-select: none;
-}
-.hex-band.footer-band { border-bottom: none; border-top: 1px solid var(--line); margin-top: 64px; }
-.hex-band span { display: inline-block; opacity: 0.55; }
-
-/* ─────────── header / nav ─────────── */
-
-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 22px 32px;
-  border-bottom: 1px solid var(--line);
-  position: sticky;
-  top: 0;
-  background: rgba(8, 8, 13, 0.92);
-  backdrop-filter: blur(8px);
-  z-index: 10;
-}
-.brand {
-  font-weight: 600;
-  color: var(--fg);
-  border-bottom: none;
-  font-size: 14px;
-  letter-spacing: -0.01em;
-}
-.brand .dot { color: var(--accent); margin-right: 4px; }
-nav { display: flex; gap: 26px; }
-nav a {
-  color: var(--fg-dim);
-  font-size: 13px;
-  border-bottom: none;
-}
-nav a:hover { color: var(--fg); }
-
-/* ─────────── shared section frame ─────────── */
-
-section {
-  max-width: 800px;
-  margin: 0 auto;
-  padding: 96px 32px;
-  border-bottom: 1px solid var(--line);
-}
-section:last-of-type { border-bottom: none; }
-
-h1, h2, h3, h4 { color: var(--fg); font-weight: 600; letter-spacing: -0.015em; }
-h2 {
-  font-size: 22px;
-  margin-bottom: 28px;
-  padding-bottom: 8px;
-  border-bottom: 1px solid var(--line);
-  letter-spacing: -0.01em;
-}
-h3 { font-size: 16px; margin-bottom: 10px; color: var(--fg); }
-h4 { font-size: 13px; color: var(--fg-dim); text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: 14px; }
-
-p { margin-bottom: 16px; }
-ul { margin: 0 0 16px 0; padding-left: 0; list-style: none; }
-ul li {
-  position: relative;
-  padding-left: 18px;
-  margin-bottom: 6px;
-  color: var(--fg);
-}
-ul li::before {
-  content: "→";
-  position: absolute;
-  left: 0;
-  color: var(--fg-mute);
-  font-size: 13px;
-}
-
-pre.code {
-  background: var(--bg-rise);
-  border: 1px solid var(--line);
-  border-radius: 6px;
-  padding: 18px 20px;
-  overflow-x: auto;
-  font-size: 13px;
-  line-height: 1.65;
-  margin: 18px 0;
-  color: var(--fg);
-}
-pre.code .comment { color: var(--fg-mute); font-style: italic; }
-pre.code .str { color: var(--accent); }
-
-/* ─────────── hero ─────────── */
-
-.hero {
-  max-width: 800px;
-  margin: 0 auto;
-  padding: 120px 32px 96px;
-  border-bottom: 1px solid var(--line);
-}
-.hero h1 {
-  font-size: clamp(34px, 5vw, 52px);
-  line-height: 1.08;
-  letter-spacing: -0.025em;
-  margin-bottom: 24px;
-  font-weight: 600;
-}
-.hero h1 .accent { color: var(--accent); }
-.hero .lede {
-  font-size: 18px;
-  color: var(--fg-dim);
-  max-width: 620px;
-  margin-bottom: 36px;
-  line-height: 1.55;
-}
-.cta { display: flex; gap: 12px; flex-wrap: wrap; margin-bottom: 36px; }
-.btn {
-  display: inline-flex;
-  align-items: center;
-  padding: 11px 20px;
-  border-radius: 4px;
-  font-size: 13px;
-  font-weight: 600;
-  font-family: var(--mono);
-  border: 1px solid var(--line-strong);
-  color: var(--fg);
-  background: transparent;
-  cursor: pointer;
-  letter-spacing: 0.01em;
-  transition: border-color 0.15s, color 0.15s, background 0.15s;
-}
-.btn:hover { border-color: var(--accent); color: var(--accent); }
-.btn.primary { background: var(--accent); color: var(--bg); border-color: var(--accent); }
-.btn.primary:hover { background: transparent; color: var(--accent); }
-.btn.ghost { color: var(--fg-dim); }
-
-.proof {
-  font-size: 12px;
-  color: var(--fg-mute);
-  border-left: 2px solid var(--accent-soft);
-  padding-left: 14px;
-  margin-top: 24px;
-  font-family: var(--mono);
-}
-.proof code { background: transparent; border: none; padding: 0; color: var(--accent); }
-
-/* ─────────── compare (without vs with confidential) ─────────── */
-
-.compare {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 14px;
-  margin-top: 28px;
-}
-.compare .col {
-  background: var(--bg-rise);
-  border: 1px solid var(--line);
-  border-radius: 6px;
-  padding: 22px;
-}
-.compare .col.bad { border-left: 2px solid var(--bad); }
-.compare .col.good { border-left: 2px solid var(--accent); }
-.compare .col ul li { font-size: 13px; padding-left: 0; }
-.compare .col ul li::before { content: ""; }
-.compare .col ul { padding-left: 0; }
-.compare .note { font-size: 12px; color: var(--fg-mute); margin-top: 12px; margin-bottom: 0; }
-
-/* ─────────── how (numbered steps) ─────────── */
-
-.steps { list-style: none; padding-left: 0; }
-.steps > li {
-  display: grid;
-  grid-template-columns: auto 1fr;
-  gap: 24px;
-  padding: 28px 0;
-  border-top: 1px solid var(--line);
-  align-items: flex-start;
-}
-.steps > li::before { content: ""; }       /* override the "→" bullet */
-.steps > li:first-child { border-top: none; padding-top: 8px; }
-.steps .num {
-  font-family: var(--mono);
-  font-size: 13px;
-  color: var(--fg-mute);
-  letter-spacing: 0.05em;
-  padding-top: 4px;
-  font-feature-settings: "tnum" 1;
-}
-.steps h3 { margin-bottom: 8px; }
-.steps p { margin-bottom: 12px; color: var(--fg-dim); }
-.steps pre.code { font-size: 12px; }
-
-/* ─────────── verify ─────────── */
-
-.footnote {
-  font-size: 13px;
-  color: var(--fg-mute);
-  border-left: 2px solid var(--line-strong);
-  padding-left: 14px;
-  margin-top: 18px;
-}
-
-/* ─────────── trust state machine ─────────── */
-
-table.trust {
-  width: 100%;
-  border-collapse: collapse;
-  margin: 24px 0 18px;
-  font-size: 14px;
-}
-table.trust td {
-  padding: 12px 14px;
-  vertical-align: top;
-  border-bottom: 1px solid var(--line);
-  color: var(--fg);
+  color: var(--text);
+  font-family: var(--sans);
   line-height: 1.6;
 }
-table.trust td:first-child { width: 140px; white-space: nowrap; }
-.state {
-  display: inline-block;
-  padding: 3px 9px;
-  border-radius: 3px;
-  font-size: 11px;
-  font-weight: 600;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  font-family: var(--mono);
-}
-.state.pristine { background: var(--accent-soft); color: var(--accent); border: 1px solid var(--accent-soft); }
-.state.tainted  { background: rgba(244, 163, 97, 0.10); color: var(--warn); border: 1px solid rgba(244, 163, 97, 0.18); }
-.state.safe     { background: var(--line); color: var(--fg-dim); border: 1px solid var(--line-strong); }
 
-.callout {
-  margin-top: 18px;
-  padding: 16px 18px;
-  background: var(--accent-soft);
-  border-left: 2px solid var(--accent);
-  border-radius: 0 4px 4px 0;
-  font-size: 14px;
-  color: var(--fg);
+a { color: var(--accent); text-decoration: none; }
+a:hover { text-decoration: underline; }
+code, pre { font-family: var(--mono); }
+code {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  padding: 0 0.3rem;
 }
 
-/* ─────────── operators (two paths) ─────────── */
+header, footer {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 1.25rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: center;
+}
+header {
+  position: sticky;
+  top: 0;
+  background: rgba(8, 9, 13, 0.94);
+  border-bottom: 1px solid var(--line);
+}
+nav { display: flex; flex-wrap: wrap; gap: 1rem; font-size: 0.9rem; }
+.brand { color: var(--text); font-weight: 700; }
+.mark {
+  color: var(--bg);
+  background: var(--accent);
+  border-radius: 4px;
+  padding: 0.1rem 0.35rem;
+  margin-right: 0.4rem;
+}
 
-.paths {
+main { max-width: 1100px; margin: 0 auto; padding: 0 1.25rem; }
+section { padding: 4.5rem 0; border-bottom: 1px solid var(--line); }
+h1, h2, h3 { line-height: 1.15; margin: 0 0 1rem; }
+h1 { font-size: clamp(2.3rem, 6vw, 5.2rem); max-width: 900px; }
+h2 { font-size: clamp(1.8rem, 4vw, 3rem); }
+h3 { font-size: 1.15rem; }
+p { margin: 0 0 1rem; color: var(--muted); max-width: 760px; }
+.eyebrow { color: var(--accent); font-family: var(--mono); font-size: 0.85rem; }
+.lede { font-size: 1.2rem; }
+.ok { color: var(--accent); }
+
+.hero {
   display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 14px;
-  margin-top: 24px;
+  grid-template-columns: minmax(0, 1.3fr) minmax(320px, 0.7fr);
+  gap: 2rem;
+  align-items: center;
+  min-height: 78vh;
 }
-.path {
-  background: var(--bg-rise);
+.actions { display: flex; flex-wrap: wrap; gap: 0.75rem; margin-top: 1.5rem; }
+.btn {
   border: 1px solid var(--line);
   border-radius: 6px;
-  padding: 24px;
+  padding: 0.75rem 1rem;
+  color: var(--text);
 }
-.path-label {
-  font-size: 11px;
-  color: var(--fg-mute);
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-  font-family: var(--mono);
-  display: block;
-  margin-bottom: 14px;
+.btn.primary { background: var(--accent); color: #04110c; border-color: var(--accent); font-weight: 700; }
+
+.proof-card, article, .node, .compare > div, .callout {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 1.25rem;
 }
-.path h3 { font-size: 17px; margin-bottom: 10px; }
-.path p { color: var(--fg-dim); font-size: 14px; margin-bottom: 14px; }
-.path > a { font-size: 13px; }
+.proof-head { display: flex; justify-content: space-between; margin-bottom: 0.75rem; font-family: var(--mono); font-size: 0.85rem; }
+pre {
+  overflow-x: auto;
+  margin: 1rem 0 0;
+  background: #06070a;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 1rem;
+  color: var(--text);
+}
+.comment { color: #7d8594; }
+.str { color: var(--accent); }
 
-/* ─────────── final CTA ─────────── */
+.section-head { margin-bottom: 1.5rem; }
+.grid { display: grid; gap: 1rem; margin-top: 1.5rem; }
+.grid.two, .compare { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.grid.three { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+.flow {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr auto 1fr;
+  gap: 1rem;
+  align-items: stretch;
+  margin-bottom: 1.5rem;
+}
+.edge { width: 2rem; border-top: 1px solid var(--accent); align-self: center; }
+.num { color: var(--accent); font-family: var(--mono); font-size: 0.8rem; }
 
-.cta-section { text-align: left; }
-.cta-section h2 { border-bottom: none; padding-bottom: 0; margin-bottom: 12px; font-size: 26px; letter-spacing: -0.02em; }
-.cta-section p { color: var(--fg-dim); margin-bottom: 24px; }
-
-/* ─────────── footer ─────────── */
-
-footer { padding-bottom: 24px; }
-.foot-row {
-  max-width: 800px;
-  margin: 0 auto;
-  padding: 18px 32px 0;
+.stack { margin-top: 1.5rem; border: 1px solid var(--line); border-radius: 8px; overflow: hidden; }
+.stack div {
   display: flex;
-  align-items: center;
   justify-content: space-between;
-  flex-wrap: wrap;
-  gap: 16px;
-  font-size: 12px;
-  color: var(--fg-mute);
+  gap: 1rem;
+  padding: 1rem;
+  border-bottom: 1px solid var(--line);
 }
-.foot-row .brand { font-size: 12px; color: var(--fg-dim); }
-.foot-row .links { display: flex; gap: 18px; }
-.foot-row .links a {
-  color: var(--fg-mute);
-  border-bottom: none;
-  font-size: 12px;
-}
-.foot-row .links a:hover { color: var(--accent); }
+.stack div:last-child { border-bottom: 0; }
+.stack span { color: var(--muted); font-family: var(--mono); }
 
-/* ─────────── responsive ─────────── */
+table { width: 100%; border-collapse: collapse; margin-top: 1rem; }
+th, td { text-align: left; border-bottom: 1px solid var(--line); padding: 0.85rem; vertical-align: top; }
+th { color: var(--accent); font-family: var(--mono); }
+.callout { margin-top: 1.5rem; color: var(--muted); }
+.final { border-bottom: 0; }
+footer { color: var(--muted); font-size: 0.9rem; border-top: 1px solid var(--line); }
 
-@media (max-width: 640px) {
-  header { padding: 16px 20px; flex-wrap: wrap; gap: 14px; }
-  nav { gap: 16px; flex-wrap: wrap; }
-  nav a { font-size: 12px; }
-  section, .hero { padding: 72px 20px; }
-  .compare, .paths { grid-template-columns: 1fr; }
-  .steps > li { grid-template-columns: 1fr; gap: 8px; }
-  .steps .num { padding-top: 0; }
-  table.trust td:first-child { width: auto; }
-  .foot-row { padding: 18px 20px 0; flex-direction: column; align-items: flex-start; }
+@media (max-width: 800px) {
+  header, footer { align-items: flex-start; flex-direction: column; }
+  .hero, .grid.two, .grid.three, .compare, .flow { grid-template-columns: 1fr; }
+  .edge { display: none; }
+  section { padding: 3rem 0; }
+  .stack div { flex-direction: column; }
 }


### PR DESCRIPTION
## Summary
- rewrite the static homepage for a crypto/protocol engineering audience
- focus copy on attestation, quote verification, EasyEnclave, workload specs, shell access modes, and taint semantics
- replace the large decorative stylesheet with a small readable CSS file

## Checks
- served locally with python3 -m http.server on port 18080
- verified index.html and style.css return 200