### PR TITLE
Shorten agent API hostnames

### DIFF
--- a/.github/actions/dd-deploy/README.md
+++ b/.github/actions/dd-deploy/README.md
@@ -24,7 +24,7 @@ The action will:
 
 1. Look up the current hostname for your target agent via the CP's `/api/agents`.
 2. Mint a GitHub Actions OIDC JWT with `audience: dd-agent`.
-3. POST the baked workload JSON to `https://<agent>-agent-api/deploy` with `Authorization: Bearer <oidc>`.
+3. POST the baked workload JSON to the agent API hostname with `Authorization: Bearer <oidc>`.
 4. Poll the agent API subdomain's `/health` until the deployment appears (or fail after `wait-for-deployment-seconds`).
 
 ## Inputs

--- a/.github/actions/dd-deploy/action.yml
+++ b/.github/actions/dd-deploy/action.yml
@@ -79,10 +79,17 @@ runs:
           echo "::error::no healthy agent with vm_name=$VM_NAME"
           exit 1
         fi
-        agent_api_host="${agent_host%%.*}-agent-api.${agent_host#*.}"
+        agent_label="${agent_host%%.*}"
+        agent_domain="${agent_host#*.}"
+        if [[ "$agent_label" == *-agent-* ]]; then
+          agent_api_label="${agent_label/-agent-/-api-}"
+        else
+          agent_api_label="${agent_label}-agent-api"
+        fi
+        agent_api_host="${agent_api_label}.${agent_domain}"
         echo "agent-host=$agent_host" >> "$GITHUB_OUTPUT"
 
-        # The agent-api hostname and its CF Access bypass app are created
+        # The agent API hostname and its CF Access bypass app are created
         # immediately before preview deploys. DNS can resolve before the
         # bypass decision is active at every edge, which shows up as transient
         # 401s on /deploy. Gate the mutating request on the read-only health

--- a/src/cf.rs
+++ b/src/cf.rs
@@ -29,7 +29,24 @@ pub fn agent_prefix(env: &str) -> String {
     format!("dd-{env}-agent-")
 }
 pub fn agent_api_hostname(agent_hostname: &str) -> String {
-    label_hostname(agent_hostname, AGENT_API_LABEL)
+    match agent_hostname.split_once('.') {
+        Some((base, rest)) => {
+            if let Some((prefix, suffix)) = base.split_once("-agent-") {
+                format!("{prefix}-api-{suffix}.{rest}")
+            } else {
+                format!("{base}-{AGENT_API_LABEL}.{rest}")
+            }
+        }
+        None => format!("{agent_hostname}-{AGENT_API_LABEL}"),
+    }
+}
+
+pub fn extra_hostname(agent_hostname: &str, label: &str) -> String {
+    if label == AGENT_API_LABEL {
+        agent_api_hostname(agent_hostname)
+    } else {
+        label_hostname(agent_hostname, label)
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -182,7 +199,7 @@ async fn apply_ingress(
         .iter()
         .map(|(label, port)| {
             serde_json::json!({
-                "hostname": label_hostname(hostname, label),
+                "hostname": extra_hostname(hostname, label),
                 "service": format!("http://localhost:{port}"),
             })
         })
@@ -208,7 +225,7 @@ async fn apply_ingress(
     upsert_cname(http, cf, tunnel_id, hostname).await?;
     let mut extra_hostnames = Vec::with_capacity(extras.len());
     for (label, _) in extras {
-        let extra = label_hostname(hostname, label);
+        let extra = extra_hostname(hostname, label);
         upsert_cname(http, cf, tunnel_id, &extra).await?;
         extra_hostnames.push(extra);
     }
@@ -708,7 +725,7 @@ pub async fn provision_cp_access(
 ///   - Human: `{agent}.{domain}` — browser dashboard only
 ///   - Human: `<admin-label>.{agent}.{domain}` for labels in
 ///     `ADMIN_LABELS` — org members only
-///   - Bypass: `{agent}-agent-api.{domain}` — machine API only
+///   - Bypass: `dd-{env}-api-{uuid}.{domain}` — machine API only
 ///   - Bypass: `{agent}.{domain}/health` — public; carries the Noise
 ///     pre-handshake `{quote_b64, pubkey_hex}` in its response
 ///   - Bypass: `{agent}.{domain}/deploy` — GH-OIDC-gated in code
@@ -768,10 +785,10 @@ pub async fn provision_agent_access(
 
     let desired: std::collections::HashSet<String> = workload_labels
         .iter()
-        .map(|l| label_hostname(agent_hostname, l))
+        .map(|l| extra_hostname(agent_hostname, l))
         .collect();
     for label in workload_labels {
-        let domain = label_hostname(agent_hostname, label);
+        let domain = extra_hostname(agent_hostname, label);
         if is_admin_label(label) {
             ensure_app(
                 http,
@@ -797,6 +814,7 @@ pub async fn provision_agent_access(
         .unwrap_or((agent_hostname, ""));
     let prefix = format!("{base}-");
     let suffix_tld = format!(".{tld}");
+    let agent_api_domain = agent_api_hostname(agent_hostname);
     let resp = call(
         http,
         cf,
@@ -810,7 +828,9 @@ pub async fn provision_agent_access(
             let Some(domain) = app["domain"].as_str() else {
                 continue;
             };
-            if !(domain.starts_with(&prefix) && domain.ends_with(&suffix_tld)) {
+            if domain != agent_api_domain
+                && !(domain.starts_with(&prefix) && domain.ends_with(&suffix_tld))
+            {
                 continue;
             }
             if desired.contains(domain) {
@@ -854,6 +874,7 @@ pub async fn delete_access_apps_for(http: &Client, cf: &CfCreds, agent_hostname:
         .unwrap_or((agent_hostname, ""));
     let prefix = format!("{base}-");
     let suffix_tld = format!(".{tld}");
+    let agent_api_domain = agent_api_hostname(agent_hostname);
     for app in items {
         let Some(domain) = app["domain"].as_str() else {
             continue;
@@ -863,6 +884,7 @@ pub async fn delete_access_apps_for(http: &Client, cf: &CfCreds, agent_hostname:
         // `{base}-*.{tld}`.
         let matches_agent = domain == agent_hostname
             || domain.starts_with(&format!("{agent_hostname}/"))
+            || domain == agent_api_domain
             || (domain.starts_with(&prefix) && domain.ends_with(&suffix_tld));
         if !matches_agent {
             continue;
@@ -904,7 +926,13 @@ mod tests {
     fn agent_api_hostname_uses_reserved_flat_subdomain() {
         assert_eq!(
             agent_api_hostname("dd-pr-144-agent-abc.devopsdefender.com"),
-            "dd-pr-144-agent-abc-agent-api.devopsdefender.com"
+            "dd-pr-144-api-abc.devopsdefender.com"
+        );
+        assert_eq!(
+            agent_api_hostname(
+                "dd-production-agent-73744f46-0a97-4628-ad8b-dd37a07b1e10.devopsdefender.com"
+            ),
+            "dd-production-api-73744f46-0a97-4628-ad8b-dd37a07b1e10.devopsdefender.com"
         );
     }
 

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -6,7 +6,7 @@
 //! or mis-signed don't enter the store. One tick:
 //!
 //!   1. List CF tunnels whose name starts with `dd-{env}-agent-`.
-//!   2. Scrape `https://{tunnel-name}-agent-api.{domain}/health` in parallel.
+//!   2. Scrape `https://dd-{env}-api-{uuid}.{domain}/health` in parallel.
 //!   3. Verify the `ita_token` field from each /health body.
 //!   4. Insert on success, including tunnel id and reported ingress.
 //!   5. Mark dead / GC tunnel on repeated scrape failures.
@@ -264,7 +264,7 @@ async fn tick(
             let _ = cf::delete_cname(http, cf, &orphan.host).await;
             let _ = cf::delete_cname(http, cf, &cf::agent_api_hostname(&orphan.host)).await;
             for (label, _) in &orphan.extras {
-                let _ = cf::delete_cname(http, cf, &cf::label_hostname(&orphan.host, label)).await;
+                let _ = cf::delete_cname(http, cf, &cf::extra_hostname(&orphan.host, label)).await;
             }
             // Sweep the agent's CF Access apps — its human dashboard
             // app and every workload-URL bypass under this hostname.


### PR DESCRIPTION
## Summary
- use dd-<env>-api-<uuid> for agent API hostnames instead of appending -agent-api to full agent tunnel labels
- route agent-api ingress/access cleanup through the shared hostname helper
- update dd-deploy to discover the shortened agent API hostname

## Why
Production agent labels like dd-production-agent-<uuid>-agent-api exceed the 63-character DNS label limit, causing reqwest InvalidDnsNameError and blocking dd-local-prod registration after #239.

## Validation
- cargo fmt --check
- cargo test
- cargo clippy -- -D warnings
- git diff --check