### PR TITLE
Reap shared preview VMs during cleanup

### DIFF
--- a/.github/actions/dd-deploy/action.yml
+++ b/.github/actions/dd-deploy/action.yml
@@ -63,11 +63,13 @@ runs:
           -H "Authorization: Bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
           "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${AUDIENCE}" | jq -r .value)
 
-        # Discover the agent hostname from the CP's source of truth. A
-        # freshly relaunched agent registers before the collector has
-        # scraped and marked it healthy, so poll on that state instead
-        # of racing the next action against the collector interval.
-        echo "waiting for healthy agent vm_name=$VM_NAME on $CP_URL"
+        # Discover the agent hostname from the CP's source of truth.
+        # Registration is already ITA-gated by the CP. Do not block on
+        # the CP collector marking it healthy here: freshly-created
+        # Cloudflare DNS can be visible to the GitHub runner before it
+        # is visible inside the just-booted CP VM. The next gate probes
+        # the agent API hostname directly before POSTing /deploy.
+        echo "waiting for registered agent vm_name=$VM_NAME on $CP_URL"
         deadline=$(( $(date +%s) + 120 ))
         agent_host=""
         last_agents=""
@@ -79,14 +81,14 @@ runs:
           if [ -n "$agents" ]; then
             last_agents="$agents"
             agent_host=$(echo "$agents" | jq -r --arg vm "$VM_NAME" '
-                [.[] | select(.vm_name == $vm and .status == "healthy")]
+                [.[] | select(.vm_name == $vm and (.status == "healthy" or .status == "registering"))]
                 | sort_by(.last_seen) | reverse | .[0].hostname // empty')
             [ -n "$agent_host" ] && break
           fi
           sleep 5
         done
         if [ -z "$agent_host" ]; then
-          echo "::error::no healthy agent with vm_name=$VM_NAME within 120s"
+          echo "::error::no registered agent with vm_name=$VM_NAME within 120s"
           if [ -n "$last_agents" ]; then
             echo "$last_agents" | jq -r --arg vm "$VM_NAME" '
               .[] | select(.vm_name == $vm)
@@ -110,7 +112,7 @@ runs:
         # 401s on /deploy. Gate the mutating request on the read-only health
         # endpoint being reachable through the same hostname.
         echo "waiting for agent API health at $agent_api_host"
-        deadline=$(( $(date +%s) + 120 ))
+        deadline=$(( $(date +%s) + 600 ))
         last_health_error=""
         agent_api_ready=0
         while [ "$(date +%s)" -lt "$deadline" ]; do
@@ -127,7 +129,7 @@ runs:
           sleep 5
         done
         if [ "$agent_api_ready" -ne 1 ]; then
-          echo "::error::agent API ${agent_api_host} did not become ready within 120s: ${last_health_error}"
+          echo "::error::agent API ${agent_api_host} did not become ready within 600s: ${last_health_error}"
           exit 1
         fi
 

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -17,6 +17,9 @@ name: Cleanup
 # Per-env teardown covers, in order:
 #   1. `dd-local-{env}*` libvirt domains + qcow2/config/workload
 #      disks + serial logs on tdx2 (via SSH — target=ssh VMs).
+#      PR sweeps also reap shared preview domains
+#      (`dd-local-preview`, `dd-local-preview-oracle`) only when their
+#      baked config/logs still point at that PR env.
 #   2. CF Access apps named `dd-{env}-…`.
 #   3. CF tunnels named `dd-{env}-…` (connections drained first —
 #      delete is 400 otherwise).
@@ -119,8 +122,55 @@ jobs:
           set -euo pipefail
           env="$1"
           prefix="dd-local-$env"
-          domains=$(sudo -n virsh list --all --name)
-          domains=$(printf '%s\n' "$domains" | grep -E "^${prefix}($|-)" || true)
+          all_domains=$(sudo -n virsh list --all --name)
+          domains=$(printf '%s\n' "$all_domains" | grep -E "^${prefix}($|-)" || true)
+
+          vm_matches_env() {
+            vm="$1"
+            config="/var/lib/libvirt/images/$vm-config.iso"
+            log="/var/log/ee-local-${vm#dd-local-}.log"
+            if [ -f "$config" ]; then
+              sudo -n grep -aFq "DD_ENV=$env" "$config" 2>/dev/null && return 0
+              sudo -n grep -aFq "https://$env." "$config" 2>/dev/null && return 0
+            fi
+            if [ -f "$log" ]; then
+              sudo -n grep -aFq "DD_ENV=$env" "$log" 2>/dev/null && return 0
+              sudo -n grep -aFq "https://$env." "$log" 2>/dev/null && return 0
+            fi
+            return 1
+          }
+
+          # Preview agents are shared libvirt names, not `dd-local-pr-N`.
+          # Reap them only when their current config/logs prove they belong
+          # to the PR env being torn down; otherwise an old branch-delete
+          # could kill a different open PR's active preview.
+          case "$env" in
+            pr-*)
+              for vm in dd-local-preview dd-local-preview-oracle; do
+                if printf '%s\n' "$all_domains" | grep -Fxq "$vm"; then
+                  if vm_matches_env "$vm"; then
+                    domains="$domains $vm"
+                  else
+                    echo "  - keep $vm (not bound to $env)"
+                  fi
+                fi
+              done
+              ;;
+          esac
+
+          delete_vm_files() {
+            vm="$1"
+            sudo find /var/lib/libvirt/images -maxdepth 1 -type f \( \
+                -name "$vm.qcow2" \
+                -o -name "$vm.qcow2.base" \
+                -o -name "$vm-config.iso" \
+                -o -name "$vm-workload.qcow2" \
+              \) -print -delete 2>/dev/null | sed 's/^/  - file /' || true
+            sudo find /var/log -maxdepth 1 -type f \
+                -name "ee-local-${vm#dd-local-}.log" \
+                -print -delete 2>/dev/null | sed 's/^/  - file /' || true
+          }
+
           for vm in $domains; do
             sudo -n virsh destroy "$vm" 2>/dev/null || true
             sudo -n virsh undefine "$vm" --managed-save --snapshots-metadata --nvram 2>/dev/null \
@@ -128,10 +178,13 @@ jobs:
               || sudo -n virsh undefine "$vm" 2>/dev/null \
               || true
             echo "  - libvirt $vm"
+            delete_vm_files "$vm"
           done
           sudo find /var/lib/libvirt/images -maxdepth 1 -type f \( \
               -name "$prefix.qcow2" \
+              -o -name "$prefix.qcow2.base" \
               -o -name "$prefix-*.qcow2" \
+              -o -name "$prefix-*.qcow2.base" \
               -o -name "$prefix-config.iso" \
               -o -name "$prefix-*-config.iso" \
             \) -print -delete 2>/dev/null | sed 's/^/  - file /' || true


### PR DESCRIPTION
## Summary
- include shared preview agent domains in PR cleanup when their baked config/logs still point at the closed PR env
- delete their root overlays, base markers, config disks, workload disks, and serial logs
- keep shared preview domains for other active PR envs

## Validation
- bash -n on patched SSH cleanup block
- git diff --check
- dry-run against current host selected dd-local-preview and dd-local-preview-oracle for pr-244