### PR TITLE
Make shell UI mobile-first

### DIFF
--- a/.github/actions/relaunch-cp/action.yml
+++ b/.github/actions/relaunch-cp/action.yml
@@ -30,7 +30,7 @@ inputs:
     required: false
     default: /home/tdx2/src/dd
   cf-api-token:
-    description: 'Cloudflare API token (tunnel + DNS + self-hosted app scopes)'
+    description: 'Cloudflare API token (tunnel + DNS + legacy Access app cleanup scopes)'
     required: true
   cf-account-id:
     description: 'Cloudflare account id'

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ Source layout (all under `src/`, flat module tree):
 
 | Module | Responsibility |
 |---|---|
-| `cp.rs` | CP HTTP: fleet dashboard, `/register` for agents, `/api/agents` public read, `/cp/attest`. Runs the collector + per-agent Cloudflare routing app + STONITH. |
+| `cp.rs` | CP HTTP: fleet dashboard, `/register` for agents, `/api/agents` public read, `/cp/attest`. Runs the collector, Cloudflare tunnel/DNS setup, legacy Access cleanup, and STONITH. |
 | `agent.rs` | Agent HTTP: per-VM dashboard, `/deploy` + `/exec` + `/logs/{app}` + `/ingress/replace`, GitHub-OIDC and ITA verification. |
-| `cf.rs` | Cloudflare API: tunnel CRUD, DNS CNAME, self-hosted app provisioning, flat `label_hostname`, orphan reaping. |
+| `cf.rs` | Cloudflare API: tunnel CRUD, DNS CNAME, legacy Access app cleanup, flat `label_hostname`, orphan reaping. |
 | `ee.rs` | Thin client for [EasyEnclave Mini](https://github.com/easyenclave/easyenclave-mini)'s unix socket — `Deploy`, `List`, `Logs`. |
 | `ita.rs` | Mint + verify Intel Trust Authority tokens (quote-v4 MRTD extraction). |
 | `gh_oidc.rs` | Verify GitHub Actions OIDC JWTs against GitHub's JWKS (`repository_owner == DD_OWNER`). |
@@ -74,12 +74,12 @@ Zero shared secrets. Cloudflare handles tunnel/DNS routing only; DD owns auth in
 
 No PATs. No Cloudflare service tokens. No Worker. Agents ship with nothing but an ITA API key; CI ships with nothing but its per-job GitHub OIDC token.
 
-Cloudflare self-hosted apps are provisioned programmatically by the CP at boot as bypass routing objects — one application per hostname (CP, agent, each routed workload label like `-shell`). Orphan apps from torn-down preview VMs are reaped on the next CP boot.
+Cloudflare Access is not part of request routing. DD uses Cloudflare for tunnels and DNS only, and cleans up old Access applications left by previous deployments so they cannot intercept DD-owned auth routes.
 
 First-time setup:
 1. Create the staging and production GitHub Apps with callback URL `https://app.devopsdefender.com/auth/github/callback`.
 2. Store the app client ids/secrets and `DD_AUTH_COOKIE_SECRET` in GitHub repo vars/secrets.
-3. Ensure `DD_CF_API_TOKEN` can manage Cloudflare tunnels, DNS, and self-hosted apps.
+3. Ensure `DD_CF_API_TOKEN` can manage Cloudflare tunnels, DNS, and legacy Access application cleanup.
 4. Deploy. No per-deploy OAuth callback setup.
 
 ## Deploy a workload from GitHub Actions

--- a/src/cf.rs
+++ b/src/cf.rs
@@ -408,23 +408,41 @@ async fn list_access_apps(http: &Client, cf: &CfCreds) -> Result<Vec<serde_json:
 }
 
 fn access_app_matches_domain(app: &serde_json::Value, domain: &str) -> bool {
-    if app["domain"].as_str() == Some(domain) {
+    if access_domain_matches(app["domain"].as_str(), domain) {
         return true;
     }
     if app["destinations"].as_array().is_some_and(|items| {
-        items
-            .iter()
-            .any(|d| d["type"].as_str() == Some("public") && d["uri"].as_str() == Some(domain))
+        items.iter().any(|d| {
+            d["type"].as_str() == Some("public") && access_domain_matches(d["uri"].as_str(), domain)
+        })
     }) {
         return true;
     }
     app["self_hosted_domains"].as_array().is_some_and(|items| {
         items.iter().any(|d| {
-            d.as_str() == Some(domain)
-                || d["domain"].as_str() == Some(domain)
-                || d["uri"].as_str() == Some(domain)
+            access_domain_matches(d.as_str(), domain)
+                || access_domain_matches(d["domain"].as_str(), domain)
+                || access_domain_matches(d["uri"].as_str(), domain)
         })
     })
+}
+
+fn access_domain_matches(app_domain: Option<&str>, target: &str) -> bool {
+    let Some(app_domain) = app_domain else {
+        return false;
+    };
+    if app_domain == target {
+        return true;
+    }
+    let app_host = app_domain.split('/').next().unwrap_or(app_domain);
+    let target_host = target.split('/').next().unwrap_or(target);
+    if app_host == target_host {
+        return true;
+    }
+    if let Some(suffix) = app_host.strip_prefix("*.") {
+        return target_host != suffix && target_host.ends_with(&format!(".{suffix}"));
+    }
+    false
 }
 
 async fn delete_access_apps_for_domains(
@@ -626,7 +644,7 @@ mod tests {
             "type": "self_hosted",
         });
         assert!(access_app_matches_domain(&app, "agent.example.com/health"));
-        assert!(!access_app_matches_domain(&app, "agent.example.com/deploy"));
+        assert!(access_app_matches_domain(&app, "agent.example.com/deploy"));
     }
 
     #[test]
@@ -639,6 +657,24 @@ mod tests {
             ],
         });
         assert!(access_app_matches_domain(&app, "agent.example.com/health"));
-        assert!(!access_app_matches_domain(&app, "agent.example.com/deploy"));
+        assert!(access_app_matches_domain(&app, "agent.example.com/deploy"));
+    }
+
+    #[test]
+    fn access_app_matches_wildcard_domain() {
+        let app = serde_json::json!({
+            "domain": "*.devopsdefender.com",
+            "type": "self_hosted",
+        });
+        assert!(access_app_matches_domain(
+            &app,
+            "pr-253.devopsdefender.com/health"
+        ));
+        assert!(access_app_matches_domain(
+            &app,
+            "dd-pr-253-api-abc.devopsdefender.com"
+        ));
+        assert!(!access_app_matches_domain(&app, "devopsdefender.com"));
+        assert!(!access_app_matches_domain(&app, "example.com"));
     }
 }

--- a/src/cf.rs
+++ b/src/cf.rs
@@ -84,10 +84,8 @@ async fn call(
     }
     let parsed: serde_json::Value = resp.json().await?;
     // CF v4 API returns 200 with {success: false, errors: [...]} on
-    // validation failures. We used to silently drop those — which led
-    // to Cloudflare apps that appeared created but never matched any
-    // requests (manifested as /health etc. 503'ing behind the root
-    // human app). Promote to Err so the CP's `?` unwinding catches it.
+    // validation failures. Promote those to Err so callers don't
+    // assume DNS, tunnel, or Access cleanup changes actually applied.
     if parsed.get("success") == Some(&serde_json::Value::Bool(false)) {
         let errors = parsed
             .get("errors")
@@ -387,21 +385,17 @@ pub async fn exists(http: &Client, cf: &CfCreds, tunnel_id: &str) -> Option<bool
     }
 }
 
-// ── Cloudflare self-hosted app provisioning ─────────────────────────────
+// ── Cloudflare Access cleanup ───────────────────────────────────────────
 //
-// The CP provisions Cloudflare self-hosted apps as routing bypasses
-// only. Browser auth is enforced in DD via GitHub App OAuth; machine
-// paths use in-code auth (ITA for /register + /ingress/replace,
-// GitHub Actions OIDC for agent /deploy + /exec).
+// DD uses Cloudflare for tunnel ingress + DNS only. Browser and machine
+// auth are enforced in-code (GitHub App sessions, ITA, GH OIDC, Noise).
+// Old deployments created Cloudflare Access self-hosted apps as bypass
+// wrappers. Those apps are now legacy state: if an exact host/path app
+// is left behind with the wrong policy, Cloudflare can intercept traffic
+// before DD sees it. Registration/startup therefore delete DD-owned
+// Access apps for the hosts they publish instead of creating bypass apps.
 
-/// List all Cloudflare self-hosted apps, return the full app JSON for
-/// one whose primary or included `domain` exactly matches `domain`, or
-/// `None`.
-async fn find_app_by_domain(
-    http: &Client,
-    cf: &CfCreds,
-    domain: &str,
-) -> Result<Option<serde_json::Value>> {
+async fn list_access_apps(http: &Client, cf: &CfCreds) -> Result<Vec<serde_json::Value>> {
     let resp = call(
         http,
         cf,
@@ -410,15 +404,10 @@ async fn find_app_by_domain(
         None,
     )
     .await?;
-    Ok(resp["result"].as_array().and_then(|items| {
-        items
-            .iter()
-            .find(|a| routing_app_matches_domain(a, domain))
-            .cloned()
-    }))
+    Ok(resp["result"].as_array().cloned().unwrap_or_default())
 }
 
-fn routing_app_matches_domain(app: &serde_json::Value, domain: &str) -> bool {
+fn access_app_matches_domain(app: &serde_json::Value, domain: &str) -> bool {
     if app["domain"].as_str() == Some(domain) {
         return true;
     }
@@ -438,88 +427,36 @@ fn routing_app_matches_domain(app: &serde_json::Value, domain: &str) -> bool {
     })
 }
 
-fn bypass_policy() -> serde_json::Value {
-    serde_json::json!({
-        "name": "dd-bypass",
-        "decision": "bypass",
-        "include": [ { "everyone": {} } ],
-    })
-}
-
-/// Idempotently upsert a Cloudflare self-hosted app at `domain` with the
-/// provided policy list. Matches on exact `domain`; updates in place
-/// if present, creates otherwise.
-async fn ensure_routing_app(
+async fn delete_access_apps_for_domains(
     http: &Client,
     cf: &CfCreds,
-    name: &str,
-    domain: &str,
-    policies: Vec<serde_json::Value>,
-) -> Result<String> {
-    let body = serde_json::json!({
-        "name": name,
-        "domain": domain,
-        "destinations": [
-            {
-                "type": "public",
-                "uri": domain,
-            }
-        ],
-        "type": "self_hosted",
-        "session_duration": "24h",
-        "app_launcher_visible": false,
-        "policies": policies,
-    });
-    if let Some(existing) = find_app_by_domain(http, cf, domain).await? {
-        let id = existing["id"].as_str().unwrap_or_default().to_string();
-        call(
-            http,
-            cf,
-            Method::PUT,
-            &format!("/accounts/{}/access/apps/{id}", cf.account_id),
-            Some(body),
-        )
-        .await?;
-        return Ok(id);
-    }
-    let resp = call(
-        http,
-        cf,
-        Method::POST,
-        &format!("/accounts/{}/access/apps", cf.account_id),
-        Some(body),
-    )
-    .await?;
-    resp["result"]["id"]
-        .as_str()
-        .map(String::from)
-        .ok_or_else(|| Error::Upstream(format!("Cloudflare app create missing id for {domain}")))
-}
-
-/// Idempotently upsert a path-scoped public routing app. Anyone can
-/// reach `domain/path` without authentication; used for /health,
-/// /register (which is authenticated by ITA in-app), and every
-/// workload-exposed URL.
-async fn ensure_public_route_app(
-    http: &Client,
-    cf: &CfCreds,
-    name: &str,
-    domain: &str,
+    domains: impl IntoIterator<Item = String>,
 ) -> Result<()> {
-    ensure_routing_app(http, cf, name, domain, vec![bypass_policy()]).await?;
+    let domains: std::collections::HashSet<String> = domains.into_iter().collect();
+    if domains.is_empty() {
+        return Ok(());
+    }
+    for app in list_access_apps(http, cf).await? {
+        if !domains.iter().any(|d| access_app_matches_domain(&app, d)) {
+            continue;
+        }
+        if let Some(id) = app["id"].as_str() {
+            call(
+                http,
+                cf,
+                Method::DELETE,
+                &format!("/accounts/{}/access/apps/{id}", cf.account_id),
+                None,
+            )
+            .await?;
+        }
+    }
     Ok(())
 }
 
-/// Hostname labels that run DD-authenticated admin workloads.
-const ADMIN_LABELS: &[&str] = &["shell"];
-
-fn is_admin_label(label: &str) -> bool {
-    ADMIN_LABELS.contains(&label)
-}
-
-/// Provision the CP's Cloudflare routing apps at startup.
+/// Delete legacy Cloudflare Access apps for the CP's published routes.
 ///
-/// Routes created:
+/// Routes are provided by tunnel ingress + DNS, not Access:
 ///   - `{hostname}` — dashboard, app-layer GitHub auth
 ///   - `{hostname}-shell` — dd-shell, app-layer GitHub auth
 ///   - `{hostname}/health` — public (read-only fleet health;
@@ -528,134 +465,42 @@ fn is_admin_label(label: &str) -> bool {
 ///   - `{hostname}/noise/ws` — Noise_IK-gated in code
 ///   - `{hostname}/register` — ITA-gated in code
 ///   - `{hostname}/ingress/replace` — ITA-gated in code
-pub async fn provision_cp_routing(
+pub async fn delete_cp_access_apps(
     http: &Client,
     cf: &CfCreds,
-    env: &str,
+    _env: &str,
     hostname: &str,
     workload_labels: &[String],
 ) -> Result<()> {
-    ensure_routing_app(
-        http,
-        cf,
-        &format!("dd-{env}-cp"),
-        hostname,
-        vec![bypass_policy()],
-    )
-    .await?;
-
-    // One Cloudflare routing app per CP-exposed workload label.
-    // Admin labels still use bypass policies: DD checks browser sessions
-    // in-code, and non-admin workload URLs remain public by default.
-    let desired: std::collections::HashSet<String> = workload_labels
+    let mut domains: Vec<String> = vec![hostname.to_string()];
+    domains.extend(
+        workload_labels
+            .iter()
+            .map(|label| label_hostname(hostname, label)),
+    );
+    domains.extend(
+        [
+            "/health",
+            "/api/agents",
+            "/api/v1/devices/trusted",
+            "/api/v1/admin/export",
+            "/noise/ws",
+            "/register",
+            "/ingress/replace",
+            // Legacy route from the old two-step Noise pre-handshake.
+            "/attest",
+        ]
         .iter()
-        .map(|l| label_hostname(hostname, l))
-        .collect();
-    for label in workload_labels {
-        let domain = label_hostname(hostname, label);
-        if is_admin_label(label) {
-            ensure_routing_app(
-                http,
-                cf,
-                &format!("dd-{env}-cp-{label}"),
-                &domain,
-                vec![bypass_policy()],
-            )
-            .await?;
-        } else {
-            ensure_public_route_app(http, cf, &format!("dd-{env}-cp-{label}"), &domain).await?;
-        }
-    }
-
-    // Reap any stale workload apps under the CP's flat subdomain space
-    // that are no longer in the desired label set. Shape is
-    // `{base}-{label}.{tld}` — prefix+suffix match so we don't touch
-    // the CP's own root human app or any bypass-path apps.
-    let (base, tld) = hostname.split_once('.').unwrap_or((hostname, ""));
-    let prefix = format!("{base}-");
-    let suffix_tld = format!(".{tld}");
-    if let Ok(resp) = call(
-        http,
-        cf,
-        Method::GET,
-        &format!("/accounts/{}/access/apps?per_page=1000", cf.account_id),
-        None,
-    )
-    .await
-    {
-        if let Some(items) = resp["result"].as_array() {
-            for app in items {
-                let Some(domain) = app["domain"].as_str() else {
-                    continue;
-                };
-                if !(domain.starts_with(&prefix) && domain.ends_with(&suffix_tld)) {
-                    continue;
-                }
-                if desired.contains(domain) {
-                    continue;
-                }
-                if let Some(id) = app["id"].as_str() {
-                    let _ = call(
-                        http,
-                        cf,
-                        Method::DELETE,
-                        &format!("/accounts/{}/access/apps/{id}", cf.account_id),
-                        None,
-                    )
-                    .await;
-                }
-            }
-        }
-    }
-    // One-shot reap: any prior deploy left behind a
-    // `dd-{env}-cp-noise-attest` route fronting `{hostname}/attest`.
-    // The attest route is gone, so the route has no job. The workload
-    // sweep above is subdomain-scoped and won't catch path-scoped routes,
-    // so delete it explicitly here. Lookup-by-domain is idempotent;
-    // no-op once the app is gone.
-    if let Ok(Some(stale)) = find_app_by_domain(http, cf, &format!("{hostname}/attest")).await {
-        if let Some(id) = stale["id"].as_str() {
-            let _ = call(
-                http,
-                cf,
-                Method::DELETE,
-                &format!("/accounts/{}/access/apps/{id}", cf.account_id),
-                None,
-            )
-            .await;
-        }
-    }
-
-    for (path_suffix, label) in [
-        ("/health", "health"),
-        ("/api/agents", "api-agents"),
-        ("/api/v1/devices/trusted", "api-devices-trusted"),
-        ("/api/v1/admin/export", "api-admin-export"),
-        // The Noise pre-handshake bundle (`quote_b64` + `pubkey_hex`)
-        // now rides on `/health` — `/attest` was deleted. Only the
-        // handshake itself still needs its own bypass.
-        ("/noise/ws", "noise-ws"),
-        ("/register", "register"),
-        ("/ingress/replace", "ingress"),
-    ] {
-        ensure_public_route_app(
-            http,
-            cf,
-            &format!("dd-{env}-cp-{label}"),
-            &format!("{hostname}{path_suffix}"),
-        )
-        .await?;
-    }
-    Ok(())
+        .map(|suffix| format!("{hostname}{suffix}")),
+    );
+    delete_access_apps_for_domains(http, cf, domains).await
 }
 
-/// Provision routing apps for one agent. Called at /register and again
-/// at /ingress/replace so newly-exposed workload labels get their
-/// public routes and labels that disappeared get cleaned up.
+/// Delete legacy Cloudflare Access apps for one agent. Called at
+/// /register and again at /ingress/replace so old exact Access apps
+/// cannot intercept the tunnel ingress that DD owns.
 ///
-///   - `{agent}.{domain}` — browser dashboard, app-layer auth
-///   - `<admin-label>.{agent}.{domain}` for labels in
-///     `ADMIN_LABELS` — app-layer auth
+///   - `{agent}.{domain}` — browser dashboard, app-layer DD auth
 ///   - `dd-{env}-api-{uuid}.{domain}` — machine API only
 ///   - `{agent}.{domain}/health` — public; carries the Noise
 ///     pre-handshake `{quote_b64, pubkey_hex}` in its response
@@ -665,143 +510,41 @@ pub async fn provision_cp_routing(
 ///   - `{agent}.{domain}/logs/*` — GH-OIDC-gated in code
 ///   - `{agent}.{domain}/noise/ws` — Noise_IK-gated in code
 ///     against the CP-trusted paired device pubkey set
-///   - `{label}.{agent}.{domain}` for other labels — workload
-///     URLs are public by default.
-///   - Any existing `*.{agent}.{domain}` app whose label is no longer
-///     in `workload_labels` is deleted.
-pub async fn provision_agent_routing(
+///   - `{label}.{agent}.{domain}` — workload URL, DD/agent-owned
+pub async fn delete_agent_access_apps(
     http: &Client,
     cf: &CfCreds,
-    env: &str,
+    _env: &str,
     agent_hostname: &str,
     workload_labels: &[String],
 ) -> Result<()> {
-    ensure_routing_app(
-        http,
-        cf,
-        &format!("dd-{env}-agent-{agent_hostname}"),
-        agent_hostname,
-        vec![bypass_policy()],
-    )
-    .await?;
     let agent_api_domain = agent_api_hostname(agent_hostname);
-    ensure_public_route_app(
-        http,
-        cf,
-        &format!("dd-{env}-agent-api-{agent_hostname}"),
-        &agent_api_domain,
-    )
-    .await?;
-    for (suffix, label) in [
-        ("/health", "health"),
-        ("/deploy", "deploy"),
-        ("/exec", "exec"),
-        ("/owner", "owner"),
-        ("/logs", "logs"),
-        // The in-process Noise gateway (merged into the agent's
-        // router in agent.rs) lives on the same port + hostname as
-        // /deploy + /exec, so a direct bastion-app attach needs the
-        // same bypass treatment the CP hostname already gets. The
-        // pre-handshake quote bundle is served by /health above
-        // (collapsed from the old /attest), so only the handshake
-        // WebSocket needs its own entry here. Noise_IK against the
-        // paired device pubkey set is the gate.
-        ("/noise/ws", "noise-ws"),
-    ] {
-        ensure_public_route_app(
-            http,
-            cf,
-            &format!("dd-{env}-agent-{agent_hostname}-{label}"),
-            &format!("{agent_hostname}{suffix}"),
-        )
-        .await?;
-    }
-
-    let mut desired: std::collections::HashSet<String> = workload_labels
+    let mut domains: Vec<String> = vec![agent_hostname.to_string(), agent_api_domain];
+    domains.extend(
+        [
+            "/health",
+            "/deploy",
+            "/exec",
+            "/owner",
+            "/logs",
+            "/noise/ws",
+        ]
         .iter()
-        .map(|l| extra_hostname(agent_hostname, l))
-        .collect();
-    desired.insert(agent_api_domain.clone());
-    for label in workload_labels {
-        let domain = extra_hostname(agent_hostname, label);
-        if is_admin_label(label) {
-            ensure_routing_app(
-                http,
-                cf,
-                &format!("dd-{env}-workload-{domain}"),
-                &domain,
-                vec![bypass_policy()],
-            )
-            .await?;
-        } else {
-            ensure_public_route_app(http, cf, &format!("dd-{env}-workload-{domain}"), &domain)
-                .await?;
-        }
-    }
-
-    // Reap any stale workload apps under this agent that are no
-    // longer in the desired set. Flat-subdomain workload URLs look
-    // like `{base}-{label}.{tld}` (one level deep — see
-    // `label_hostname` for why). Prefix + suffix match so we don't
-    // accidentally delete the agent's own human app at
-    // `{base}.{tld}`.
-    let (base, tld) = agent_hostname
-        .split_once('.')
-        .unwrap_or((agent_hostname, ""));
-    let prefix = format!("{base}-");
-    let suffix_tld = format!(".{tld}");
-    let resp = call(
-        http,
-        cf,
-        Method::GET,
-        &format!("/accounts/{}/access/apps?per_page=1000", cf.account_id),
-        None,
-    )
-    .await?;
-    if let Some(items) = resp["result"].as_array() {
-        for app in items {
-            let Some(domain) = app["domain"].as_str() else {
-                continue;
-            };
-            if domain != agent_api_domain
-                && !(domain.starts_with(&prefix) && domain.ends_with(&suffix_tld))
-            {
-                continue;
-            }
-            if desired.contains(domain) {
-                continue;
-            }
-            if let Some(id) = app["id"].as_str() {
-                let _ = call(
-                    http,
-                    cf,
-                    Method::DELETE,
-                    &format!("/accounts/{}/access/apps/{id}", cf.account_id),
-                    None,
-                )
-                .await;
-            }
-        }
-    }
-    Ok(())
+        .map(|suffix| format!("{agent_hostname}{suffix}")),
+    );
+    domains.extend(
+        workload_labels
+            .iter()
+            .map(|label| extra_hostname(agent_hostname, label)),
+    );
+    delete_access_apps_for_domains(http, cf, domains).await
 }
 
 /// Cleanup hook invoked by the collector's orphan-GC path and by any
-/// explicit reap: delete the agent's dashboard route, its /health
-/// route, and every `*.{agent_hostname}` workload route in one sweep.
-pub async fn delete_routing_apps_for(http: &Client, cf: &CfCreds, agent_hostname: &str) {
-    let Ok(resp) = call(
-        http,
-        cf,
-        Method::GET,
-        &format!("/accounts/{}/access/apps?per_page=1000", cf.account_id),
-        None,
-    )
-    .await
-    else {
-        return;
-    };
-    let Some(items) = resp["result"].as_array() else {
+/// explicit reap: delete legacy Access apps for the agent's dashboard,
+/// path routes, machine API hostname, and workload URL hostnames.
+pub async fn delete_access_apps_for_agent(http: &Client, cf: &CfCreds, agent_hostname: &str) {
+    let Ok(items) = list_access_apps(http, cf).await else {
         return;
     };
     let (base, tld) = agent_hostname
@@ -877,20 +620,17 @@ mod tests {
     }
 
     #[test]
-    fn routing_app_matches_primary_domain() {
+    fn access_app_matches_primary_domain() {
         let app = serde_json::json!({
             "domain": "agent.example.com/health",
             "type": "self_hosted",
         });
-        assert!(routing_app_matches_domain(&app, "agent.example.com/health"));
-        assert!(!routing_app_matches_domain(
-            &app,
-            "agent.example.com/deploy"
-        ));
+        assert!(access_app_matches_domain(&app, "agent.example.com/health"));
+        assert!(!access_app_matches_domain(&app, "agent.example.com/deploy"));
     }
 
     #[test]
-    fn routing_app_matches_public_destination() {
+    fn access_app_matches_public_destination() {
         let app = serde_json::json!({
             "domain": "agent.example.com",
             "destinations": [
@@ -898,10 +638,7 @@ mod tests {
                 { "type": "private", "hostname": "agent.internal" }
             ],
         });
-        assert!(routing_app_matches_domain(&app, "agent.example.com/health"));
-        assert!(!routing_app_matches_domain(
-            &app,
-            "agent.example.com/deploy"
-        ));
+        assert!(access_app_matches_domain(&app, "agent.example.com/health"));
+        assert!(!access_app_matches_domain(&app, "agent.example.com/deploy"));
     }
 }

--- a/src/cf.rs
+++ b/src/cf.rs
@@ -684,6 +684,14 @@ pub async fn provision_agent_routing(
         vec![bypass_policy()],
     )
     .await?;
+    let agent_api_domain = agent_api_hostname(agent_hostname);
+    ensure_public_route_app(
+        http,
+        cf,
+        &format!("dd-{env}-agent-api-{agent_hostname}"),
+        &agent_api_domain,
+    )
+    .await?;
     for (suffix, label) in [
         ("/health", "health"),
         ("/deploy", "deploy"),
@@ -709,10 +717,11 @@ pub async fn provision_agent_routing(
         .await?;
     }
 
-    let desired: std::collections::HashSet<String> = workload_labels
+    let mut desired: std::collections::HashSet<String> = workload_labels
         .iter()
         .map(|l| extra_hostname(agent_hostname, l))
         .collect();
+    desired.insert(agent_api_domain.clone());
     for label in workload_labels {
         let domain = extra_hostname(agent_hostname, label);
         if is_admin_label(label) {
@@ -741,7 +750,6 @@ pub async fn provision_agent_routing(
         .unwrap_or((agent_hostname, ""));
     let prefix = format!("{base}-");
     let suffix_tld = format!(".{tld}");
-    let agent_api_domain = agent_api_hostname(agent_hostname);
     let resp = call(
         http,
         cf,

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -296,11 +296,10 @@ async fn tick(
             for (label, _) in &orphan.extras {
                 let _ = cf::delete_cname(http, cf, &cf::extra_hostname(&orphan.host, label)).await;
             }
-            // Sweep the agent's Cloudflare routing apps: its
-            // dashboard route and every workload URL under this hostname.
-            // Without this the account accumulates dead apps every
-            // STONITH cycle.
-            cf::delete_routing_apps_for(http, cf, &orphan.host).await;
+            // Sweep legacy Cloudflare Access apps for this agent so
+            // stale exact host/path apps cannot intercept future
+            // DNS+tunnel routes.
+            cf::delete_access_apps_for_agent(http, cf, &orphan.host).await;
         }
     }
 

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -3,7 +3,9 @@
 //! Every agent entry in the store carries freshly-verified ITA claims. The
 //! collector scrapes `/health`, extracts the `ita_token` field, and runs
 //! it through the CP's verifier; agents whose tokens are missing, expired,
-//! or mis-signed don't enter the store. One tick:
+//! or mis-signed don't enter the store. Known registered agents are scraped
+//! frequently from the CP store; Cloudflare tunnel discovery runs on a slower
+//! interval for new/unknown tunnels and orphan cleanup. One discovery pass:
 //!
 //!   1. List CF tunnels whose name starts with `dd-{env}-agent-`.
 //!   2. Scrape `https://dd-{env}-api-{uuid}.{domain}/health` in parallel.
@@ -18,7 +20,8 @@ use std::time::Duration;
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, Notify};
+use tokio::time::MissedTickBehavior;
 
 use crate::cf;
 use crate::config::CfCreds;
@@ -86,6 +89,15 @@ struct Orphan {
     extras: Vec<(String, u16)>,
 }
 
+#[derive(Debug, Clone)]
+struct ScrapeTarget {
+    name: String,
+    tunnel_id: String,
+    host: String,
+    created_at: Option<DateTime<Utc>>,
+    known: bool,
+}
+
 #[allow(clippy::too_many_arguments)]
 pub async fn run(
     store: Store,
@@ -94,7 +106,11 @@ pub async fn run(
     cp_hostname: String,
     ee: Arc<Ee>,
     verifier: Arc<ita::Verifier>,
-    interval: Duration,
+    wake: Arc<Notify>,
+    scrape_interval: Duration,
+    discovery_interval: Duration,
+    shard_index: u64,
+    shard_total: u64,
 ) -> ! {
     let prefix = cf::agent_prefix(&env_label);
     let http = reqwest::Client::builder()
@@ -103,13 +119,26 @@ pub async fn run(
         .unwrap_or_else(|_| reqwest::Client::new());
 
     eprintln!(
-        "cp: collector starting (prefix={prefix}*, interval={}s)",
-        interval.as_secs()
+        "cp: collector starting (prefix={prefix}*, scrape={}s, discovery={}s, shard={}/{})",
+        scrape_interval.as_secs(),
+        discovery_interval.as_secs(),
+        shard_index + 1,
+        shard_total
     );
 
-    let mut ticker = tokio::time::interval(interval);
+    let mut ticker = tokio::time::interval(scrape_interval);
+    ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
+    let mut next_discovery = tokio::time::Instant::now();
     loop {
-        ticker.tick().await;
+        tokio::select! {
+            _ = ticker.tick() => {}
+            _ = wake.notified() => {}
+        }
+        let now = tokio::time::Instant::now();
+        let discover = now >= next_discovery;
+        if discover {
+            next_discovery = now + discovery_interval;
+        }
         tick(
             &store,
             &http,
@@ -119,6 +148,9 @@ pub async fn run(
             &verifier,
             &env_label,
             &cp_hostname,
+            discover,
+            shard_index,
+            shard_total,
         )
         .await;
     }
@@ -134,51 +166,34 @@ async fn tick(
     verifier: &Arc<ita::Verifier>,
     env_label: &str,
     cp_hostname: &str,
+    discover: bool,
+    shard_index: u64,
+    shard_total: u64,
 ) {
-    let tunnels: Vec<(String, String, String, Option<DateTime<Utc>>)> = cf::list(http, cf)
-        .await
-        .unwrap_or_default()
-        .into_iter()
-        .filter_map(|t| {
-            let name = t["name"].as_str()?;
-            let id = t["id"].as_str()?;
-            if !name.starts_with(prefix) {
-                return None;
-            }
-            let hostname = format!("{name}.{}", cf.domain);
-            let created_at = t["created_at"]
-                .as_str()
-                .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
-                .map(|dt| dt.with_timezone(&Utc));
-            Some((name.to_string(), id.to_string(), hostname, created_at))
-        })
-        .collect();
-
-    let known_hosts: std::collections::HashSet<String> = {
-        let s = store.lock().await;
-        s.values().map(|a| a.hostname.clone()).collect()
+    let mut targets = if discover {
+        discover_targets(store, http, cf, prefix).await
+    } else {
+        known_targets(store).await
     };
+    targets.retain(|t| should_scrape_key(&t.name, shard_index, shard_total));
 
     let now = Utc::now();
-    let scrapes = tunnels.iter().map(|(name, tunnel_id, host, created_at)| {
+    let scrapes = targets.iter().map(|target| {
         let http = http.clone();
-        let name = name.clone();
-        let tunnel_id = tunnel_id.clone();
-        let host = host.clone();
-        let created_at = *created_at;
-        let known = known_hosts.contains(&host);
+        let target = target.clone();
         async move {
-            if !known && unknown_tunnel_should_wait_for_registration(created_at, now) {
+            if !target.known && unknown_tunnel_should_wait_for_registration(target.created_at, now)
+            {
                 return (
-                    name,
-                    tunnel_id,
-                    host,
-                    created_at,
+                    target.name,
+                    target.tunnel_id,
+                    target.host,
+                    target.created_at,
                     None,
                     Some("fresh unknown tunnel pending registration".into()),
                 );
             }
-            let health_host = cf::agent_api_hostname(&host);
+            let health_host = cf::agent_api_hostname(&target.host);
             let r = http
                 .get(format!("https://{health_host}/health"))
                 .send()
@@ -186,21 +201,28 @@ async fn tick(
             match r {
                 Ok(resp) if resp.status().is_success() => {
                     let body = resp.json::<serde_json::Value>().await.ok();
-                    (name, tunnel_id, host, created_at, body, None)
+                    (
+                        target.name,
+                        target.tunnel_id,
+                        target.host,
+                        target.created_at,
+                        body,
+                        None,
+                    )
                 }
                 Ok(resp) => (
-                    name,
-                    tunnel_id,
-                    host,
-                    created_at,
+                    target.name,
+                    target.tunnel_id,
+                    target.host,
+                    target.created_at,
                     None,
                     Some(format!("status {}", resp.status())),
                 ),
                 Err(e) => (
-                    name,
-                    tunnel_id,
-                    host,
-                    created_at,
+                    target.name,
+                    target.tunnel_id,
+                    target.host,
+                    target.created_at,
                     None,
                     Some(format!("{e:?}")),
                 ),
@@ -340,10 +362,65 @@ async fn tick(
     drop(store_lock);
 
     eprintln!(
-        "cp: scraped {} tunnels ({verified} verified, {} orphans GC'd)",
+        "cp: scraped {} {} ({verified} verified, {} orphans GC'd)",
         results.len(),
+        if discover {
+            "discovered targets"
+        } else {
+            "known agents"
+        },
         orphans.len()
     );
+}
+
+async fn discover_targets(
+    store: &Store,
+    http: &reqwest::Client,
+    cf: &CfCreds,
+    prefix: &str,
+) -> Vec<ScrapeTarget> {
+    let known_hosts: std::collections::HashSet<String> = {
+        let s = store.lock().await;
+        s.values().map(|a| a.hostname.clone()).collect()
+    };
+    cf::list(http, cf)
+        .await
+        .unwrap_or_default()
+        .into_iter()
+        .filter_map(|t| {
+            let name = t["name"].as_str()?;
+            let id = t["id"].as_str()?;
+            if !name.starts_with(prefix) {
+                return None;
+            }
+            let hostname = format!("{name}.{}", cf.domain);
+            let created_at = t["created_at"]
+                .as_str()
+                .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
+                .map(|dt| dt.with_timezone(&Utc));
+            Some(ScrapeTarget {
+                name: name.to_string(),
+                tunnel_id: id.to_string(),
+                known: known_hosts.contains(&hostname),
+                host: hostname,
+                created_at,
+            })
+        })
+        .collect()
+}
+
+async fn known_targets(store: &Store) -> Vec<ScrapeTarget> {
+    let s = store.lock().await;
+    s.iter()
+        .filter(|(name, a)| name.as_str() != "control-plane" && !a.tunnel_id.is_empty())
+        .map(|(name, a)| ScrapeTarget {
+            name: name.clone(),
+            tunnel_id: a.tunnel_id.clone(),
+            host: a.hostname.clone(),
+            created_at: None,
+            known: true,
+        })
+        .collect()
 }
 
 fn parse_extra_ingress(h: &serde_json::Value) -> Option<Vec<(String, u16)>> {
@@ -427,6 +504,38 @@ fn unknown_tunnel_should_wait_for_registration(
     })
 }
 
+fn should_scrape_key(key: &str, shard_index: u64, shard_total: u64) -> bool {
+    if shard_total <= 1 {
+        return true;
+    }
+    rendezvous_shard(key, shard_total) == shard_index
+}
+
+fn rendezvous_shard(key: &str, shard_total: u64) -> u64 {
+    let mut best_shard = 0;
+    let mut best_score = 0;
+    for shard in 0..shard_total.max(1) {
+        let mut bytes = Vec::with_capacity(key.len() + 8);
+        bytes.extend_from_slice(key.as_bytes());
+        bytes.extend_from_slice(&shard.to_le_bytes());
+        let score = fnv1a64(&bytes);
+        if shard == 0 || score > best_score {
+            best_score = score;
+            best_shard = shard;
+        }
+    }
+    best_shard
+}
+
+fn fnv1a64(bytes: &[u8]) -> u64 {
+    let mut hash = 0xcbf29ce484222325u64;
+    for byte in bytes {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    hash
+}
+
 fn scrape_failure_is_dead_signal(err: &Option<String>) -> bool {
     let Some(err) = err.as_deref() else {
         return false;
@@ -448,8 +557,8 @@ mod tests {
     use chrono::{Duration, Utc};
 
     use super::{
-        parse_extra_ingress, scrape_failure_is_dead_signal, unknown_tunnel_is_gc_candidate,
-        unknown_tunnel_should_wait_for_registration,
+        parse_extra_ingress, rendezvous_shard, scrape_failure_is_dead_signal, should_scrape_key,
+        unknown_tunnel_is_gc_candidate, unknown_tunnel_should_wait_for_registration,
     };
 
     #[test]
@@ -554,5 +663,22 @@ mod tests {
             now
         ));
         assert!(!unknown_tunnel_should_wait_for_registration(None, now));
+    }
+
+    #[test]
+    fn rendezvous_shards_assign_each_key_once() {
+        for key in ["agent-a", "agent-b", "agent-c", "agent-d"] {
+            let assigned = (0..4)
+                .filter(|idx| should_scrape_key(key, *idx, 4))
+                .collect::<Vec<_>>();
+            assert_eq!(assigned.len(), 1);
+            assert_eq!(assigned[0], rendezvous_shard(key, 4));
+        }
+    }
+
+    #[test]
+    fn single_shard_scrapes_every_key() {
+        assert!(should_scrape_key("agent-a", 0, 1));
+        assert!(should_scrape_key("agent-a", 7, 0));
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -164,6 +164,9 @@ pub struct Cp {
     pub auth: crate::auth::AuthConfig,
     pub hostname: String,
     pub scrape_interval_secs: u64,
+    pub discovery_interval_secs: u64,
+    pub scraper_shard_index: u64,
+    pub scraper_shard_total: u64,
     pub ita: Ita,
     /// Source-of-truth file for the device registry (JSON). Survives
     /// CP restart; mutations fsync through to disk.
@@ -183,7 +186,27 @@ impl Cp {
         let scrape_interval_secs = std::env::var("DD_SCRAPE_INTERVAL")
             .ok()
             .and_then(|s| s.parse().ok())
-            .unwrap_or(30);
+            .unwrap_or(5)
+            .max(1);
+        let discovery_interval_secs = std::env::var("DD_DISCOVERY_INTERVAL")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(30)
+            .max(scrape_interval_secs);
+        let scraper_shard_total = std::env::var("DD_SCRAPER_SHARD_TOTAL")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(1)
+            .max(1);
+        let scraper_shard_index = std::env::var("DD_SCRAPER_SHARD_INDEX")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(0);
+        if scraper_shard_index >= scraper_shard_total {
+            return Err(Error::Internal(format!(
+                "DD_SCRAPER_SHARD_INDEX ({scraper_shard_index}) must be less than DD_SCRAPER_SHARD_TOTAL ({scraper_shard_total})"
+            )));
+        }
         // `/tmp/` (tmpfs) is the only universally-writable path in the
         // EE workload sandbox — the root FS is RO, and `/var/lib/` +
         // `/data/` are both unavailable on the CP VM (no mount-data
@@ -205,6 +228,9 @@ impl Cp {
             auth,
             hostname,
             scrape_interval_secs,
+            discovery_interval_secs,
+            scraper_shard_index,
+            scraper_shard_total,
             ita,
             devices_path,
             noise_key_path,

--- a/src/cp.rs
+++ b/src/cp.rs
@@ -18,7 +18,7 @@ use axum::response::{Html, IntoResponse, Response};
 use axum::routing::{get, post};
 use axum::{Json, Router};
 use serde::Deserialize;
-use tokio::sync::{Mutex, RwLock};
+use tokio::sync::{Mutex, Notify, RwLock};
 
 use crate::cf;
 use crate::collector::{self, Store};
@@ -46,6 +46,7 @@ struct St {
     cfg: Arc<Cfg>,
     ee: Arc<Ee>,
     store: Store,
+    collector_wake: Arc<Notify>,
     started: Instant,
     verifier: Arc<ita::Verifier>,
     /// The CP's own ITA token. Refreshed by a background task.
@@ -318,6 +319,7 @@ pub async fn run() -> Result<()> {
     // Start the collector with the verifier. It re-verifies each
     // scraped agent's ita_token, so expired / revoked / unsigned
     // agents drop off the dashboard automatically.
+    let collector_wake = Arc::new(Notify::new());
     tokio::spawn(collector::run(
         store.clone(),
         cfg.cf.clone(),
@@ -325,7 +327,11 @@ pub async fn run() -> Result<()> {
         cfg.hostname.clone(),
         ee.clone(),
         verifier.clone(),
+        collector_wake.clone(),
         Duration::from_secs(cfg.scrape_interval_secs),
+        Duration::from_secs(cfg.discovery_interval_secs),
+        cfg.scraper_shard_index,
+        cfg.scraper_shard_total,
     ));
 
     let gh = crate::gh_oidc::Verifier::new(cfg.common.owner.clone(), "dd-agent".into());
@@ -353,6 +359,7 @@ pub async fn run() -> Result<()> {
         cfg: cfg.clone(),
         ee,
         store,
+        collector_wake,
         started: Instant::now(),
         verifier,
         cp_ita_token,
@@ -660,6 +667,7 @@ async fn register(
     }
 
     eprintln!("cp: registered {} as {}", req.vm_name, agent_hostname);
+    s.collector_wake.notify_one();
 
     Ok(Json(serde_json::json!({
         "tunnel_token": tunnel.token,
@@ -751,6 +759,7 @@ async fn ingress_replace(
     }
 
     eprintln!("cp: ingress/replace {} → {:?}", req.agent_id, hostnames);
+    s.collector_wake.notify_one();
     Ok(Json(serde_json::json!({
         "agent_id": req.agent_id,
         "extra_hostnames": hostnames,

--- a/src/cp.rs
+++ b/src/cp.rs
@@ -201,14 +201,13 @@ pub async fn run() -> Result<()> {
         shutdown_tx.clone(),
     ));
 
-    // Stage 4: provision Cloudflare self-hosted apps as bypass routing
-    // objects for our tunnel. DD owns browser and machine auth in-code.
-    // `/health` also carries the Noise pre-handshake quote + pubkey
-    // (the former `/attest`, now inlined to save a bootstrap round-trip).
+    // Stage 4: delete legacy Cloudflare Access apps for our published
+    // hosts/paths. DD owns browser and machine auth in-code; Cloudflare
+    // should only provide DNS + tunnel ingress.
     let cp_labels: Vec<String> = cp_extras.iter().map(|(l, _)| l.clone()).collect();
-    let mut routing_ready = false;
+    let mut access_cleanup_ready = false;
     for attempt in 1..=5 {
-        match cf::provision_cp_routing(
+        match cf::delete_cp_access_apps(
             &http,
             &cfg.cf,
             &cfg.common.env_label,
@@ -218,20 +217,20 @@ pub async fn run() -> Result<()> {
         .await
         {
             Ok(()) => {
-                routing_ready = true;
+                access_cleanup_ready = true;
                 break;
             }
             Err(e) => {
-                eprintln!("cp: Cloudflare app provisioning attempt {attempt}/5 failed: {e}");
+                eprintln!("cp: Cloudflare Access cleanup attempt {attempt}/5 failed: {e}");
                 tokio::time::sleep(Duration::from_secs(5 * attempt)).await;
             }
         }
     }
-    if !routing_ready {
-        eprintln!("cp: Cloudflare app provisioning failed after retries");
+    if !access_cleanup_ready {
+        eprintln!("cp: Cloudflare Access cleanup failed after retries");
         stonith::poweroff();
     }
-    eprintln!("cp: Cloudflare routing apps ready");
+    eprintln!("cp: Cloudflare Access cleanup complete");
     let cp_ita_token = Arc::new(RwLock::new(initial_token));
 
     // Seed the CP into the store before the collector starts ticking.
@@ -565,8 +564,8 @@ struct ExtraIngress {
 }
 
 /// POST /register — ITA attestation is the gate. We verify the
-/// agent's Intel-signed quote, create its tunnel, provision its
-/// Cloudflare routing apps, and return the tunnel token. `owner` / `env_label`
+/// agent's Intel-signed quote, create its tunnel, remove legacy
+/// Cloudflare Access apps, and return the tunnel token. `owner` / `env_label`
 /// used to be in the body for double-check; they're implicit now —
 /// the CP authoritatively owns them from its config and the ITA
 /// token authenticates the agent regardless.
@@ -601,7 +600,7 @@ async fn register(
     }
 
     let labels: Vec<String> = tunnel_extras.iter().map(|(l, _)| l.clone()).collect();
-    if let Err(e) = cf::provision_agent_routing(
+    if let Err(e) = cf::delete_agent_access_apps(
         &http,
         &s.cfg.cf,
         &s.cfg.common.env_label,
@@ -610,7 +609,7 @@ async fn register(
     )
     .await
     {
-        eprintln!("cp: provision_agent_routing {agent_hostname} failed: {e}");
+        eprintln!("cp: delete_agent_access_apps {agent_hostname} failed: {e}");
     }
 
     // Seed the store so the dashboard shows the agent before the first
@@ -698,8 +697,7 @@ struct IngressPair {
 /// POST /ingress/replace — authenticated by the same Intel ITA token
 /// the agent already refreshes for /health. The agent forwards its
 /// full current ingress list; the CP re-PUTs the tunnel config +
-/// CNAMEs and reconciles per-workload Cloudflare routing apps (creates
-/// new, deletes stale).
+/// CNAMEs and removes legacy Cloudflare Access apps for those hosts.
 async fn ingress_replace(
     State(s): State<St>,
     Json(req): Json<IngressReplaceReq>,
@@ -733,7 +731,7 @@ async fn ingress_replace(
         cf::update_ingress(&http, &s.cfg.cf, &tunnel_id, &hostname, &tunnel_extras).await?;
 
     let labels: Vec<String> = tunnel_extras.iter().map(|(l, _)| l.clone()).collect();
-    if let Err(e) = cf::provision_agent_routing(
+    if let Err(e) = cf::delete_agent_access_apps(
         &http,
         &s.cfg.cf,
         &s.cfg.common.env_label,
@@ -742,7 +740,7 @@ async fn ingress_replace(
     )
     .await
     {
-        eprintln!("cp: provision_agent_routing on /ingress/replace failed: {e}");
+        eprintln!("cp: delete_agent_access_apps on /ingress/replace failed: {e}");
     }
 
     {
@@ -987,9 +985,9 @@ async fn fleet(State(s): State<St>, headers: HeaderMap, uri: Uri) -> Response {
 // ── Devices API ─────────────────────────────────────────────────────────
 //
 // Paired client-device X25519 pubkeys that the local Noise gateway
-// accepts during the handshake. POST + DELETE are behind the CP's
-// human DD browser-auth app (admin enrollment); the machine-readable
-// `/trusted` view is edge-bypassed for cross-VM agent polls.
+// accepts during the handshake. POST + DELETE are behind DD browser
+// auth (admin enrollment); the machine-readable `/trusted` view is
+// gated in-code for cross-VM agent polls.
 
 /// GET /api/v1/admin/export — full state snapshot for a successor CP
 /// to hydrate from during a zero-downtime deploy. Returns the

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -1387,6 +1387,18 @@ main { max-width:none; padding:0; height:100dvh; display:grid; grid-template-col
 .pill { border:1px solid #2b3242; border-radius:999px; padding:2px 7px; color:#8791a5; font-size:11px; }
 .pill.ok { color:#9ece6a; border-color:#334b35; }
 .pill.bad { color:#f7768e; border-color:#57323d; }
+.notify-feed { display:flex; flex-direction:column; gap:8px; margin-top:8px; }
+.notify-item { background:#171c29; border:1px solid #2b3242; border-radius:6px; padding:9px 10px; min-width:0; }
+.notify-item .notify-title { display:flex; align-items:center; justify-content:space-between; gap:8px; font-size:12px; font-weight:700; }
+.notify-item .notify-time { color:#8791a5; font-size:10px; font-weight:400; white-space:nowrap; }
+.notify-item .notify-body { margin-top:3px; color:#8791a5; font-size:11px; line-height:1.4; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+.notify-badge { display:none; min-width:18px; height:18px; border-radius:999px; background:#7aa2f7; color:#05070a; font-size:11px; font-weight:800; align-items:center; justify-content:center; padding:0 5px; }
+.notify-badge.active { display:inline-flex; }
+.toast-stack { position:fixed; top:60px; right:14px; z-index:50; display:flex; flex-direction:column; gap:8px; width:min(340px, calc(100vw - 28px)); pointer-events:none; }
+.toast { background:#171c29; border:1px solid #3a4256; box-shadow:0 12px 30px #0008; border-radius:7px; padding:10px 12px; opacity:0; transform:translateY(-8px); transition:opacity .14s ease, transform .14s ease; }
+.toast.show { opacity:1; transform:translateY(0); }
+.toast .notify-title { font-size:12px; font-weight:800; }
+.toast .notify-body { margin-top:3px; color:#d7deea; font-size:12px; line-height:1.35; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
 .filter { width:100%; margin-top:10px; box-sizing:border-box; background:#0b0d12; color:#d7deea; border:1px solid #2b3242; border-radius:6px; padding:9px 10px; font:inherit; font-size:13px; }
 .filter:focus { outline:1px solid #7aa2f7; border-color:#7aa2f7; }
 .empty-mini { color:#8791a5; font-size:12px; padding:8px 2px; }
@@ -1414,6 +1426,7 @@ button.secondary { background:#252a36; color:#d7deea; }
   .mobile-tabs { position:fixed; left:0; right:0; bottom:0; z-index:30; display:grid; grid-template-columns:repeat(4,1fr); height:52px; padding-bottom:env(safe-area-inset-bottom); background:#111520; border-top:1px solid #252a36; }
   .mobile-tabs button { border:0; border-right:1px solid #252a36; border-radius:0; background:#111520; color:#8791a5; font-size:12px; padding:8px 4px; }
   .mobile-tabs button.active { color:#d7deea; background:#171c29; }
+  .toast-stack { top:52px; right:8px; width:calc(100vw - 16px); }
 }
 </style>
 <div class="sidebar">
@@ -1428,6 +1441,8 @@ button.secondary { background:#252a36; color:#d7deea; }
       <div class="panel active" data-panel="system">
         <div class="group-title">System</div>
         <div class="system" id="system"></div>
+        <div class="group-title">Notifications</div>
+        <div class="notify-feed" id="notify-feed"></div>
       </div>
       <div class="panel" data-panel="recipes">
         <div class="group-title">New session</div>
@@ -1454,10 +1469,12 @@ button.secondary { background:#252a36; color:#d7deea; }
     <button class="secondary" id="close">Close session</button>
     <button class="secondary" id="notify" title="Enable notifications">Notify</button>
     <button class="secondary" id="notify-test" title="Send a test notification">Test</button>
+    <span class="notify-badge" id="notify-badge">0</span>
     <span class="status" id="status">No session</span>
   </div>
   <div class="term" id="terminal"></div>
 </div>
+<div class="toast-stack" id="toast-stack"></div>
 <div class="mobile-tabs" id="mobile-tabs">
   <button data-panel="system" class="active">System</button>
   <button data-panel="recipes">New</button>
@@ -1503,6 +1520,8 @@ let oscBuffer = "";
 let cachedRecipes = [];
 let cachedWorkloads = [];
 let activePanel = "system";
+let notifications = loadNotificationHistory();
+let unreadNotifications = 0;
 const decoder = new TextDecoder();
 
 async function api(path, opts) {
@@ -1520,6 +1539,7 @@ async function refresh() {
     api("/api/workloads").catch(() => [])
   ]);
   renderSystem(system);
+  renderNotificationFeed();
   cachedRecipes = recipes;
   renderRecipes();
   cachedWorkloads = workloads;
@@ -1629,8 +1649,26 @@ function notificationHtml() {
   const supported = "Notification" in window;
   const permission = supported ? Notification.permission : "unavailable";
   const enabled = supported && permission === "granted" && notifyMode !== "off";
-  const detail = supported ? `${permission}, mode ${notifyMode}` : "browser does not expose Notification API";
-  return `<div class="probe"><div class="row"><span class="name">Notifications</span><span class="pill ${enabled ? "ok" : "bad"}">${enabled ? "enabled" : "off"}</span></div><div class="meta">${escapeHtml(detail)}</div></div>`;
+  const detail = supported ? `native ${permission}; in-app history on` : "in-app history on; native unavailable";
+  return `<div class="probe"><div class="row"><span class="name">Notifications</span><span class="pill ${enabled ? "ok" : "bad"}">${enabled ? "native" : "in-app"}</span></div><div class="meta">${escapeHtml(detail)}</div></div>`;
+}
+
+function renderNotificationFeed() {
+  const root = document.getElementById("notify-feed");
+  const badge = document.getElementById("notify-badge");
+  if (!root || !badge) return;
+  badge.textContent = unreadNotifications > 99 ? "99+" : String(unreadNotifications);
+  badge.classList.toggle("active", unreadNotifications > 0);
+  if (!notifications.length) {
+    root.innerHTML = `<div class="empty-mini">No notifications yet</div>`;
+    return;
+  }
+  root.innerHTML = notifications.slice(0, 12).map(n => `
+    <div class="notify-item">
+      <div class="notify-title"><span>${escapeHtml(n.title || "Shell")}</span><span class="notify-time">${escapeHtml(formatClock(n.ts))}</span></div>
+      <div class="notify-body">${escapeHtml(n.body || "")}</div>
+    </div>
+  `).join("");
 }
 
 function probeHtml(name, probe) {
@@ -1780,11 +1818,7 @@ document.getElementById("notify").onclick = async () => {
   }
 };
 document.getElementById("notify-test").onclick = async () => {
-  if (!("Notification" in window)) {
-    document.getElementById("status").textContent = "Notifications unavailable";
-    return;
-  }
-  if (Notification.permission !== "granted") {
+  if ("Notification" in window && Notification.permission !== "granted") {
     await document.getElementById("notify").onclick();
   }
   notify("DD Shell", "notification test");
@@ -1794,6 +1828,10 @@ function setPanel(panel) {
   activePanel = panel || "system";
   document.querySelectorAll(".panel").forEach(el => el.classList.toggle("active", el.dataset.panel === activePanel));
   document.querySelectorAll("#mobile-tabs button").forEach(el => el.classList.toggle("active", el.dataset.panel === activePanel));
+  if (activePanel === "system") {
+    unreadNotifications = 0;
+    renderNotificationFeed();
+  }
 }
 
 function openPanels(panel) {
@@ -1898,6 +1936,17 @@ function scanNotifications(data) {
   if (oscBuffer.length > 8192) oscBuffer = oscBuffer.slice(-1024);
 }
 function notify(title, body) {
+  const item = {
+    title: title || "Shell",
+    body: body || "",
+    ts: Date.now()
+  };
+  notifications.unshift(item);
+  notifications = notifications.slice(0, 50);
+  saveNotificationHistory();
+  if (activePanel !== "system") unreadNotifications++;
+  renderNotificationFeed();
+  showToast(item);
   if (!("Notification" in window) || Notification.permission !== "granted") return;
   if (notifyMode !== "always" && document.hasFocus()) return;
   const n = new Notification(title || "Shell", {
@@ -1909,6 +1958,37 @@ function notify(title, body) {
     term.focus();
     n.close();
   };
+}
+function loadNotificationHistory() {
+  try {
+    const parsed = JSON.parse(localStorage.getItem("dd-shell-notifications") || "[]");
+    return Array.isArray(parsed) ? parsed.slice(0, 50) : [];
+  } catch (_) {
+    return [];
+  }
+}
+function saveNotificationHistory() {
+  localStorage.setItem("dd-shell-notifications", JSON.stringify(notifications.slice(0, 50)));
+}
+function showToast(item) {
+  const stack = document.getElementById("toast-stack");
+  if (!stack) return;
+  const el = document.createElement("div");
+  el.className = "toast";
+  el.innerHTML = `<div class="notify-title">${escapeHtml(item.title || "Shell")}</div><div class="notify-body">${escapeHtml(item.body || "")}</div>`;
+  stack.prepend(el);
+  requestAnimationFrame(() => el.classList.add("show"));
+  setTimeout(() => {
+    el.classList.remove("show");
+    setTimeout(() => el.remove(), 180);
+  }, 4200);
+}
+function formatClock(ts) {
+  try {
+    return new Date(ts).toLocaleTimeString([], {hour:"2-digit", minute:"2-digit"});
+  } catch (_) {
+    return "";
+  }
 }
 function formatBytes(value) {
   const n = Number(value || 0);

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -1349,29 +1349,37 @@ const XTERM_FIT_JS: &str = include_str!("../assets/xterm/addon-fit.js");
 const SHELL_HTML: &str = r##"
 <link rel="stylesheet" href="/assets/xterm/xterm.css">
 <style>
-body { background:#0b0d12; color:#d7deea; }
-main { max-width:none; padding:0; height:100vh; display:grid; grid-template-columns:280px 1fr; }
+body { background:#0b0d12; color:#d7deea; overflow:hidden; }
+main { max-width:none; padding:0; height:100dvh; display:grid; grid-template-columns:320px 1fr; }
 .sidebar { border-right:1px solid #252a36; background:#111520; overflow:auto; min-height:0; }
 .sidebar-top { position:sticky; top:0; z-index:5; background:#111520; padding:16px 16px 12px; border-bottom:1px solid #252a36; }
 .sidebar-scroll { padding:0 16px 16px; }
-.terminal-wrap { height:100vh; display:flex; flex-direction:column; min-width:0; }
+.terminal-wrap { height:100dvh; display:flex; flex-direction:column; min-width:0; }
 .toolbar { height:48px; border-bottom:1px solid #252a36; display:flex; align-items:center; gap:8px; padding:0 12px; background:#111520; }
 .term { flex:1; min-height:0; background:#05070a; overflow:hidden; padding:8px; }
 .term .xterm { height:100%; }
 .term .xterm-viewport { background:#05070a !important; }
 .groups { display:flex; flex-direction:column; gap:18px; }
 .group-title { position:sticky; top:126px; z-index:4; color:#8791a5; font-size:11px; font-weight:700; letter-spacing:0; text-transform:uppercase; margin:0 -16px 8px; padding:8px 16px; background:#111520; border-bottom:1px solid #202634; }
-.sessions, .recipes { display:flex; flex-direction:column; gap:8px; }
-.session, .recipe { text-align:left; color:#d7deea; background:#171c29; border:1px solid #2b3242; border-radius:6px; padding:10px; cursor:pointer; }
+.sessions { display:flex; flex-direction:column; gap:8px; }
+.session { text-align:left; color:#d7deea; background:#171c29; border:1px solid #2b3242; border-radius:6px; padding:10px; cursor:pointer; }
 .session.active { border-color:#7aa2f7; }
-.session .name, .recipe .name { font-weight:700; font-size:13px; }
-.session .meta, .recipe .meta { margin:3px 0 0; font-size:11px; color:#8791a5; }
+.session .name { font-weight:700; font-size:13px; }
+.session .meta { margin:3px 0 0; font-size:11px; color:#8791a5; }
 .session.readonly { background:#131720; border-style:dashed; }
+.recipe-launcher { display:grid; grid-template-columns:1fr auto; gap:8px; }
+.recipe-select { min-width:0; background:#0b0d12; color:#d7deea; border:1px solid #2b3242; border-radius:6px; padding:9px 10px; font:inherit; font-size:13px; }
+.recipe-summary { margin-top:8px; color:#8791a5; font-size:11px; line-height:1.4; }
 .badges { display:flex; flex-wrap:wrap; gap:5px; margin-top:7px; }
 .badge { border:1px solid #2b3242; border-radius:999px; padding:1px 6px; color:#8791a5; font-size:10px; }
 .badge.ok { color:#9ece6a; border-color:#334b35; }
 .badge.bad { color:#f7768e; border-color:#57323d; }
 .system { display:flex; flex-direction:column; gap:8px; }
+.metrics { display:grid; grid-template-columns:1fr 1fr; gap:8px; }
+.metric { background:#171c29; border:1px solid #2b3242; border-radius:6px; padding:10px; min-width:0; }
+.metric .label { color:#8791a5; font-size:10px; text-transform:uppercase; }
+.metric .value { margin-top:3px; font-size:16px; font-weight:700; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+.metric .subvalue { margin-top:2px; color:#8791a5; font-size:11px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
 .probe { color:#d7deea; background:#171c29; border:1px solid #2b3242; border-radius:6px; padding:10px; }
 .probe .row { display:flex; align-items:center; justify-content:space-between; gap:8px; }
 .probe .name { font-weight:700; font-size:13px; }
@@ -1384,29 +1392,56 @@ main { max-width:none; padding:0; height:100vh; display:grid; grid-template-colu
 .empty-mini { color:#8791a5; font-size:12px; padding:8px 2px; }
 .status { color:#8791a5; font-size:12px; margin-left:auto; }
 button.secondary { background:#252a36; color:#d7deea; }
-@media (max-width:760px) { main { grid-template-columns:1fr; grid-template-rows:240px 1fr; } .sidebar { height:240px; border-right:0; border-bottom:1px solid #252a36; } .group-title { top:126px; } .terminal-wrap { height:calc(100vh - 240px); } }
+.mobile-tabs { display:none; }
+.panel { display:block; }
+.panel-close { display:none; }
+@media (max-width:860px) {
+  main { display:block; height:100dvh; }
+  .terminal-wrap { height:calc(100dvh - 52px); padding-bottom:env(safe-area-inset-bottom); }
+  .toolbar { height:44px; padding:0 8px; gap:6px; }
+  .toolbar button { padding:8px 10px; font-size:12px; }
+  .status { font-size:11px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+  .term { padding:4px; }
+  .sidebar { position:fixed; left:0; right:0; bottom:52px; z-index:20; height:min(64dvh,520px); border-right:0; border-top:1px solid #252a36; border-radius:10px 10px 0 0; transform:translateY(105%); transition:transform .16s ease; box-shadow:0 -16px 40px #0008; }
+  .sidebar.open { transform:translateY(0); }
+  .sidebar-top { padding:12px 14px; }
+  .sidebar-scroll { padding:0 14px 14px; }
+  .groups { gap:0; }
+  .panel { display:none; }
+  .panel.active { display:block; }
+  .group-title { position:static; margin:0 -14px 10px; padding:10px 14px; }
+  .panel-close { display:inline-flex; position:absolute; top:10px; right:12px; padding:7px 10px; }
+  .mobile-tabs { position:fixed; left:0; right:0; bottom:0; z-index:30; display:grid; grid-template-columns:repeat(4,1fr); height:52px; padding-bottom:env(safe-area-inset-bottom); background:#111520; border-top:1px solid #252a36; }
+  .mobile-tabs button { border:0; border-right:1px solid #252a36; border-radius:0; background:#111520; color:#8791a5; font-size:12px; padding:8px 4px; }
+  .mobile-tabs button.active { color:#d7deea; background:#171c29; }
+}
 </style>
 <div class="sidebar">
   <div class="sidebar-top">
     <h1>Shell</h1>
     <div class="sub">Observed logs and controlled PTYs</div>
+    <button class="secondary panel-close" id="panel-close">Done</button>
     <input class="filter" id="workload-filter" type="search" placeholder="Filter workloads">
   </div>
   <div class="sidebar-scroll">
     <div class="groups">
-      <div>
+      <div class="panel active" data-panel="system">
         <div class="group-title">System</div>
         <div class="system" id="system"></div>
       </div>
-      <div>
-        <div class="group-title">Recipes</div>
-        <div class="recipes" id="recipes"></div>
+      <div class="panel" data-panel="recipes">
+        <div class="group-title">New session</div>
+        <div class="recipe-launcher">
+          <select class="recipe-select" id="recipe-select"></select>
+          <button class="secondary" id="launch-recipe">Start</button>
+        </div>
+        <div class="recipe-summary" id="recipe-summary"></div>
       </div>
-      <div>
+      <div class="panel" data-panel="sessions">
         <div class="group-title">Read-write sessions</div>
         <div class="sessions" id="sessions"></div>
       </div>
-      <div>
+      <div class="panel" data-panel="workloads">
         <div class="group-title">Read-only workloads</div>
         <div class="sessions" id="workloads"></div>
       </div>
@@ -1415,11 +1450,19 @@ button.secondary { background:#252a36; color:#d7deea; }
 </div>
 <div class="terminal-wrap">
   <div class="toolbar">
+    <button class="secondary" id="panels">Panels</button>
     <button class="secondary" id="close">Close session</button>
-    <button class="secondary" id="notify" title="Enable desktop notifications">Notify</button>
+    <button class="secondary" id="notify" title="Enable notifications">Notify</button>
+    <button class="secondary" id="notify-test" title="Send a test notification">Test</button>
     <span class="status" id="status">No session</span>
   </div>
   <div class="term" id="terminal"></div>
+</div>
+<div class="mobile-tabs" id="mobile-tabs">
+  <button data-panel="system" class="active">System</button>
+  <button data-panel="recipes">New</button>
+  <button data-panel="sessions">Sessions</button>
+  <button data-panel="workloads">Logs</button>
 </div>
 <script src="/assets/xterm/xterm.js"></script>
 <script src="/assets/xterm/addon-fit.js"></script>
@@ -1459,6 +1502,7 @@ let notifyMode = localStorage.getItem("dd-shell-notify") || "always";
 let oscBuffer = "";
 let cachedRecipes = [];
 let cachedWorkloads = [];
+let activePanel = "system";
 const decoder = new TextDecoder();
 
 async function api(path, opts) {
@@ -1493,19 +1537,33 @@ async function refresh() {
 }
 
 function renderRecipes() {
-  const root = document.getElementById("recipes");
-  root.innerHTML = "";
+  const select = document.getElementById("recipe-select");
+  const summary = document.getElementById("recipe-summary");
+  const selected = select.value;
+  select.innerHTML = "";
   if (!cachedRecipes.length) {
-    root.innerHTML = `<div class="empty-mini">No recipes</div>`;
+    select.innerHTML = `<option value="">No recipes</option>`;
+    select.disabled = true;
+    document.getElementById("launch-recipe").disabled = true;
+    summary.textContent = "";
     return;
   }
+  select.disabled = false;
+  document.getElementById("launch-recipe").disabled = false;
   cachedRecipes.forEach(recipe => {
-    const el = document.createElement("button");
-    el.className = "recipe";
-    el.innerHTML = `<div class="name">${escapeHtml(recipe.title || recipe.id)}</div><div class="meta">${escapeHtml(recipe.description || recipe.command || "")}</div>`;
-    el.onclick = () => createSession(recipe.id);
-    root.appendChild(el);
+    const option = document.createElement("option");
+    option.value = recipe.id;
+    option.textContent = recipe.title || recipe.id;
+    select.appendChild(option);
   });
+  if (selected && cachedRecipes.some(r => r.id === selected)) select.value = selected;
+  renderRecipeSummary();
+}
+
+function renderRecipeSummary() {
+  const select = document.getElementById("recipe-select");
+  const recipe = cachedRecipes.find(r => r.id === select.value);
+  document.getElementById("recipe-summary").textContent = recipe ? (recipe.description || recipe.command || recipe.id) : "";
 }
 
 function renderWorkloads() {
@@ -1539,9 +1597,40 @@ function renderSystem(system) {
     return;
   }
   root.innerHTML = [
+    metricsHtml(system.agent && system.agent.data),
+    notificationHtml(),
     probeHtml("EasyEnclave", system.ee),
     probeHtml("Agent API", system.agent)
   ].join("");
+}
+
+function metricsHtml(data) {
+  if (!data) return "";
+  const cpu = data.cpu_percent ?? data.cpu_pct;
+  const memUsed = data.memory_used_mb ?? data.mem_used_mb;
+  const memTotal = data.memory_total_mb ?? data.mem_total_mb;
+  const uptime = data.system_uptime_secs ?? data.uptime_secs;
+  const load = data.load_1m;
+  const disks = Array.isArray(data.disks) ? data.disks : [];
+  const disk = disks.find(d => d.mount === "/var/lib/easyenclave/data") || disks.find(d => d.mount === "/") || disks[0];
+  return `<div class="metrics">
+    ${metricHtml("CPU", cpu === undefined ? "unknown" : `${cpu}%`, load === undefined ? "load unknown" : `load ${Number(load).toFixed(2)}`)}
+    ${metricHtml("Memory", memUsed === undefined || memTotal === undefined ? "unknown" : `${memUsed}/${memTotal} MB`, memTotal ? `${Math.round((memUsed / memTotal) * 100)}% used` : "")}
+    ${metricHtml("Disk", disk ? `${formatBytes(disk.used_bytes)} / ${formatBytes(disk.total_bytes)}` : "unknown", disk ? disk.mount : "no disk data")}
+    ${metricHtml("Uptime", uptime === undefined ? "unknown" : formatDuration(uptime), data.vm_name || "agent")}
+  </div>`;
+}
+
+function metricHtml(label, value, subvalue) {
+  return `<div class="metric"><div class="label">${escapeHtml(label)}</div><div class="value">${escapeHtml(value)}</div><div class="subvalue">${escapeHtml(subvalue || "")}</div></div>`;
+}
+
+function notificationHtml() {
+  const supported = "Notification" in window;
+  const permission = supported ? Notification.permission : "unavailable";
+  const enabled = supported && permission === "granted" && notifyMode !== "off";
+  const detail = supported ? `${permission}, mode ${notifyMode}` : "browser does not expose Notification API";
+  return `<div class="probe"><div class="row"><span class="name">Notifications</span><span class="pill ${enabled ? "ok" : "bad"}">${enabled ? "enabled" : "off"}</span></div><div class="meta">${escapeHtml(detail)}</div></div>`;
 }
 
 function probeHtml(name, probe) {
@@ -1569,6 +1658,7 @@ async function createSession(recipeId) {
   const body = recipeId ? {recipe_id: recipeId} : {};
   const r = await api("/api/sessions", {method:"POST", headers:{"content-type":"application/json"}, body:JSON.stringify(body)});
   await refresh();
+  closePanels();
   attach(r.id);
 }
 
@@ -1606,6 +1696,7 @@ async function attach(id) {
   };
   ws.onclose = () => document.getElementById("status").textContent = "Detached";
   refresh();
+  closePanels();
   setTimeout(() => term.focus(), 0);
 }
 
@@ -1616,6 +1707,7 @@ async function attachWorkload(name) {
   current = name;
   currentKind = "workload";
   await loadWorkload(name);
+  closePanels();
   workloadTimer = setInterval(() => loadWorkload(name), 2000);
 }
 
@@ -1650,6 +1742,19 @@ term.onData(data => {
 });
 
 document.getElementById("workload-filter").oninput = renderWorkloads;
+document.getElementById("recipe-select").onchange = renderRecipeSummary;
+document.getElementById("launch-recipe").onclick = () => {
+  const id = document.getElementById("recipe-select").value;
+  if (id) createSession(id);
+};
+document.getElementById("panels").onclick = () => openPanels(activePanel);
+document.getElementById("panel-close").onclick = closePanels;
+document.querySelectorAll("#mobile-tabs button").forEach(btn => {
+  btn.onclick = () => {
+    setPanel(btn.dataset.panel);
+    openPanels(btn.dataset.panel);
+  };
+});
 document.getElementById("close").onclick = async () => {
   if (!current || currentKind !== "session") return;
   await api(`/api/sessions/${current}/close`, {method:"POST"});
@@ -1666,12 +1771,40 @@ document.getElementById("notify").onclick = async () => {
     notifyMode = "always";
     localStorage.setItem("dd-shell-notify", notifyMode);
     document.getElementById("status").textContent = "Notifications enabled";
+    renderSystem(await api("/api/system").catch(() => null));
   } else {
     notifyMode = "off";
     localStorage.setItem("dd-shell-notify", notifyMode);
     document.getElementById("status").textContent = "Notifications blocked";
+    renderSystem(await api("/api/system").catch(() => null));
   }
 };
+document.getElementById("notify-test").onclick = async () => {
+  if (!("Notification" in window)) {
+    document.getElementById("status").textContent = "Notifications unavailable";
+    return;
+  }
+  if (Notification.permission !== "granted") {
+    await document.getElementById("notify").onclick();
+  }
+  notify("DD Shell", "notification test");
+};
+
+function setPanel(panel) {
+  activePanel = panel || "system";
+  document.querySelectorAll(".panel").forEach(el => el.classList.toggle("active", el.dataset.panel === activePanel));
+  document.querySelectorAll("#mobile-tabs button").forEach(el => el.classList.toggle("active", el.dataset.panel === activePanel));
+}
+
+function openPanels(panel) {
+  setPanel(panel || activePanel);
+  document.querySelector(".sidebar").classList.add("open");
+}
+
+function closePanels() {
+  document.querySelector(".sidebar").classList.remove("open");
+}
+
 function base64Bytes(value) {
   const raw = atob(value);
   const bytes = new Uint8Array(raw.length);
@@ -1777,12 +1910,31 @@ function notify(title, body) {
     n.close();
   };
 }
+function formatBytes(value) {
+  const n = Number(value || 0);
+  if (n < 1024) return `${n} B`;
+  const units = ["KB", "MB", "GB", "TB"];
+  let v = n / 1024;
+  let i = 0;
+  while (v >= 1024 && i < units.length - 1) { v /= 1024; i++; }
+  return `${v >= 10 ? v.toFixed(0) : v.toFixed(1)} ${units[i]}`;
+}
+function formatDuration(value) {
+  let s = Number(value || 0);
+  const d = Math.floor(s / 86400); s %= 86400;
+  const h = Math.floor(s / 3600); s %= 3600;
+  const m = Math.floor(s / 60);
+  if (d) return `${d}d ${h}h`;
+  if (h) return `${h}h ${m}m`;
+  return `${m}m`;
+}
 function escapeHtml(s) {
   return String(s).replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
 }
 window.addEventListener("resize", fitAndResize);
 new ResizeObserver(fitAndResize).observe(terminalEl);
 refresh();
+setPanel("system");
 fitAndResize();
 term.focus();
 </script>

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -57,6 +57,7 @@ CACHE_DIR=${DD_CACHE:-$SESSION_DIR/cache}
 TMP_DIR=${TMPDIR:-$SESSION_DIR/tmp}
 until [ -x "$PODMAN" ]; do echo "codex-podman: waiting for podman"; $BB sleep 2; done
 $BB mkdir -p "$HOME_DIR" "$WORKSPACE" "$CACHE_DIR" "$TMP_DIR"
+$BB chmod 1777 "$TMP_DIR"
 SAFE_SESSION=$(printf '%s' "$SESSION_ID" | $BB tr -c 'A-Za-z0-9_.-' '-')
 exec "$PODMAN" run --rm --replace -it --pull=missing \
   --network=host \
@@ -86,6 +87,7 @@ CACHE_DIR=${DD_CACHE:-$SESSION_DIR/cache}
 TMP_DIR=${TMPDIR:-$SESSION_DIR/tmp}
 until [ -x "$PODMAN" ]; do echo "podman-ubuntu: waiting for podman"; $BB sleep 2; done
 $BB mkdir -p "$HOME_DIR" "$WORKSPACE" "$CACHE_DIR" "$TMP_DIR"
+$BB chmod 1777 "$TMP_DIR"
 SAFE_SESSION=$(printf '%s' "$SESSION_ID" | $BB tr -c 'A-Za-z0-9_.-' '-')
 exec "$PODMAN" run --rm --replace -it --pull=missing \
   --network=host \
@@ -114,6 +116,7 @@ CACHE_DIR=${DD_CACHE:-$SESSION_DIR/cache}
 TMP_DIR=${TMPDIR:-$SESSION_DIR/tmp}
 until [ -x "$PODMAN" ]; do echo "podman-alpine: waiting for podman"; $BB sleep 2; done
 $BB mkdir -p "$HOME_DIR" "$WORKSPACE" "$CACHE_DIR" "$TMP_DIR"
+$BB chmod 1777 "$TMP_DIR"
 SAFE_SESSION=$(printf '%s' "$SESSION_ID" | $BB tr -c 'A-Za-z0-9_.-' '-')
 exec "$PODMAN" run --rm --replace -it --pull=missing \
   --network=host \


### PR DESCRIPTION
## Summary
- redesign dd-shell around a terminal-first mobile layout with a bottom panel drawer
- replace the recipe card stack with a compact session launcher
- add visible notification permission/state plus a test action
- surface CPU, memory, disk, and uptime metric cards from the existing system probe

Closes #246.

## Tests
- cargo fmt --check
- cargo check
- cargo test
- git diff --check
- node syntax check for embedded shell JS