### PR TITLE
Add dogfood agent and shell PWA notifications

### DIFF
--- a/.github/actions/relaunch-agent/action.yml
+++ b/.github/actions/relaunch-agent/action.yml
@@ -237,7 +237,7 @@ runs:
             last_payload="$payload"
           fi
           ready_count=$(echo "$payload" | jq -r --arg since "$since" --argjson expected "$expected_json" '
-                [.[] | select((.status=="healthy" or .status=="registering") and .last_seen > $since and (.vm_name as $vm | $expected | index($vm)))]
+                [.[] | select(.status=="healthy" and .last_seen > $since and (.vm_name as $vm | $expected | index($vm)))]
                 | unique_by(.vm_name)
                 | length' 2>/dev/null || echo 0)
           if [ "$ready_count" = "${#expected_vms[@]}" ]; then
@@ -247,14 +247,14 @@ runs:
               agent_count=$(echo "$cp_health" | jq -r '.agent_count // 0' 2>/dev/null || echo 0)
               if [ "$healthy_count" -lt 3 ] || [ "$agent_count" -lt 3 ]; then
                 last_payload="$payload"
-                echo "  CP /api/agents has preview agents registered, but /health reports agent_count=$agent_count healthy_count=$healthy_count; waiting for collector/store convergence... (${i}/60)"
+                echo "  CP /api/agents has preview agents healthy, but /health reports agent_count=$agent_count healthy_count=$healthy_count; waiting for collector/store convergence... (${i}/60)"
                 sleep 10
                 continue
               fi
             fi
             echo "registered agents:"
             echo "$payload" | jq -r --arg since "$since" --argjson expected "$expected_json" '
-              .[] | select((.status=="healthy" or .status=="registering") and .last_seen > $since and (.vm_name as $vm | $expected | index($vm)))
+              .[] | select(.status=="healthy" and .last_seen > $since and (.vm_name as $vm | $expected | index($vm)))
               | "  \(.vm_name) [\(.status)] at https://\(.hostname)"' 2>/dev/null || true
             cleanup_tail
             exit 0

--- a/.github/actions/relaunch-agent/action.yml
+++ b/.github/actions/relaunch-agent/action.yml
@@ -241,6 +241,17 @@ runs:
                 | unique_by(.vm_name)
                 | length' 2>/dev/null || echo 0)
           if [ "$ready_count" = "${#expected_vms[@]}" ]; then
+            if [ "$KIND" = "preview" ]; then
+              cp_health=$(curl -fsS --max-time 10 "$URL/health" 2>/dev/null || true)
+              healthy_count=$(echo "$cp_health" | jq -r '.healthy_count // 0' 2>/dev/null || echo 0)
+              agent_count=$(echo "$cp_health" | jq -r '.agent_count // 0' 2>/dev/null || echo 0)
+              if [ "$healthy_count" -lt 3 ] || [ "$agent_count" -lt 3 ]; then
+                last_payload="$payload"
+                echo "  CP /api/agents has preview agents registered, but /health reports agent_count=$agent_count healthy_count=$healthy_count; waiting for collector/store convergence... (${i}/60)"
+                sleep 10
+                continue
+              fi
+            fi
             echo "registered agents:"
             echo "$payload" | jq -r --arg since "$since" --argjson expected "$expected_json" '
               .[] | select((.status=="healthy" or .status=="registering") and .last_seen > $since and (.vm_name as $vm | $expected | index($vm)))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -260,6 +271,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -372,6 +413,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-as-inner"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -434,6 +487,12 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
@@ -558,6 +617,52 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hickory-proto"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna",
+ "ipnet",
+ "once_cell",
+ "rand 0.9.2",
+ "ring",
+ "thiserror",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-proto",
+ "ipconfig",
+ "moka",
+ "once_cell",
+ "parking_lot",
+ "rand 0.9.2",
+ "resolv-conf",
+ "smallvec",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
 
 [[package]]
 name = "hmac"
@@ -829,6 +934,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipconfig"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
+dependencies = [
+ "socket2",
+ "widestring",
+ "windows-registry",
+ "windows-result 0.4.1",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -900,6 +1018,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -938,6 +1065,23 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "moka"
+version = "0.12.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid",
 ]
 
 [[package]]
@@ -988,12 +1132,39 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
 
 [[package]]
 name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
 
 [[package]]
 name = "pem"
@@ -1045,6 +1216,12 @@ dependencies = [
  "opaque-debug",
  "universal-hash",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
@@ -1225,6 +1402,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1233,6 +1419,7 @@ dependencies = [
  "base64",
  "bytes",
  "futures-core",
+ "hickory-resolver",
  "http",
  "http-body",
  "http-body-util",
@@ -1241,6 +1428,7 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
+ "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -1261,6 +1449,12 @@ dependencies = [
  "web-sys",
  "webpki-roots",
 ]
+
+[[package]]
+name = "resolv-conf"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "ring"
@@ -1350,6 +1544,12 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
@@ -1566,6 +1766,12 @@ dependencies = [
  "ntapi",
  "windows",
 ]
+
+[[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tempfile"
@@ -2031,6 +2237,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2136,6 +2348,17 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result 0.4.1",
+ "windows-strings",
+]
 
 [[package]]
 name = "windows-result"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -372,6 +372,7 @@ dependencies = [
  "chrono",
  "futures-util",
  "hex",
+ "hickory-resolver",
  "hmac",
  "jsonwebtoken",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ hmac = "0.12"
 jsonwebtoken = "9"
 libc = "0.2"
 rand = "0.8"
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["hickory-dns", "json", "rustls-tls"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ chacha20poly1305 = "0.10"
 chrono = { version = "0.4", features = ["serde"] }
 hex = "0.4"
 futures-util = "0.3"
+hickory-resolver = { version = "0.25", default-features = false, features = ["tokio"] }
 hmac = "0.12"
 jsonwebtoken = "9"
 libc = "0.2"

--- a/README.md
+++ b/README.md
@@ -61,6 +61,11 @@ Every path lives in `.github/workflows/release.yml`: one `build` job, then eithe
 4. No other `dd-{env}-*` VM is RUNNING after deploy (STONITH must have halted the previous instance)
 5. `dd-local-{env}` re-registers with the new CP within 5 min
 
+`dd-local-dogfood` is the exception: it is a manually managed production
+development agent for real Codex/Podman work. Release deploys never recreate
+it. Launch or refresh it explicitly with `apps/_infra/dd-dogfood.sh`; it keeps
+its workload disk and reconnects to production across CP redeploys.
+
 ## Auth
 
 Zero shared secrets. Cloudflare handles tunnel/DNS routing only; DD owns auth in-process with signed browser sessions, ITA tokens, GitHub Actions OIDC tokens, and Noise device keys.
@@ -107,6 +112,11 @@ The agent verifies the OIDC token against GitHub's JWKS, checks `repository_owne
 ## Terminal access
 
 Each VM runs `dd-shell` as a workload on a `-shell` labelled subdomain (for example `app-shell.devopsdefender.com` or `<agent>-shell.devopsdefender.com`). DD gates it behind the same GitHub App broker session as the dashboards. The shell UI separates observed read-only workload logs from controlled read-write PTY sessions. Read-only viewing does not change integrity state because it cannot send input or signals; read-write PTYs are controlled as soon as they exist and keep encrypted transcript history inside the enclave.
+
+The shell is installable as a small PWA. Browser notifications are always
+delivered by default when permission is granted; on mobile, install the shell
+from the browser so the service worker can present notifications through the
+platform notification surface while the shell is active.
 
 ## STONITH
 

--- a/apps/README.md
+++ b/apps/README.md
@@ -170,7 +170,7 @@ inline in two places so both lifecycle points behave identically:
 
 ## Where each workload runs
 
-| workload | CP VM | agent VM (preview) | agent VM (prod) |
+| workload | CP VM | agent VM (preview) | agent VM (prod / dogfood) |
 |---|---|---|---|
 | `busybox` | | ✅ | ✅ |
 | `cloudflared` | ✅ | ✅ | ✅ |
@@ -208,7 +208,36 @@ Additional examples:
 CP stays slim: just `cloudflared` + `dd-management`. Preview agent VMs run a
 small read-only oracle plus agent + podman for CI to prove registration,
 scraping, vanity ingress, and dashboards end-to-end. Prod agent VMs use the
-same CPU-only boot shape without demo workloads for now.
+same CPU-only boot shape without demo workloads for now. `dd-local-dogfood`
+uses that same prod boot chain but is manually managed, sized larger by
+default, and not relaunched by CI.
+
+## Production dogfood agent
+
+Use `apps/_infra/dd-dogfood.sh` when you want a real, long-lived local VM
+registered to production for Codex/Podman development:
+
+```bash
+export DD_ITA_API_KEY="$(cat ~/.secrets/ita_api_key)"
+export DD_AUTH_COOKIE_SECRET="$(cat ~/.secrets/dd_auth_cookie_secret)"
+export EE_OWNER="posix4e" # or an org/repo principal
+./apps/_infra/dd-dogfood.sh
+```
+
+The script defines and starts `dd-local-dogfood` against
+`https://app.devopsdefender.com`. It follows the production stable EE image and
+the `latest` DD release by default. It preserves
+`/var/lib/libvirt/images/dd-local-dogfood-workload.qcow2` across runs, so
+Podman images, shell transcript storage, and Codex login state survive explicit
+operator refreshes. Production deploys do not call this script and do not
+destroy the dogfood VM.
+
+Optional sizing knobs:
+
+```bash
+DD_DOGFOOD_DISK_SIZE=1024G DD_DOGFOOD_MEM_KIB=67108864 DD_DOGFOOD_VCPUS=12 \
+  ./apps/_infra/dd-dogfood.sh
+```
 
 ## Ordering
 

--- a/apps/_infra/dd-dogfood.sh
+++ b/apps/_infra/dd-dogfood.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# dd-dogfood.sh — define/start the manually managed production dogfood agent.
+#
+# This is intentionally outside the Release cascade. Production deploys
+# recreate dd-local-prod as a canary, but they must not destroy the operator's
+# long-lived Codex/Podman development VM. Re-run this script only when you
+# explicitly want to redefine/restart dd-local-dogfood; its workload disk is
+# preserved across runs.
+
+set -euo pipefail
+export LIBVIRT_DEFAULT_URI="${LIBVIRT_DEFAULT_URI:-qemu:///system}"
+
+CP="${1:-https://app.devopsdefender.com}"
+: "${DD_ITA_API_KEY?DD_ITA_API_KEY must be set}"
+: "${EE_OWNER?EE_OWNER must be set to a GitHub login or owner/repo path}"
+: "${DD_AUTH_COOKIE_SECRET?DD_AUTH_COOKIE_SECRET must be set}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$REPO_ROOT"
+
+# Dogfood follows production's stable EE image and latest DD binary unless
+# the operator deliberately pins either value for a one-off test.
+export DD_EE_CHANNEL="${DD_EE_CHANNEL:-stable}"
+export DD_RELEASE_TAG="${DD_RELEASE_TAG:-latest}"
+export DD_AUTH_BROKER_URL="${DD_AUTH_BROKER_URL:-https://app.devopsdefender.com}"
+export DD_AUTH_COOKIE_DOMAIN="${DD_AUTH_COOKIE_DOMAIN:-.devopsdefender.com}"
+
+# shellcheck source=./ee-sync.sh
+. ./apps/_infra/ee-sync.sh
+sync_base /var/lib/libvirt/images/easyenclave-local.qcow2
+ensure_base_domain /var/lib/libvirt/images/easyenclave-local.qcow2 easyenclave-local
+
+./apps/_infra/local-agents.sh "" "" "" "$CP"
+virsh start dd-local-dogfood
+
+echo "dogfood agent started against $CP"
+echo "console: virsh console dd-local-dogfood"

--- a/apps/_infra/local-agents.sh
+++ b/apps/_infra/local-agents.sh
@@ -20,8 +20,13 @@
 #                      workload onto this agent's /deploy. Same boot
 #                      chain as preview/prod (cloudflared + dd-agent +
 #                      dd-shell + podman). Modest sizing.
+#   dd-local-dogfood : CPU-only, registers with production. Dedicated
+#                      manually-managed development agent for real Codex /
+#                      Podman work. CI never reprovisions it; production
+#                      deploys can roll the CP while this VM keeps trying to
+#                      reconnect with its persistent workload disk intact.
 #
-# All three reuse the existing easyenclave base qcow2 via copy-on-write
+# All agents reuse the existing easyenclave base qcow2 via copy-on-write
 # overlays; each gets its own config.iso baking in DD_CP_URL +
 # DD_ITA_API_KEY for that target. No GitHub PAT — the agent
 # authenticates to the CP via ITA attestation at /register and uses
@@ -44,15 +49,16 @@
 # Usage:
 #   export DD_ITA_API_KEY="$(cat ~/.secrets/ita_api_key)"
 #   export EE_OWNER="devopsdefender"   # or "alice", "alice/dd-foo", etc.
-#   ./apps/_infra/local-agents.sh <preview> <prod> <bot>
+#   ./apps/_infra/local-agents.sh <preview> <prod> <bot> <dogfood>
 #
 # Each URL arg is independent — pass "" to skip provisioning that VM:
-#   ./apps/_infra/local-agents.sh "" https://app.devopsdefender.com ""                          # prod only
-#   ./apps/_infra/local-agents.sh https://pr-N.devopsdefender.com "" ""                         # preview only
-#   ./apps/_infra/local-agents.sh "" "" https://app.devopsdefender.com                          # bot only
-#   ./apps/_infra/local-agents.sh "" https://app.devopsdefender.com https://app.devopsdefender.com  # prod + bot
+#   ./apps/_infra/local-agents.sh "" https://app.devopsdefender.com "" ""                         # prod only
+#   ./apps/_infra/local-agents.sh https://pr-N.devopsdefender.com "" "" ""                        # preview only
+#   ./apps/_infra/local-agents.sh "" "" https://app.devopsdefender.com ""                         # bot only
+#   ./apps/_infra/local-agents.sh "" "" "" https://app.devopsdefender.com                         # dogfood only
+#   ./apps/_infra/local-agents.sh "" https://app.devopsdefender.com https://app.devopsdefender.com ""  # prod + bot
 #
-# After: virsh start dd-local-preview && virsh start dd-local-preview-oracle && virsh start dd-local-prod && virsh start dd-local-bot
+# After: virsh start dd-local-preview && virsh start dd-local-preview-oracle && virsh start dd-local-prod && virsh start dd-local-bot && virsh start dd-local-dogfood
 
 set -euo pipefail
 export LIBVIRT_DEFAULT_URI="${LIBVIRT_DEFAULT_URI:-qemu:///system}"
@@ -60,8 +66,9 @@ export LIBVIRT_DEFAULT_URI="${LIBVIRT_DEFAULT_URI:-qemu:///system}"
 PREVIEW_CP="${1-}"
 PROD_CP="${2-}"
 BOT_CP="${3-}"
-if [ -z "$PREVIEW_CP" ] && [ -z "$PROD_CP" ] && [ -z "$BOT_CP" ]; then
-  echo "usage: $0 <preview-cp-url|\"\"> <prod-cp-url|\"\"> <bot-cp-url|\"\">" >&2
+DOGFOOD_CP="${4-}"
+if [ -z "$PREVIEW_CP" ] && [ -z "$PROD_CP" ] && [ -z "$BOT_CP" ] && [ -z "$DOGFOOD_CP" ]; then
+  echo "usage: $0 <preview-cp-url|\"\"> <prod-cp-url|\"\"> <bot-cp-url|\"\"> <dogfood-cp-url|\"\">" >&2
   exit 1
 fi
 : "${DD_ITA_API_KEY?set DD_ITA_API_KEY}"
@@ -338,6 +345,14 @@ build_overlay() {
   echo "  wrote $overlay (20G sparse, backing $BASE)"
 }
 
+workload_disk_size() {
+  # $1=name
+  case "$1" in
+    dogfood) echo "${DD_DOGFOOD_DISK_SIZE:-512G}" ;;
+    *)       echo "160G" ;;
+  esac
+}
+
 build_workload_disk() {
   # $1=name   $2=size-spec (e.g. 160G, 1920G)
   #
@@ -459,9 +474,14 @@ with open(p, "w") as f: f.write(x)
 PY
   fi
 
-  # CPU-only agent sizing.
+  # CPU-only agent sizing. Dogfood is meant for real interactive
+  # development, so give it enough room for Codex + nested containers.
   local mem_kib=16777216    # 16 GiB
   local vcpus=4
+  if [ "$name" = dogfood ]; then
+    mem_kib="${DD_DOGFOOD_MEM_KIB:-33554432}" # 32 GiB
+    vcpus="${DD_DOGFOOD_VCPUS:-8}"
+  fi
   sed -i -E "s|<memory unit='KiB'>[0-9]+</memory>|<memory unit='KiB'>$mem_kib</memory>|" "$out"
   sed -i -E "s|<currentMemory unit='KiB'>[0-9]+</currentMemory>|<currentMemory unit='KiB'>$mem_kib</currentMemory>|" "$out"
   sed -i -E "s|<vcpu placement='static'>[0-9]+</vcpu>|<vcpu placement='static'>$vcpus</vcpu>|" "$out"
@@ -536,7 +556,7 @@ define_agent() {
   # Workload disk (/dev/vdc, ext4, mounted at /var/lib/easyenclave/data
   # by the mount-data boot workload). Sparse qcow2, so only grows with
   # actual writes.
-  build_workload_disk "$name" 160G
+  build_workload_disk "$name" "$(workload_disk_size "$name")"
   build_config_iso "$name" "$cp" "$env_label"
   local xml
   xml=$(render_domain_xml "$name")
@@ -548,6 +568,7 @@ define_agent() {
 [ -n "$PREVIEW_CP" ] && define_agent preview-oracle "$PREVIEW_CP"
 [ -n "$PROD_CP"    ] && define_agent prod    "$PROD_CP"
 [ -n "$BOT_CP"     ] && define_agent bot     "$BOT_CP"
+[ -n "$DOGFOOD_CP" ] && define_agent dogfood "$DOGFOOD_CP"
 
 echo
 echo "done. start with:"
@@ -555,14 +576,16 @@ echo "done. start with:"
 [ -n "$PREVIEW_CP" ] && echo "  virsh start dd-local-preview-oracle"
 [ -n "$PROD_CP"    ] && echo "  virsh start dd-local-prod"
 [ -n "$BOT_CP"     ] && echo "  virsh start dd-local-bot"
+[ -n "$DOGFOOD_CP" ] && echo "  virsh start dd-local-dogfood"
 echo
 echo "watch registration (Ctrl-] to exit):"
 [ -n "$PREVIEW_CP" ] && echo "  virsh console dd-local-preview"
 [ -n "$PREVIEW_CP" ] && echo "  virsh console dd-local-preview-oracle"
 [ -n "$PROD_CP"    ] && echo "  virsh console dd-local-prod"
 [ -n "$BOT_CP"     ] && echo "  virsh console dd-local-bot"
+[ -n "$DOGFOOD_CP" ] && echo "  virsh console dd-local-dogfood"
 
 # Explicit 0 — the tail `[ -n "$BOT_CP" ] && …` returns 1 when
-# BOT_CP="" (preview/prod-only), bubbling up as the script exit
+# BOT_CP/DOGFOOD_CP="" (preview/prod-only), bubbling up as the script exit
 # status and tripping set -e in dd-relaunch.sh. Force success.
 exit 0

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -160,7 +160,7 @@ pub async fn run() -> Result<()> {
         let token = ita_token.clone();
         let trust = trust.clone();
         tokio::spawn(async move {
-            let http = reqwest::Client::new();
+            let http = crate::system_http_client();
             loop {
                 if let Err(e) = sync_trusted_devices(&http, &cp_url, &token, &trust).await {
                     eprintln!("agent: device sync failed: {e}");
@@ -401,8 +401,9 @@ enum RegisterAttempt {
 async fn register(cfg: &Cfg, ee: &Ee) -> Result<(String, Bootstrap)> {
     let http = reqwest::Client::builder()
         .timeout(Duration::from_secs(60))
+        .no_hickory_dns()
         .build()
-        .unwrap_or_else(|_| reqwest::Client::new());
+        .unwrap_or_else(|_| crate::system_http_client());
     let url = format!("{}/register", cfg.cp_url.trim_end_matches('/'));
     let extra_ingress: Vec<serde_json::Value> = cfg
         .extra_ingress
@@ -1320,7 +1321,7 @@ async fn push_extra_ingress(s: &St, label: String, port: u16) -> Result<()> {
     });
 
     let url = format!("{}/ingress/replace", s.cfg.cp_url.trim_end_matches('/'));
-    let resp = reqwest::Client::new()
+    let resp = crate::system_http_client()
         .post(&url)
         .json(&body)
         .send()

--- a/src/cf.rs
+++ b/src/cf.rs
@@ -12,6 +12,12 @@ use serde::{Deserialize, Serialize};
 use crate::config::CfCreds;
 use crate::error::{Error, Result};
 
+/// Cloudflare control-plane API client. Keep this on reqwest's system
+/// resolver path even when scrape clients enable Hickory DNS.
+pub fn http_client() -> Client {
+    crate::system_http_client()
+}
+
 const API: &str = "https://api.cloudflare.com/client/v4";
 pub const AGENT_API_LABEL: &str = "agent-api";
 pub const AGENT_API_PORT: u16 = 8081;

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -451,6 +451,13 @@ async fn mark_stale_or_orphan(
     let mut s = store.lock().await;
     if let Some(a) = s.values_mut().find(|a| a.hostname == *host) {
         let age = now.signed_duration_since(a.last_seen).num_seconds();
+        if a.status == "registering" && age < UNKNOWN_TUNNEL_SCRAPE_DELAY_SECS {
+            eprintln!(
+                "cp: collector: {name} scrape failed during registration grace: {}",
+                err.as_deref().unwrap_or("unknown error")
+            );
+            return;
+        }
         if age > DEAD_THRESHOLD_SECS && scrape_failure_is_dead_signal(err) {
             let extras = a.extras.clone();
             a.status = "dead".into();
@@ -559,6 +566,7 @@ mod tests {
     use super::{
         parse_extra_ingress, rendezvous_shard, scrape_failure_is_dead_signal, should_scrape_key,
         unknown_tunnel_is_gc_candidate, unknown_tunnel_should_wait_for_registration,
+        UNKNOWN_TUNNEL_SCRAPE_DELAY_SECS,
     };
 
     #[test]
@@ -663,6 +671,20 @@ mod tests {
             now
         ));
         assert!(!unknown_tunnel_should_wait_for_registration(None, now));
+    }
+
+    #[test]
+    fn registration_grace_matches_unknown_tunnel_delay() {
+        let now = Utc::now();
+
+        assert!(unknown_tunnel_should_wait_for_registration(
+            Some(now - Duration::seconds(UNKNOWN_TUNNEL_SCRAPE_DELAY_SECS - 1)),
+            now
+        ));
+        assert!(!unknown_tunnel_should_wait_for_registration(
+            Some(now - Duration::seconds(UNKNOWN_TUNNEL_SCRAPE_DELAY_SECS + 1)),
+            now
+        ));
     }
 
     #[test]

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -16,11 +16,16 @@
 
 use std::collections::HashMap;
 use std::error::Error as StdError;
+use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
 
 use chrono::{DateTime, Utc};
-use reqwest::StatusCode;
+use hickory_resolver::config::{LookupIpStrategy, ResolveHosts, ResolverConfig};
+use hickory_resolver::name_server::TokioConnectionProvider;
+use hickory_resolver::TokioResolver;
+use reqwest::dns::{Addrs, Name, Resolve, Resolving};
+use reqwest::{Client, StatusCode};
 use serde::{Deserialize, Serialize};
 use tokio::sync::{Mutex, Notify};
 use tokio::time::MissedTickBehavior;
@@ -114,6 +119,44 @@ struct ScrapeFailure {
     message: String,
 }
 
+#[derive(Clone)]
+struct ScrapeDnsResolver {
+    inner: TokioResolver,
+}
+
+impl ScrapeDnsResolver {
+    fn cloudflare() -> Self {
+        let mut builder = TokioResolver::builder_with_config(
+            ResolverConfig::cloudflare(),
+            TokioConnectionProvider::default(),
+        );
+        let opts = builder.options_mut();
+        opts.timeout = Duration::from_secs(3);
+        opts.attempts = 2;
+        opts.cache_size = 0;
+        opts.negative_max_ttl = Some(Duration::from_secs(0));
+        opts.use_hosts_file = ResolveHosts::Never;
+        opts.ip_strategy = LookupIpStrategy::Ipv4AndIpv6;
+        opts.try_tcp_on_error = true;
+        Self {
+            inner: builder.build(),
+        }
+    }
+}
+
+impl Resolve for ScrapeDnsResolver {
+    fn resolve(&self, name: Name) -> Resolving {
+        let resolver = self.inner.clone();
+        let name = name.as_str().to_string();
+        Box::pin(async move {
+            let lookup = resolver.lookup_ip(name).await?;
+            let addrs: Vec<SocketAddr> = lookup.iter().map(|ip| SocketAddr::new(ip, 0)).collect();
+            let addrs: Addrs = Box::new(addrs.into_iter());
+            Ok(addrs)
+        })
+    }
+}
+
 impl ScrapeFailure {
     fn status(status: StatusCode) -> Self {
         Self {
@@ -168,6 +211,14 @@ impl ScrapeFailure {
     }
 }
 
+fn collector_scrape_client() -> Client {
+    Client::builder()
+        .timeout(Duration::from_secs(20))
+        .dns_resolver(Arc::new(ScrapeDnsResolver::cloudflare()))
+        .build()
+        .expect("build collector scrape HTTP client")
+}
+
 #[allow(clippy::too_many_arguments)]
 pub async fn run(
     store: Store,
@@ -188,11 +239,7 @@ pub async fn run(
         .no_hickory_dns()
         .build()
         .unwrap_or_else(|_| crate::system_http_client());
-    let scrape_http = reqwest::Client::builder()
-        .timeout(Duration::from_secs(20))
-        .hickory_dns(true)
-        .build()
-        .unwrap_or_else(|_| reqwest::Client::new());
+    let scrape_http = collector_scrape_client();
 
     eprintln!(
         "cp: collector starting (prefix={prefix}*, scrape={}s, discovery={}s, shard={}/{})",

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -15,10 +15,12 @@
 //!   6. Refresh the `control-plane` entry (its claims come from CP startup).
 
 use std::collections::HashMap;
+use std::error::Error as StdError;
 use std::sync::Arc;
 use std::time::Duration;
 
 use chrono::{DateTime, Utc};
+use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
 use tokio::sync::{Mutex, Notify};
 use tokio::time::MissedTickBehavior;
@@ -98,6 +100,74 @@ struct ScrapeTarget {
     known: bool,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ScrapeFailureKind {
+    Dns,
+    Status(StatusCode),
+    Request,
+    PendingRegistration,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ScrapeFailure {
+    kind: ScrapeFailureKind,
+    message: String,
+}
+
+impl ScrapeFailure {
+    fn status(status: StatusCode) -> Self {
+        Self {
+            kind: ScrapeFailureKind::Status(status),
+            message: format!("status {status}"),
+        }
+    }
+
+    fn request(err: &reqwest::Error) -> Self {
+        let message = format!("{err:?}");
+        let kind = if reqwest_error_is_dns(err) {
+            ScrapeFailureKind::Dns
+        } else {
+            ScrapeFailureKind::Request
+        };
+        Self { kind, message }
+    }
+
+    fn pending_registration() -> Self {
+        Self {
+            kind: ScrapeFailureKind::PendingRegistration,
+            message: "fresh unknown tunnel pending registration".into(),
+        }
+    }
+
+    #[cfg(test)]
+    fn dns_for_test(message: impl Into<String>) -> Self {
+        Self {
+            kind: ScrapeFailureKind::Dns,
+            message: message.into(),
+        }
+    }
+
+    fn is_dns(&self) -> bool {
+        self.kind == ScrapeFailureKind::Dns
+    }
+
+    fn is_non_dead_signal(&self) -> bool {
+        matches!(
+            self.kind,
+            ScrapeFailureKind::PendingRegistration
+                | ScrapeFailureKind::Status(
+                    StatusCode::MOVED_PERMANENTLY
+                        | StatusCode::FOUND
+                        | StatusCode::SEE_OTHER
+                        | StatusCode::TEMPORARY_REDIRECT
+                        | StatusCode::PERMANENT_REDIRECT
+                        | StatusCode::UNAUTHORIZED
+                        | StatusCode::FORBIDDEN
+                )
+        )
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 pub async fn run(
     store: Store,
@@ -113,8 +183,14 @@ pub async fn run(
     shard_total: u64,
 ) -> ! {
     let prefix = cf::agent_prefix(&env_label);
-    let http = reqwest::Client::builder()
+    let cf_http = reqwest::Client::builder()
         .timeout(Duration::from_secs(20))
+        .no_hickory_dns()
+        .build()
+        .unwrap_or_else(|_| crate::system_http_client());
+    let scrape_http = reqwest::Client::builder()
+        .timeout(Duration::from_secs(20))
+        .hickory_dns(true)
         .build()
         .unwrap_or_else(|_| reqwest::Client::new());
 
@@ -141,7 +217,8 @@ pub async fn run(
         }
         tick(
             &store,
-            &http,
+            &cf_http,
+            &scrape_http,
             &cf,
             &prefix,
             &ee,
@@ -159,7 +236,8 @@ pub async fn run(
 #[allow(clippy::too_many_arguments)]
 async fn tick(
     store: &Store,
-    http: &reqwest::Client,
+    cf_http: &reqwest::Client,
+    scrape_http: &reqwest::Client,
     cf: &CfCreds,
     prefix: &str,
     ee: &Arc<Ee>,
@@ -171,7 +249,7 @@ async fn tick(
     shard_total: u64,
 ) {
     let mut targets = if discover {
-        discover_targets(store, http, cf, prefix).await
+        discover_targets(store, cf_http, cf, prefix).await
     } else {
         known_targets(store).await
     };
@@ -179,7 +257,7 @@ async fn tick(
 
     let now = Utc::now();
     let scrapes = targets.iter().map(|target| {
-        let http = http.clone();
+        let scrape_http = scrape_http.clone();
         let target = target.clone();
         async move {
             if !target.known && unknown_tunnel_should_wait_for_registration(target.created_at, now)
@@ -190,11 +268,11 @@ async fn tick(
                     target.host,
                     target.created_at,
                     None,
-                    Some("fresh unknown tunnel pending registration".into()),
+                    Some(ScrapeFailure::pending_registration()),
                 );
             }
             let health_host = cf::agent_api_hostname(&target.host);
-            let r = http
+            let r = scrape_http
                 .get(format!("https://{health_host}/health"))
                 .send()
                 .await;
@@ -216,7 +294,7 @@ async fn tick(
                     target.host,
                     target.created_at,
                     None,
-                    Some(format!("status {}", resp.status())),
+                    Some(ScrapeFailure::status(resp.status())),
                 ),
                 Err(e) => (
                     target.name,
@@ -224,7 +302,7 @@ async fn tick(
                     target.host,
                     target.created_at,
                     None,
-                    Some(format!("{e:?}")),
+                    Some(ScrapeFailure::request(&e)),
                 ),
             }
         }
@@ -312,16 +390,17 @@ async fn tick(
     if !orphans.is_empty() {
         for orphan in &orphans {
             eprintln!("cp: GC dead tunnel {}", orphan.name);
-            cf::delete_by_name(http, cf, &orphan.name).await;
-            let _ = cf::delete_cname(http, cf, &orphan.host).await;
-            let _ = cf::delete_cname(http, cf, &cf::agent_api_hostname(&orphan.host)).await;
+            cf::delete_by_name(cf_http, cf, &orphan.name).await;
+            let _ = cf::delete_cname(cf_http, cf, &orphan.host).await;
+            let _ = cf::delete_cname(cf_http, cf, &cf::agent_api_hostname(&orphan.host)).await;
             for (label, _) in &orphan.extras {
-                let _ = cf::delete_cname(http, cf, &cf::extra_hostname(&orphan.host, label)).await;
+                let _ =
+                    cf::delete_cname(cf_http, cf, &cf::extra_hostname(&orphan.host, label)).await;
             }
             // Sweep legacy Cloudflare Access apps for this agent so
             // stale exact host/path apps cannot intercept future
             // DNS+tunnel routes.
-            cf::delete_access_apps_for_agent(http, cf, &orphan.host).await;
+            cf::delete_access_apps_for_agent(cf_http, cf, &orphan.host).await;
         }
     }
 
@@ -444,17 +523,28 @@ async fn mark_stale_or_orphan(
     host: &str,
     name: &str,
     created_at: Option<DateTime<Utc>>,
-    err: &Option<String>,
+    err: &Option<ScrapeFailure>,
     now: DateTime<Utc>,
     orphans: &mut Vec<Orphan>,
 ) {
     let mut s = store.lock().await;
     if let Some(a) = s.values_mut().find(|a| a.hostname == *host) {
         let age = now.signed_duration_since(a.last_seen).num_seconds();
+        if a.status == "registering" && err.as_ref().is_some_and(ScrapeFailure::is_dns) {
+            if age <= DEAD_THRESHOLD_SECS {
+                eprintln!(
+                    "cp: collector: {name} DNS lookup failed for {}; still registering (age={}s): {}",
+                    cf::agent_api_hostname(host),
+                    age,
+                    scrape_failure_message(err)
+                );
+                return;
+            }
+        }
         if a.status == "registering" && age < UNKNOWN_TUNNEL_SCRAPE_DELAY_SECS {
             eprintln!(
                 "cp: collector: {name} scrape failed during registration grace: {}",
-                err.as_deref().unwrap_or("unknown error")
+                scrape_failure_message(err)
             );
             return;
         }
@@ -470,13 +560,13 @@ async fn mark_stale_or_orphan(
             a.status = "stale".into();
             eprintln!(
                 "cp: collector: {name} scrape failed: {}",
-                err.as_deref().unwrap_or("unknown error")
+                scrape_failure_message(err)
             );
         }
     } else if unknown_tunnel_is_gc_candidate(created_at, err, now) {
         eprintln!(
             "cp: collector: {name} unknown stale tunnel failed scrape; GC'ing: {}",
-            err.as_deref().unwrap_or("unknown error")
+            scrape_failure_message(err)
         );
         orphans.push(Orphan {
             name: name.to_string(),
@@ -484,15 +574,24 @@ async fn mark_stale_or_orphan(
             extras: Vec::new(),
         });
     } else if let Some(e) = err {
-        eprintln!(
-            "cp: collector: {name} not in store yet; preserving tunnel after scrape error: {e}"
-        );
+        if e.is_dns() {
+            eprintln!(
+                "cp: collector: {name} DNS lookup failed for {}; not in store yet, preserving tunnel: {}",
+                cf::agent_api_hostname(host),
+                e.message
+            );
+        } else {
+            eprintln!(
+                "cp: collector: {name} not in store yet; preserving tunnel after scrape error: {}",
+                e.message
+            );
+        }
     }
 }
 
 fn unknown_tunnel_is_gc_candidate(
     created_at: Option<DateTime<Utc>>,
-    err: &Option<String>,
+    err: &Option<ScrapeFailure>,
     now: DateTime<Utc>,
 ) -> bool {
     let Some(created_at) = created_at else {
@@ -543,31 +642,108 @@ fn fnv1a64(bytes: &[u8]) -> u64 {
     hash
 }
 
-fn scrape_failure_is_dead_signal(err: &Option<String>) -> bool {
-    let Some(err) = err.as_deref() else {
+fn scrape_failure_is_dead_signal(err: &Option<ScrapeFailure>) -> bool {
+    let Some(err) = err else {
         return false;
     };
-    !matches!(
-        err,
-        "status 301 Moved Permanently"
-            | "status 302 Found"
-            | "status 303 See Other"
-            | "status 307 Temporary Redirect"
-            | "status 308 Permanent Redirect"
-            | "status 401 Unauthorized"
-            | "status 403 Forbidden"
-    )
+    !err.is_non_dead_signal()
+}
+
+fn scrape_failure_message(err: &Option<ScrapeFailure>) -> &str {
+    err.as_ref()
+        .map(|e| e.message.as_str())
+        .unwrap_or("unknown error")
+}
+
+fn reqwest_error_is_dns(err: &reqwest::Error) -> bool {
+    if error_text_is_dns(&format!("{err:?}")) {
+        return true;
+    }
+
+    let mut source = err.source();
+    while let Some(err) = source {
+        if error_text_is_dns(&err.to_string()) {
+            return true;
+        }
+        source = err.source();
+    }
+    false
+}
+
+fn error_text_is_dns(text: &str) -> bool {
+    let text = text.to_ascii_lowercase();
+    text.contains("dns error")
+        || text.contains("failed to lookup address information")
+        || text.contains("failed to resolve")
+        || text.contains("name or service not known")
+        || text.contains("temporary failure in name resolution")
+        || text.contains("no record found")
 }
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
     use chrono::{Duration, Utc};
+    use tokio::sync::Mutex;
 
     use super::{
-        parse_extra_ingress, rendezvous_shard, scrape_failure_is_dead_signal, should_scrape_key,
-        unknown_tunnel_is_gc_candidate, unknown_tunnel_should_wait_for_registration,
+        mark_stale_or_orphan, parse_extra_ingress, rendezvous_shard, scrape_failure_is_dead_signal,
+        should_scrape_key, unknown_tunnel_is_gc_candidate,
+        unknown_tunnel_should_wait_for_registration, Agent, ScrapeFailure, Store,
         UNKNOWN_TUNNEL_SCRAPE_DELAY_SECS,
     };
+    use crate::ita;
+    use crate::taint::IntegrityState;
+    use crate::units::AgentMode;
+
+    fn status_failure(status: reqwest::StatusCode) -> Option<ScrapeFailure> {
+        Some(ScrapeFailure::status(status))
+    }
+
+    fn dns_failure() -> Option<ScrapeFailure> {
+        Some(ScrapeFailure::dns_for_test("dns error: no record found"))
+    }
+
+    fn request_failure() -> Option<ScrapeFailure> {
+        Some(ScrapeFailure {
+            kind: super::ScrapeFailureKind::Request,
+            message: "error sending request".into(),
+        })
+    }
+
+    fn test_agent(status: &str, last_seen: chrono::DateTime<chrono::Utc>) -> Agent {
+        Agent {
+            agent_id: "dd-test-agent-1".into(),
+            hostname: "dd-test-agent-1.example.com".into(),
+            vm_name: "dd-local-preview".into(),
+            attestation_type: "tdx".into(),
+            status: status.into(),
+            last_seen,
+            agent_mode: AgentMode::ReadWrite,
+            integrity_state: IntegrityState::Controlled,
+            deployment_count: 0,
+            deployment_names: Vec::new(),
+            unit_count: 0,
+            units: Vec::new(),
+            cpu_percent: 0,
+            memory_used_mb: 0,
+            memory_total_mb: 0,
+            nets: Vec::new(),
+            disks: Vec::new(),
+            ita: ita::Claims::default(),
+            tunnel_id: "tunnel-1".into(),
+            extras: Vec::new(),
+            oracles: Vec::new(),
+        }
+    }
+
+    async fn store_with(agent: Agent) -> Store {
+        let mut agents = HashMap::new();
+        agents.insert(agent.agent_id.clone(), agent);
+        Arc::new(Mutex::new(agents))
+    }
 
     #[test]
     fn missing_extra_ingress_preserves_existing_state() {
@@ -610,28 +786,30 @@ mod tests {
     fn auth_gate_scrape_failures_are_not_dead_signals() {
         for err in [
             None,
-            Some("status 302 Found".to_string()),
-            Some("status 401 Unauthorized".to_string()),
-            Some("status 403 Forbidden".to_string()),
+            status_failure(reqwest::StatusCode::FOUND),
+            status_failure(reqwest::StatusCode::UNAUTHORIZED),
+            status_failure(reqwest::StatusCode::FORBIDDEN),
+            Some(ScrapeFailure::pending_registration()),
         ] {
-            assert!(!scrape_failure_is_dead_signal(&err));
+            assert!(!scrape_failure_is_dead_signal(&err), "{err:?}");
         }
     }
 
     #[test]
     fn origin_scrape_failures_are_dead_signals() {
         for err in [
-            Some("status 530 <unknown status code>".to_string()),
-            Some("error sending request".to_string()),
+            status_failure(reqwest::StatusCode::from_u16(530).unwrap()),
+            request_failure(),
+            dns_failure(),
         ] {
-            assert!(scrape_failure_is_dead_signal(&err));
+            assert!(scrape_failure_is_dead_signal(&err), "{err:?}");
         }
     }
 
     #[test]
     fn unknown_tunnels_gc_only_after_grace_window() {
         let now = Utc::now();
-        let err = Some("error sending request".to_string());
+        let err = request_failure();
 
         assert!(!unknown_tunnel_is_gc_candidate(None, &err, now));
         assert!(!unknown_tunnel_is_gc_candidate(
@@ -649,10 +827,74 @@ mod tests {
     #[test]
     fn unknown_tunnels_keep_auth_gate_failures() {
         let now = Utc::now();
-        let err = Some("status 403 Forbidden".to_string());
+        let err = status_failure(reqwest::StatusCode::FORBIDDEN);
 
         assert!(!unknown_tunnel_is_gc_candidate(
             Some(now - Duration::seconds(1200)),
+            &err,
+            now
+        ));
+    }
+
+    #[tokio::test]
+    async fn dns_failure_keeps_fresh_registering_agent_registering() {
+        let now = Utc::now();
+        let store = store_with(test_agent(
+            "registering",
+            now - Duration::seconds(super::DEAD_THRESHOLD_SECS - 60),
+        ))
+        .await;
+        let mut orphans = Vec::new();
+
+        mark_stale_or_orphan(
+            &store,
+            "dd-test-agent-1.example.com",
+            "dd-test-agent-1",
+            Some(now - Duration::seconds(60)),
+            &dns_failure(),
+            now,
+            &mut orphans,
+        )
+        .await;
+
+        let agents = store.lock().await;
+        assert_eq!(agents["dd-test-agent-1"].status, "registering");
+        assert!(orphans.is_empty());
+    }
+
+    #[tokio::test]
+    async fn dns_failure_can_mark_old_registering_agent_dead() {
+        let now = Utc::now();
+        let store = store_with(test_agent(
+            "registering",
+            now - Duration::seconds(super::DEAD_THRESHOLD_SECS + 1),
+        ))
+        .await;
+        let mut orphans = Vec::new();
+
+        mark_stale_or_orphan(
+            &store,
+            "dd-test-agent-1.example.com",
+            "dd-test-agent-1",
+            Some(now - Duration::seconds(super::DEAD_THRESHOLD_SECS + 1)),
+            &dns_failure(),
+            now,
+            &mut orphans,
+        )
+        .await;
+
+        let agents = store.lock().await;
+        assert_eq!(agents["dd-test-agent-1"].status, "dead");
+        assert_eq!(orphans.len(), 1);
+    }
+
+    #[test]
+    fn dns_failure_can_gc_unknown_tunnel_after_grace_window() {
+        let now = Utc::now();
+        let err = dns_failure();
+
+        assert!(unknown_tunnel_is_gc_candidate(
+            Some(now - Duration::seconds(super::DEAD_THRESHOLD_SECS + 1)),
             &err,
             now
         ));

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -530,16 +530,17 @@ async fn mark_stale_or_orphan(
     let mut s = store.lock().await;
     if let Some(a) = s.values_mut().find(|a| a.hostname == *host) {
         let age = now.signed_duration_since(a.last_seen).num_seconds();
-        if a.status == "registering" && err.as_ref().is_some_and(ScrapeFailure::is_dns) {
-            if age <= DEAD_THRESHOLD_SECS {
-                eprintln!(
-                    "cp: collector: {name} DNS lookup failed for {}; still registering (age={}s): {}",
-                    cf::agent_api_hostname(host),
-                    age,
-                    scrape_failure_message(err)
-                );
-                return;
-            }
+        if a.status == "registering"
+            && err.as_ref().is_some_and(ScrapeFailure::is_dns)
+            && age <= DEAD_THRESHOLD_SECS
+        {
+            eprintln!(
+                "cp: collector: {name} DNS lookup failed for {}; still registering (age={}s): {}",
+                cf::agent_api_hostname(host),
+                age,
+                scrape_failure_message(err)
+            );
+            return;
         }
         if a.status == "registering" && age < UNKNOWN_TUNNEL_SCRAPE_DELAY_SECS {
             eprintln!(

--- a/src/cp.rs
+++ b/src/cp.rs
@@ -70,7 +70,7 @@ pub async fn run() -> Result<()> {
     let cfg = Arc::new(Cfg::from_env()?);
     let ee = Arc::new(Ee::new("/var/lib/easyenclave/agent.sock"));
 
-    let http = reqwest::Client::new();
+    let http = cf::http_client();
     let h = match ee.wait_ready(EE_READY_TIMEOUT).await {
         Ok(h) => h,
         Err(e) => {
@@ -589,7 +589,7 @@ async fn register(
         ita_claims.tcb_status.as_deref().unwrap_or("?")
     );
 
-    let http = reqwest::Client::new();
+    let http = cf::http_client();
     let name = cf::agent_tunnel_name(&s.cfg.common.env_label);
     let agent_hostname = format!("{name}.{}", s.cfg.cf.domain);
     let extras: Vec<(String, u16)> = req
@@ -734,7 +734,7 @@ async fn ingress_replace(
         .collect();
     let tunnel_extras = agent_tunnel_extras(&extras);
 
-    let http = reqwest::Client::new();
+    let http = cf::http_client();
     let hostnames =
         cf::update_ingress(&http, &s.cfg.cf, &tunnel_id, &hostname, &tunnel_extras).await?;
 
@@ -852,7 +852,7 @@ async fn auth_callback(
         .cfg
         .auth
         .callback_response(
-            &reqwest::Client::new(),
+            &crate::system_http_client(),
             &s.cfg.common.owner,
             code,
             state,

--- a/src/gh_oidc.rs
+++ b/src/gh_oidc.rs
@@ -163,7 +163,7 @@ impl Verifier {
         Arc::new(Self {
             owner,
             audience,
-            http: Client::new(),
+            http: crate::system_http_client(),
             keys: RwLock::new(HashMap::new()),
         })
     }
@@ -312,7 +312,7 @@ impl Verifier {
         Arc::new(Self {
             owner,
             audience,
-            http: Client::new(),
+            http: crate::system_http_client(),
             keys: RwLock::new(keys),
         })
     }

--- a/src/ita.rs
+++ b/src/ita.rs
@@ -89,7 +89,7 @@ struct MintResponse {
 /// is typically `https://api.trustauthority.intel.com`.
 pub async fn mint(base_url: &str, api_key: &str, quote_b64: &str) -> Result<String> {
     let url = format!("{}/appraisal/v1/attest", base_url.trim_end_matches('/'));
-    let resp = Client::new()
+    let resp = crate::system_http_client()
         .post(&url)
         .header("x-api-key", api_key)
         .header("Accept", "application/json")
@@ -123,7 +123,7 @@ impl Verifier {
         Arc::new(Self {
             jwks_url,
             issuer,
-            http: Client::new(),
+            http: crate::system_http_client(),
             keys: RwLock::new(HashMap::new()),
             local_key: None,
         })
@@ -133,7 +133,7 @@ impl Verifier {
         Arc::new(Self {
             jwks_url: String::new(),
             issuer,
-            http: Client::new(),
+            http: crate::system_http_client(),
             keys: RwLock::new(HashMap::new()),
             local_key: Some(secret.into_bytes()),
         })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,3 +17,10 @@ pub mod shell;
 pub mod stonith;
 pub mod taint;
 pub mod units;
+
+pub(crate) fn system_http_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .no_hickory_dns()
+        .build()
+        .expect("build system-resolver HTTP client")
+}

--- a/src/oracle.rs
+++ b/src/oracle.rs
@@ -46,8 +46,9 @@ pub fn spawn_scrapers(specs: Vec<OracleSpec>, store: OracleStore) {
     }
     let http = reqwest::Client::builder()
         .timeout(Duration::from_secs(5))
+        .no_hickory_dns()
         .build()
-        .unwrap_or_else(|_| reqwest::Client::new());
+        .unwrap_or_else(|_| crate::system_http_client());
     for spec in specs {
         let http = http.clone();
         let store = store.clone();

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -303,8 +303,9 @@ pub async fn run() -> Result<()> {
         ee: Arc::new(Ee::new(ee_socket)),
         http: reqwest::Client::builder()
             .timeout(Duration::from_secs(3))
+            .no_hickory_dns()
             .build()
-            .unwrap_or_else(|_| reqwest::Client::new()),
+            .unwrap_or_else(|_| crate::system_http_client()),
         agent_api,
         owner: common.owner,
         auth,

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -316,6 +316,9 @@ pub async fn run() -> Result<()> {
     let app = Router::new()
         .route("/", get(index))
         .route("/favicon.ico", get(favicon))
+        .route("/manifest.webmanifest", get(manifest))
+        .route("/sw.js", get(service_worker))
+        .route("/icon.svg", get(icon_svg))
         .route("/assets/xterm/xterm.css", get(xterm_css))
         .route("/assets/xterm/xterm.js", get(xterm_js))
         .route("/assets/xterm/addon-fit.js", get(xterm_fit_js))
@@ -372,6 +375,82 @@ async fn index(State(app): State<App>, headers: HeaderMap, uri: Uri) -> Response
 
 async fn favicon() -> StatusCode {
     StatusCode::NO_CONTENT
+}
+
+async fn manifest() -> impl IntoResponse {
+    (
+        [
+            ("content-type", "application/manifest+json; charset=utf-8"),
+            ("cache-control", "no-cache"),
+        ],
+        r##"{
+  "name": "DD Shell",
+  "short_name": "DD Shell",
+  "description": "DevOps Defender confidential shell",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "background_color": "#05070a",
+  "theme_color": "#111520",
+  "icons": [
+    {"src": "/icon.svg", "sizes": "any", "type": "image/svg+xml", "purpose": "any maskable"}
+  ]
+}"##,
+    )
+}
+
+async fn service_worker() -> impl IntoResponse {
+    (
+        [
+            ("content-type", "application/javascript; charset=utf-8"),
+            ("cache-control", "no-cache"),
+        ],
+        r#"self.addEventListener("install", event => {
+  event.waitUntil(self.skipWaiting());
+});
+self.addEventListener("activate", event => {
+  event.waitUntil(self.clients.claim());
+});
+self.addEventListener("notificationclick", event => {
+  event.notification.close();
+  event.waitUntil((async () => {
+    const allClients = await self.clients.matchAll({type: "window", includeUncontrolled: true});
+    if (allClients.length) {
+      await allClients[0].focus();
+      return;
+    }
+    await self.clients.openWindow("/");
+  })());
+});
+self.addEventListener("message", event => {
+  const data = event.data || {};
+  if (data.type !== "notify") return;
+  const title = data.title || "DD Shell";
+  const body = data.body || "";
+  event.waitUntil(self.registration.showNotification(title, {
+    body,
+    tag: data.tag || "dd-shell",
+    renotify: true,
+    icon: "/icon.svg",
+    badge: "/icon.svg"
+  }));
+});
+"#,
+    )
+}
+
+async fn icon_svg() -> impl IntoResponse {
+    (
+        [
+            ("content-type", "image/svg+xml; charset=utf-8"),
+            ("cache-control", "public, max-age=31536000, immutable"),
+        ],
+        r##"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <rect width="128" height="128" rx="24" fill="#05070a"/>
+  <path fill="#7aa2f7" d="M25 28h37c25 0 42 14 42 36S87 100 62 100H25V28Zm20 18v36h17c14 0 22-7 22-18s-8-18-22-18H45Z"/>
+  <path fill="#9ece6a" d="M38 55h23v18H38z"/>
+</svg>"##,
+    )
 }
 
 async fn xterm_css() -> impl IntoResponse {
@@ -1526,6 +1605,9 @@ let activePanel = "system";
 let notifications = loadNotificationHistory();
 let unreadNotifications = 0;
 const decoder = new TextDecoder();
+let serviceWorkerReady = null;
+installPwaMetadata();
+registerServiceWorker();
 
 async function api(path, opts) {
   const res = await fetch(path, opts);
@@ -1652,7 +1734,8 @@ function notificationHtml() {
   const supported = "Notification" in window;
   const permission = supported ? Notification.permission : "unavailable";
   const enabled = supported && permission === "granted" && notifyMode !== "off";
-  const detail = supported ? `native ${permission}; in-app history on` : "in-app history on; native unavailable";
+  const sw = "serviceWorker" in navigator ? "service worker ready" : "service worker unavailable";
+  const detail = supported ? `native ${permission}; ${sw}; in-app history on` : `in-app history on; native unavailable; ${sw}`;
   return `<div class="probe"><div class="row"><span class="name">Notifications</span><span class="pill ${enabled ? "ok" : "bad"}">${enabled ? "native" : "in-app"}</span></div><div class="meta">${escapeHtml(detail)}</div></div>`;
 }
 
@@ -1803,6 +1886,7 @@ document.getElementById("close").onclick = async () => {
   await refresh();
 };
 document.getElementById("notify").onclick = async () => {
+  await registerServiceWorker();
   if (!("Notification" in window)) {
     document.getElementById("status").textContent = "Notifications unavailable";
     return;
@@ -1950,17 +2034,40 @@ function notify(title, body) {
   if (activePanel !== "system") unreadNotifications++;
   renderNotificationFeed();
   showToast(item);
+  deliverNativeNotification(item);
+}
+function registerServiceWorker() {
+  if (!("serviceWorker" in navigator) || !window.isSecureContext) return Promise.resolve(null);
+  if (!serviceWorkerReady) {
+    serviceWorkerReady = navigator.serviceWorker.register("/sw.js")
+      .then(() => navigator.serviceWorker.ready)
+      .catch(() => null);
+  }
+  return serviceWorkerReady;
+}
+async function deliverNativeNotification(item) {
   if (!("Notification" in window) || Notification.permission !== "granted") return;
   if (notifyMode !== "always" && document.hasFocus()) return;
-  const n = new Notification(title || "Shell", {
-    body: body || "",
-    tag: current ? `dd-shell-${current}` : "dd-shell"
-  });
-  n.onclick = () => {
-    window.focus();
-    term.focus();
-    n.close();
-  };
+  const title = item.title || "DD Shell";
+  const body = item.body || "";
+  const tag = current ? `dd-shell-${current}` : "dd-shell";
+  const registration = await registerServiceWorker();
+  if (registration && "showNotification" in registration) {
+    await registration.showNotification(title, {body, tag, renotify: true, icon: "/icon.svg", badge: "/icon.svg"});
+    return;
+  }
+  const n = new Notification(title, {body, tag});
+  n.onclick = () => { window.focus(); term.focus(); n.close(); };
+}
+function installPwaMetadata() {
+  const manifest = document.createElement("link");
+  manifest.rel = "manifest";
+  manifest.href = "/manifest.webmanifest";
+  document.head.appendChild(manifest);
+  const theme = document.createElement("meta");
+  theme.name = "theme-color";
+  theme.content = "#111520";
+  document.head.appendChild(theme);
 }
 function loadNotificationHistory() {
   try {

--- a/src/stonith.rs
+++ b/src/stonith.rs
@@ -80,8 +80,9 @@ pub async fn self_watchdog(
 ) -> ! {
     let http = reqwest::Client::builder()
         .timeout(Duration::from_secs(10))
+        .no_hickory_dns()
         .build()
-        .unwrap_or_else(|_| reqwest::Client::new());
+        .unwrap_or_else(|_| crate::system_http_client());
 
     let initial = rand::thread_rng().gen_range(INITIAL_MIN_SECS..=INITIAL_MAX_SECS);
     tokio::time::sleep(Duration::from_secs(initial)).await;


### PR DESCRIPTION
## Summary
- add a manually managed production dogfood agent path (dd-local-dogfood) with a dedicated apps/_infra/dd-dogfood.sh launcher
- keep dogfood out of the release cascade while preserving its workload qcow2 across explicit refreshes
- size dogfood larger by default for Codex/Podman dev work, with disk/mem/vCPU env knobs
- make dd-shell installable as a small PWA and route native notifications through a service worker when available

## Validation
- bash -n apps/_infra/local-agents.sh
- bash -n apps/_infra/dd-dogfood.sh
- cargo fmt --check
- cargo test