### PR TITLE
Add sessiond-backed shell sessions

### DIFF
--- a/.github/workflows/deploy-cp.yml
+++ b/.github/workflows/deploy-cp.yml
@@ -256,6 +256,7 @@ jobs:
           EE_BOOT_WORKLOADS=$({
             bake apps/cloudflared/workload.json
             bake apps/dd-management/workload.json.tmpl
+            bake apps/dd-sessiond/workload.json.tmpl
             DD_DOMAIN="$DD_DOMAIN" \
               DD_HOSTNAME="$DD_HOSTNAME" \
               DD_ENV="$DD_ENV" \

--- a/.github/workflows/deploy-cp.yml
+++ b/.github/workflows/deploy-cp.yml
@@ -256,7 +256,9 @@ jobs:
           EE_BOOT_WORKLOADS=$({
             bake apps/cloudflared/workload.json
             bake apps/dd-management/workload.json.tmpl
-            bake apps/dd-sessiond/workload.json.tmpl
+            DD_SESSIOND_DIR=/tmp/dd-shell \
+              DD_SESSIOND_SCRATCH_DIR=/tmp/dd-shell/sessions \
+              bake apps/dd-sessiond/workload.json.tmpl
             DD_DOMAIN="$DD_DOMAIN" \
               DD_HOSTNAME="$DD_HOSTNAME" \
               DD_ENV="$DD_ENV" \

--- a/apps/_infra/local-agents.sh
+++ b/apps/_infra/local-agents.sh
@@ -245,7 +245,9 @@ build_config_iso() {
         DD_RELEASE_TAG="$DD_RELEASE_TAG" bake "$REPO_ROOT/apps/ca-certificates/workload.json.tmpl"
         bake "$REPO_ROOT/apps/podman-bootstrap/workload.json"
         bake "$REPO_ROOT/apps/cloudflared/workload.json"
-        bake "$REPO_ROOT/apps/dd-sessiond/workload.json.tmpl"
+        DD_SESSIOND_DIR=/var/lib/easyenclave/data/dd-shell \
+          DD_SESSIOND_SCRATCH_DIR=/var/lib/easyenclave/data/dd-shell/sessions \
+          bake "$REPO_ROOT/apps/dd-sessiond/workload.json.tmpl"
         DD_DOMAIN="$domain" \
           DD_HOSTNAME="dd-local-$name" \
           DD_ENV="$env" \

--- a/apps/_infra/local-agents.sh
+++ b/apps/_infra/local-agents.sh
@@ -245,6 +245,7 @@ build_config_iso() {
         DD_RELEASE_TAG="$DD_RELEASE_TAG" bake "$REPO_ROOT/apps/ca-certificates/workload.json.tmpl"
         bake "$REPO_ROOT/apps/podman-bootstrap/workload.json"
         bake "$REPO_ROOT/apps/cloudflared/workload.json"
+        bake "$REPO_ROOT/apps/dd-sessiond/workload.json.tmpl"
         DD_DOMAIN="$domain" \
           DD_HOSTNAME="dd-local-$name" \
           DD_ENV="$env" \
@@ -288,7 +289,7 @@ build_config_iso() {
 
   local workloads
   if [ "$name" = dogfood ]; then
-    # Dogfood boots both dd-agent and dd-shell from the same devopsdefender
+    # Dogfood boots dd-agent, dd-sessiond, and dd-shell from the same devopsdefender
     # release asset. Fetch it once up front, then run both workloads from the
     # prefetched binary so concurrent startup does not try to overwrite an
     # executable that another workload already has mapped.

--- a/apps/dd-sessiond/workload.json.tmpl
+++ b/apps/dd-sessiond/workload.json.tmpl
@@ -1,0 +1,13 @@
+{
+  "app_name": "dd-sessiond",
+  "env": [
+    "DD_MODE=sessiond",
+    "DD_SESSIOND_HTTP_ADDR=127.0.0.1:7683",
+    "DD_SESSIOND_ATTACH_ADDR=127.0.0.1:7684",
+    "DD_SESSIOND_DIR=/var/lib/easyenclave/data/dd-shell",
+    "DD_SESSIOND_SCRATCH_DIR=/var/lib/easyenclave/data/dd-shell/sessions"
+  ],
+  "cmd": [
+    "devopsdefender", "sessiond"
+  ]
+}

--- a/apps/dd-sessiond/workload.json.tmpl
+++ b/apps/dd-sessiond/workload.json.tmpl
@@ -4,8 +4,8 @@
     "DD_MODE=sessiond",
     "DD_SESSIOND_HTTP_ADDR=127.0.0.1:7683",
     "DD_SESSIOND_ATTACH_ADDR=127.0.0.1:7684",
-    "DD_SESSIOND_DIR=/var/lib/easyenclave/data/dd-shell",
-    "DD_SESSIOND_SCRATCH_DIR=/var/lib/easyenclave/data/dd-shell/sessions"
+    "DD_SESSIOND_DIR=${DD_SESSIOND_DIR}",
+    "DD_SESSIOND_SCRATCH_DIR=${DD_SESSIOND_SCRATCH_DIR}"
   ],
   "cmd": [
     "devopsdefender", "sessiond"

--- a/apps/dd-shell/workload.json.tmpl
+++ b/apps/dd-shell/workload.json.tmpl
@@ -6,6 +6,8 @@
     "DD_SHELL_PORT=7682",
     "DD_SHELL_DIR=/tmp/dd-shell",
     "DD_SHELL_EE_SOCKET=/var/lib/easyenclave/agent.sock",
+    "DD_SESSIOND_HTTP_URL=http://127.0.0.1:7683",
+    "DD_SESSIOND_ATTACH_ADDR=127.0.0.1:7684",
     "DD_ENV=${DD_ENV}",
     "DD_OWNER=${DD_OWNER}",
     "DD_OWNER_ID=${DD_OWNER_ID}",

--- a/docs/sessiond-central-ui-plan.md
+++ b/docs/sessiond-central-ui-plan.md
@@ -1,0 +1,151 @@
+# Sessiond + Central UI Plan
+
+## Goal
+
+Accept one disruptive dogfood redeploy to install a durable session backend.
+After that, iterate on desktop/mobile/assistant UI from the centralized fleet
+control plane without restarting the dogfood VM or killing active Codex/Claude
+sessions.
+
+## Target Shape
+
+```text
+browser
+  -> app.devopsdefender.com fleet UI
+  -> selected agent session gateway
+  -> dd-sessiond Unix socket on that VM
+  -> PTY + child process group
+```
+
+Agent VM responsibilities:
+
+- `dd-sessiond` owns live sessions, PTYs, child process groups, transcripts,
+  recipes, session metadata, and notification/input-needed state.
+- `dd-agent` owns the remote HTTPS/tunnel API surface, authorization,
+  attestation/noise integration, and proxying to local `dd-sessiond`.
+- The old agent-local `dd-shell` UI becomes temporary/minimal and no longer
+  owns PTYs.
+
+Control-plane responsibilities:
+
+- Serve the desktop shell UI, mobile UI, and Claude-style assistant view.
+- Let users select a fleet agent and attach to sessions through that agent's
+  session API.
+- Ship UI updates via normal CP/web deploys, without touching agent VMs.
+
+## Non-Goals
+
+- No fleet-wide self-upgrade machinery.
+- No hot-swappable UI directory as the primary mechanism.
+- No fallback in-process PTY mode once `dd-sessiond` is introduced.
+- No CRIU/checkpoint work in the first implementation.
+- No full browser-side Noise handshake in the first implementation.
+
+## Phase 1: One Disruptive Dogfood Upgrade
+
+Ship the new backend shape to dogfood, accepting that existing live dogfood
+sessions will be lost during this rollout.
+
+Deliverables:
+
+- Add `DD_MODE=sessiond`. Implemented in this branch.
+- Add a `dd-sessiond` boot workload for dogfood agents. Implemented in this branch.
+- Change interactive sessions so `dd-sessiond` owns PTYs. Implemented for `dd-shell`
+  by proxying session create/list/attach/resize/close/replay to sessiond.
+- Change `dd-agent` to proxy session APIs to `dd-sessiond`. Implemented with
+  browser-auth-gated routes for the first cut.
+- Keep Codex launch working through the session manager.
+- Preserve persistent disk state, including Codex/npm/login state.
+
+Acceptance:
+
+- Dogfood agent is healthy after redeploy.
+- Codex launches through `dd-sessiond`.
+- Existing session metadata and transcripts are visible through the session API.
+- Restarting only the web/UI layer does not kill a running Codex session.
+
+## Phase 2: Stable Session API
+
+Expose session functionality through `dd-agent`, backed by local
+`dd-sessiond`.
+
+Initial API:
+
+```text
+GET  /api/sessions
+POST /api/sessions
+GET  /api/sessions/:id
+WS   /api/sessions/:id/attach
+POST /api/sessions/:id/input
+POST /api/sessions/:id/resize
+POST /api/sessions/:id/close
+GET  /api/sessions/:id/transcript
+WS   /api/session-events
+```
+
+Implementation notes:
+
+- `dd-sessiond` listens only on a Unix socket on the VM.
+- `dd-agent` is the only remote gateway.
+- Multiple clients may attach to the same session.
+- Transcript and events are canonical session state, not UI state.
+- Mobile clients should not resize the canonical PTY by default.
+
+## Phase 3: Centralized Fleet UI
+
+Move active shell UI development to the CP/fleet dashboard.
+
+Deliverables:
+
+- Add CP route for agent sessions.
+- UI lists sessions for the selected agent.
+- UI can create, attach, input, resize, close, and replay sessions.
+- Desktop terminal view remains raw PTY-first.
+- Mobile view can add touch controls, smart sizing, and assistant-style
+  rendering without changing agent-side session ownership.
+
+Acceptance:
+
+- Updating CP UI via PR/release updates the shell/mobile experience.
+- No dogfood agent restart is needed for UI-only changes.
+- Active dogfood Codex sessions survive CP UI updates.
+
+Status:
+
+- Not implemented in the first branch slice. The agent-side session gateway is
+  present so the CP UI can target it next.
+
+## Phase 4: Auth, Attestation, And Noise
+
+Start simple:
+
+- CP issues short-lived scoped session tokens.
+- Tokens bind user, agent id, session/action scope, and expiry.
+- `dd-agent` validates tokens before proxying to `dd-sessiond`.
+
+Then strengthen:
+
+- Bind session authorization to the attested agent Noise public key.
+- CP tracks agent attestation and `noise_pubkey`.
+- Desktop/CLI clients can eventually use a direct Noise channel.
+- Browser UI can stay token-over-HTTPS until custom browser crypto is worth it.
+
+Design rule:
+
+```text
+remote clients never trust naked tunnel DNS
+remote clients trust CP-issued scoped authorization and, later, attested keys
+dd-sessiond stays local-only
+dd-agent is the policy/encryption gateway
+```
+
+## Risks And Open Questions
+
+- Whether to keep a minimal agent-local shell UI for emergency access.
+- How to model recipes so CP UI and `dd-sessiond` agree on available launchers.
+- How to represent "input requested" events for Codex/Claude without making
+  terminal parsing authoritative.
+- Whether `dd-sessiond` should support graceful self-upgrade later via fd
+  passing or exec handoff.
+- How much of the existing transcript encryption format should move unchanged
+  into `dd-sessiond`.

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -21,13 +21,18 @@
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use axum::extract::{Path, State};
+use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
+use axum::extract::{Path, Query, State};
 use axum::http::{HeaderMap, Uri};
 use axum::response::{Html, IntoResponse, Response};
 use axum::routing::{get, post};
 use axum::{Json, Router};
 use base64::Engine as _;
+use futures_util::{SinkExt, StreamExt};
+use serde::de::DeserializeOwned;
 use serde::Deserialize;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
 use tokio::sync::RwLock;
 
 use crate::config::Agent as Cfg;
@@ -99,6 +104,12 @@ struct St {
     taint: TaintSet,
     /// Read-only oracle scrape state derived from boot workload metadata.
     oracles: oracle::OracleStore,
+    /// Local session supervisor control endpoint. Public callers reach this
+    /// through dd-agent; dd-sessiond itself stays loopback-local.
+    sessiond_http_url: String,
+    /// Local raw attach socket used to proxy PTY bytes over WebSocket.
+    sessiond_attach_addr: String,
+    http: reqwest::Client,
 }
 
 pub async fn run() -> Result<()> {
@@ -192,6 +203,10 @@ pub async fn run() -> Result<()> {
     };
 
     let gh = gh_oidc::Verifier::new(cfg.common.owner.clone(), "dd-agent".into());
+    let sessiond_http_url =
+        std::env::var("DD_SESSIOND_HTTP_URL").unwrap_or_else(|_| "http://127.0.0.1:7683".into());
+    let sessiond_attach_addr =
+        std::env::var("DD_SESSIOND_ATTACH_ADDR").unwrap_or_else(|_| "127.0.0.1:7684".into());
 
     // Seed taint set. Boot-time facts go in now; runtime events
     // (CustomerOwnerEnabled, CustomerWorkloadDeployed) are appended
@@ -215,6 +230,9 @@ pub async fn run() -> Result<()> {
         agent_owner: Arc::new(RwLock::new(None)),
         taint,
         oracles: oracle_store,
+        sessiond_http_url,
+        sessiond_attach_addr,
+        http: crate::system_http_client(),
     };
     let api_state = state.clone();
     let api_ng_state = ng_state.clone();
@@ -231,6 +249,11 @@ pub async fn run() -> Result<()> {
         .route("/health", get(health))
         .route("/api/oracles", get(api_oracles))
         .route("/api/units", get(api_units))
+        .route("/api/sessions", get(api_sessions).post(create_session))
+        .route("/api/sessions/{id}/replay", get(replay_session))
+        .route("/api/sessions/{id}/resize", post(resize_session))
+        .route("/api/sessions/{id}/close", post(close_session))
+        .route("/api/sessions/{id}/attach", get(attach_session))
         .route("/workload/{id}", get(workload_page))
         .route("/logs/{app}", get(logs));
     if !cfg.confidential {
@@ -256,6 +279,11 @@ pub async fn run() -> Result<()> {
         .route("/health", get(health))
         .route("/api/oracles", get(api_oracles))
         .route("/api/units", get(api_units))
+        .route("/api/sessions", get(api_sessions).post(create_session))
+        .route("/api/sessions/{id}/replay", get(replay_session))
+        .route("/api/sessions/{id}/resize", post(resize_session))
+        .route("/api/sessions/{id}/close", post(close_session))
+        .route("/api/sessions/{id}/attach", get(attach_session))
         .route("/logs/{app}", get(logs));
     if !cfg.confidential {
         api = api
@@ -891,6 +919,194 @@ async fn dashboard(State(s): State<St>, headers: HeaderMap, uri: Uri) -> Respons
         &body,
     ))
     .into_response()
+}
+
+async fn api_sessions(
+    State(s): State<St>,
+    headers: HeaderMap,
+    uri: Uri,
+) -> Result<Json<Vec<crate::sessiond::SessionMeta>>> {
+    ensure_browser_auth(&s, &headers, &uri)?;
+    sessiond_get(&s, "/api/sessions").await.map(Json)
+}
+
+async fn create_session(
+    State(s): State<St>,
+    headers: HeaderMap,
+    uri: Uri,
+    Json(req): Json<crate::sessiond::CreateSession>,
+) -> Result<Json<crate::sessiond::CreateSessionResponse>> {
+    ensure_browser_auth(&s, &headers, &uri)?;
+    sessiond_post(&s, "/api/sessions", &req).await.map(Json)
+}
+
+async fn replay_session(
+    State(s): State<St>,
+    headers: HeaderMap,
+    uri: Uri,
+    Path(id): Path<String>,
+) -> Result<Json<crate::sessiond::ReplayResponse>> {
+    ensure_browser_auth(&s, &headers, &uri)?;
+    sessiond_get(&s, &format!("/api/sessions/{id}/replay"))
+        .await
+        .map(Json)
+}
+
+async fn resize_session(
+    State(s): State<St>,
+    headers: HeaderMap,
+    uri: Uri,
+    Path(id): Path<String>,
+    Json(req): Json<crate::sessiond::ResizeSession>,
+) -> Result<axum::http::StatusCode> {
+    ensure_browser_auth(&s, &headers, &uri)?;
+    sessiond_post_empty_json(&s, &format!("/api/sessions/{id}/resize"), &req).await
+}
+
+async fn close_session(
+    State(s): State<St>,
+    headers: HeaderMap,
+    uri: Uri,
+    Path(id): Path<String>,
+) -> Result<axum::http::StatusCode> {
+    ensure_browser_auth(&s, &headers, &uri)?;
+    sessiond_post_empty(&s, &format!("/api/sessions/{id}/close")).await
+}
+
+async fn attach_session(
+    State(s): State<St>,
+    headers: HeaderMap,
+    uri: Uri,
+    Path(id): Path<String>,
+    Query(query): Query<AttachQuery>,
+    ws: WebSocketUpgrade,
+) -> Result<Response> {
+    ensure_browser_auth(&s, &headers, &uri)?;
+    let attach_addr = s.sessiond_attach_addr.clone();
+    Ok(ws.on_upgrade(move |socket| async move {
+        if let Err(e) =
+            attach_to_sessiond(socket, attach_addr, id, query.tail.unwrap_or(true)).await
+        {
+            eprintln!("agent: session attach ended: {e:#}");
+        }
+    }))
+}
+
+#[derive(Debug, Deserialize)]
+struct AttachQuery {
+    tail: Option<bool>,
+}
+
+fn ensure_browser_auth(s: &St, headers: &HeaderMap, uri: &Uri) -> Result<()> {
+    if require_browser_auth(s, headers, uri).is_some() {
+        Err(Error::Unauthorized)
+    } else {
+        Ok(())
+    }
+}
+
+async fn attach_to_sessiond(
+    socket: WebSocket,
+    attach_addr: String,
+    id: String,
+    tail: bool,
+) -> anyhow::Result<()> {
+    let mut stream = TcpStream::connect(&attach_addr).await?;
+    let tail_arg = if tail { "tail" } else { "notail" };
+    stream
+        .write_all(format!("{id} {tail_arg}\n").as_bytes())
+        .await?;
+    let (mut tcp_rx, mut tcp_tx) = stream.into_split();
+    let (mut ws_tx, mut ws_rx) = socket.split();
+
+    let output = tokio::spawn(async move {
+        let mut buf = [0u8; 4096];
+        loop {
+            let n = match tcp_rx.read(&mut buf).await {
+                Ok(0) => break,
+                Ok(n) => n,
+                Err(_) => break,
+            };
+            if ws_tx
+                .send(Message::Binary(buf[..n].to_vec().into()))
+                .await
+                .is_err()
+            {
+                break;
+            }
+        }
+    });
+
+    while let Some(msg) = ws_rx.next().await {
+        match msg? {
+            Message::Binary(bytes) => tcp_tx.write_all(&bytes).await?,
+            Message::Text(text) => tcp_tx.write_all(text.as_bytes()).await?,
+            Message::Close(_) => break,
+            Message::Ping(_) | Message::Pong(_) => {}
+        }
+    }
+    output.abort();
+    Ok(())
+}
+
+async fn sessiond_get<T: DeserializeOwned>(s: &St, path: &str) -> Result<T> {
+    let url = format!("{}{}", s.sessiond_http_url.trim_end_matches('/'), path);
+    let resp = s.http.get(url).send().await?;
+    decode_sessiond_response(path, resp).await
+}
+
+async fn sessiond_post<T: DeserializeOwned, B: serde::Serialize>(
+    s: &St,
+    path: &str,
+    body: &B,
+) -> Result<T> {
+    let url = format!("{}{}", s.sessiond_http_url.trim_end_matches('/'), path);
+    let resp = s.http.post(url).json(body).send().await?;
+    decode_sessiond_response(path, resp).await
+}
+
+async fn sessiond_post_empty(s: &St, path: &str) -> Result<axum::http::StatusCode> {
+    let url = format!("{}{}", s.sessiond_http_url.trim_end_matches('/'), path);
+    let resp = s.http.post(url).send().await?;
+    decode_sessiond_empty(path, resp).await
+}
+
+async fn sessiond_post_empty_json<B: serde::Serialize>(
+    s: &St,
+    path: &str,
+    body: &B,
+) -> Result<axum::http::StatusCode> {
+    let url = format!("{}{}", s.sessiond_http_url.trim_end_matches('/'), path);
+    let resp = s.http.post(url).json(body).send().await?;
+    decode_sessiond_empty(path, resp).await
+}
+
+async fn decode_sessiond_response<T: DeserializeOwned>(
+    path: &str,
+    resp: reqwest::Response,
+) -> Result<T> {
+    let status = resp.status();
+    if !status.is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        return Err(Error::Upstream(format!(
+            "sessiond {path}: HTTP {status}: {body}"
+        )));
+    }
+    Ok(resp.json().await?)
+}
+
+async fn decode_sessiond_empty(
+    path: &str,
+    resp: reqwest::Response,
+) -> Result<axum::http::StatusCode> {
+    let status = resp.status();
+    if !status.is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        return Err(Error::Upstream(format!(
+            "sessiond {path}: HTTP {status}: {body}"
+        )));
+    }
+    Ok(axum::http::StatusCode::NO_CONTENT)
 }
 
 async fn api_oracles(State(s): State<St>) -> Json<Vec<oracle::OracleStatus>> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub mod ita;
 pub mod metrics;
 pub mod noise_gateway;
 pub mod oracle;
+pub mod sessiond;
 pub mod shell;
 pub mod stonith;
 pub mod taint;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,11 +2,12 @@
 //!
 //!   DD_MODE=cp      devopsdefender    # control-plane
 //!   DD_MODE=agent   devopsdefender    # in-VM agent
-//!   DD_MODE=shell   devopsdefender    # multi-session shell service
+//!   DD_MODE=shell   devopsdefender    # shell web service
+//!   DD_MODE=sessiond devopsdefender   # local session supervisor
 //!
 //! (Also accepts `devopsdefender cp` / `devopsdefender agent` for local dev.)
 
-use devopsdefender::{agent, cp, shell};
+use devopsdefender::{agent, cp, sessiond, shell};
 
 #[tokio::main]
 async fn main() {
@@ -18,8 +19,9 @@ async fn main() {
         Some("cp") | Some("management") => cp::run().await.map_err(Into::into),
         Some("agent") => agent::run().await.map_err(Into::into),
         Some("shell") => shell::run().await.map_err(Into::into),
+        Some("sessiond") => sessiond::run().await.map_err(Into::into),
         _ => {
-            eprintln!("usage: devopsdefender <cp|agent|shell>");
+            eprintln!("usage: devopsdefender <cp|agent|shell|sessiond>");
             eprintln!("   or: DD_MODE=<mode> devopsdefender");
             std::process::exit(2);
         }

--- a/src/sessiond.rs
+++ b/src/sessiond.rs
@@ -1,0 +1,1004 @@
+//! Local interactive session supervisor.
+//!
+//! `dd-sessiond` owns PTYs and child process groups. Web/API surfaces such as
+//! `dd-shell` and `dd-agent` should proxy to this process instead of spawning
+//! interactive commands themselves.
+
+use std::cmp::Reverse;
+use std::collections::{HashMap, VecDeque};
+use std::fs::File as StdFile;
+use std::os::fd::{AsRawFd, FromRawFd};
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use axum::extract::{Path as AxPath, State};
+use axum::http::StatusCode;
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use base64::Engine as _;
+use chacha20poly1305::aead::{Aead, KeyInit};
+use chacha20poly1305::{ChaCha20Poly1305, Key, Nonce};
+use rand::RngCore;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use tokio::fs::File as TokioFile;
+use tokio::fs::OpenOptions;
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::process::{Child, Command};
+use tokio::sync::{broadcast, Mutex, RwLock};
+use uuid::Uuid;
+
+use crate::error::{Error, Result};
+use crate::taint::IntegrityState;
+
+const DEFAULT_HTTP_ADDR: &str = "127.0.0.1:7683";
+const DEFAULT_ATTACH_ADDR: &str = "127.0.0.1:7684";
+const DEFAULT_DIR: &str = "/var/lib/devopsdefender/sessiond";
+const RING_LIMIT: usize = 256 * 1024;
+
+const CODEX_PODMAN_RECIPE: &str = r#"#!/var/lib/easyenclave/bin/busybox sh
+set -eu
+BB=/var/lib/easyenclave/bin/busybox
+BIN=/var/lib/easyenclave/bin
+PODMAN=$BIN/podman
+SESSION_ID=${DD_SESSION_ID:-manual-$$}
+SESSION_DIR=${DD_SESSION_DIR:-/var/lib/easyenclave/data/dd-shell/sessions/$SESSION_ID}
+WORKSPACE=${DD_WORKSPACE:-$SESSION_DIR/workspace}
+HOME_DIR=${DD_HOME:-$SESSION_DIR/home}
+CACHE_DIR=${DD_CACHE:-$SESSION_DIR/cache}
+TMP_DIR=${TMPDIR:-$SESSION_DIR/tmp}
+until [ -x "$PODMAN" ]; do echo "codex-podman: waiting for podman"; $BB sleep 2; done
+$BB mkdir -p "$HOME_DIR" "$WORKSPACE" "$CACHE_DIR" "$TMP_DIR"
+$BB chmod 1777 "$TMP_DIR"
+SAFE_SESSION=$(printf '%s' "$SESSION_ID" | $BB tr -c 'A-Za-z0-9_.-' '-')
+exec "$PODMAN" run --rm --replace -it --pull=missing \
+  --cgroups=disabled \
+  --network=host \
+  --name "codex-shell-$SAFE_SESSION" \
+  -e HOME=/root \
+  -e TERM=xterm-256color \
+  -e COLORTERM=truecolor \
+  -e NPM_CONFIG_PREFIX=/root/.npm-global \
+  -v "$HOME_DIR:/root" \
+  -v "$WORKSPACE:/workspace" \
+  -v "$CACHE_DIR:/root/.cache" \
+  -v "$TMP_DIR:/tmp" \
+  -w /workspace \
+  docker.io/library/node:22-bookworm \
+  sh -lc 'set -e; mkdir -p "$HOME/.npm-global/bin" "$HOME/.local/bin"; printf "%s\n" "export NPM_CONFIG_PREFIX=\${NPM_CONFIG_PREFIX:-\$HOME/.npm-global}" "export PATH=\"\$HOME/.npm-global/bin:\$HOME/.local/bin:\$PATH\"" > "$HOME/.bashrc"; printf "%s\n" "[ -r \"\$HOME/.bashrc\" ] && . \"\$HOME/.bashrc\"" > "$HOME/.bash_profile"; export PATH="$HOME/.npm-global/bin:$HOME/.local/bin:$PATH"; if ! command -v codex >/dev/null 2>&1; then npm install -g @openai/codex; fi; exec bash -l'
+"#;
+
+const PODMAN_UBUNTU_RECIPE: &str = r#"#!/var/lib/easyenclave/bin/busybox sh
+set -eu
+BB=/var/lib/easyenclave/bin/busybox
+BIN=/var/lib/easyenclave/bin
+PODMAN=$BIN/podman
+SESSION_ID=${DD_SESSION_ID:-manual-$$}
+SESSION_DIR=${DD_SESSION_DIR:-/var/lib/easyenclave/data/dd-shell/sessions/$SESSION_ID}
+WORKSPACE=${DD_WORKSPACE:-$SESSION_DIR/workspace}
+HOME_DIR=${DD_HOME:-$SESSION_DIR/home}
+CACHE_DIR=${DD_CACHE:-$SESSION_DIR/cache}
+TMP_DIR=${TMPDIR:-$SESSION_DIR/tmp}
+until [ -x "$PODMAN" ]; do echo "podman-ubuntu: waiting for podman"; $BB sleep 2; done
+$BB mkdir -p "$HOME_DIR" "$WORKSPACE" "$CACHE_DIR" "$TMP_DIR"
+$BB chmod 1777 "$TMP_DIR"
+SAFE_SESSION=$(printf '%s' "$SESSION_ID" | $BB tr -c 'A-Za-z0-9_.-' '-')
+exec "$PODMAN" run --rm --replace -it --pull=missing \
+  --cgroups=disabled \
+  --network=host \
+  --name "ubuntu-shell-$SAFE_SESSION" \
+  -e HOME=/root \
+  -e TERM=xterm-256color \
+  -e COLORTERM=truecolor \
+  -v "$HOME_DIR:/root" \
+  -v "$WORKSPACE:/workspace" \
+  -v "$CACHE_DIR:/root/.cache" \
+  -v "$TMP_DIR:/tmp" \
+  -w /workspace \
+  docker.io/library/ubuntu:24.04 \
+  bash -l
+"#;
+
+const PODMAN_ALPINE_RECIPE: &str = r#"#!/var/lib/easyenclave/bin/busybox sh
+set -eu
+BB=/var/lib/easyenclave/bin/busybox
+BIN=/var/lib/easyenclave/bin
+PODMAN=$BIN/podman
+SESSION_ID=${DD_SESSION_ID:-manual-$$}
+SESSION_DIR=${DD_SESSION_DIR:-/var/lib/easyenclave/data/dd-shell/sessions/$SESSION_ID}
+WORKSPACE=${DD_WORKSPACE:-$SESSION_DIR/workspace}
+HOME_DIR=${DD_HOME:-$SESSION_DIR/home}
+CACHE_DIR=${DD_CACHE:-$SESSION_DIR/cache}
+TMP_DIR=${TMPDIR:-$SESSION_DIR/tmp}
+until [ -x "$PODMAN" ]; do echo "podman-alpine: waiting for podman"; $BB sleep 2; done
+$BB mkdir -p "$HOME_DIR" "$WORKSPACE" "$CACHE_DIR" "$TMP_DIR"
+$BB chmod 1777 "$TMP_DIR"
+SAFE_SESSION=$(printf '%s' "$SESSION_ID" | $BB tr -c 'A-Za-z0-9_.-' '-')
+exec "$PODMAN" run --rm --replace -it --pull=missing \
+  --cgroups=disabled \
+  --network=host \
+  --name "alpine-shell-$SAFE_SESSION" \
+  -e HOME=/root \
+  -e TERM=xterm-256color \
+  -e COLORTERM=truecolor \
+  -v "$HOME_DIR:/root" \
+  -v "$WORKSPACE:/workspace" \
+  -v "$CACHE_DIR:/root/.cache" \
+  -v "$TMP_DIR:/tmp" \
+  -w /workspace \
+  docker.io/library/alpine:3.20 \
+  /bin/sh
+"#;
+
+#[derive(Clone)]
+struct App {
+    sessions: Arc<RwLock<HashMap<String, Arc<Session>>>>,
+    store: TranscriptStore,
+    recipes: Arc<Vec<Recipe>>,
+    scratch_root: PathBuf,
+}
+
+struct Session {
+    meta: RwLock<SessionMeta>,
+    input: Mutex<TokioFile>,
+    master_fd: i32,
+    child: Mutex<Child>,
+    pgid: i32,
+    tx: broadcast::Sender<Vec<u8>>,
+    ring: Mutex<VecDeque<u8>>,
+    scratch_dir: Option<PathBuf>,
+    cleanup_scratch_on_exit: bool,
+}
+
+#[derive(Clone, Deserialize, Serialize)]
+pub struct SessionMeta {
+    pub id: String,
+    pub name: String,
+    pub recipe_id: String,
+    pub recipe_title: String,
+    pub workspace_policy: WorkspacePolicy,
+    pub command: String,
+    pub cwd: String,
+    pub terminal_mode: TerminalMode,
+    pub integrity_state: IntegrityState,
+    pub integrity_reason: String,
+    pub created_at: i64,
+    pub updated_at: i64,
+    pub status: SessionStatus,
+    pub exit_code: Option<i32>,
+}
+
+#[derive(Clone, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TerminalMode {
+    ReadWrite,
+}
+
+#[derive(Clone, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SessionStatus {
+    Running,
+    Exited,
+}
+
+#[derive(Clone, Deserialize, Serialize)]
+pub struct Recipe {
+    pub id: String,
+    pub title: String,
+    pub description: String,
+    pub command: String,
+    pub cwd: String,
+    pub workspace_policy: WorkspacePolicy,
+}
+
+#[derive(Clone, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkspacePolicy {
+    EphemeralScratch,
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct CreateSession {
+    pub name: Option<String>,
+    pub recipe_id: Option<String>,
+    pub command: Option<String>,
+    pub cwd: Option<String>,
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct CreateSessionResponse {
+    pub id: String,
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct ResizeSession {
+    pub cols: u16,
+    pub rows: u16,
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct ReplayResponse {
+    pub id: String,
+    pub bytes_b64: String,
+}
+
+struct RecipeSeed {
+    id: &'static str,
+    title: &'static str,
+    description: &'static str,
+    script_name: &'static str,
+    script: &'static str,
+}
+
+#[derive(Clone)]
+struct TranscriptStore {
+    dir: PathBuf,
+    key: [u8; 32],
+}
+
+#[derive(Serialize, Deserialize)]
+struct TranscriptRecord {
+    ts: i64,
+    kind: String,
+    data_b64: String,
+}
+
+pub async fn run() -> Result<()> {
+    let http_addr =
+        std::env::var("DD_SESSIOND_HTTP_ADDR").unwrap_or_else(|_| DEFAULT_HTTP_ADDR.to_string());
+    let attach_addr = std::env::var("DD_SESSIOND_ATTACH_ADDR")
+        .unwrap_or_else(|_| DEFAULT_ATTACH_ADDR.to_string());
+    let dir = std::env::var("DD_SESSIOND_DIR")
+        .or_else(|_| std::env::var("DD_SHELL_DIR"))
+        .unwrap_or_else(|_| DEFAULT_DIR.into());
+    let requested_shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".into());
+    let scratch_root = std::env::var("DD_SESSIOND_SCRATCH_DIR")
+        .or_else(|_| std::env::var("DD_SHELL_SCRATCH_DIR"))
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from(&dir).join("sessions"));
+
+    let root = PathBuf::from(&dir);
+    let store = TranscriptStore::new(root.clone()).await?;
+    tokio::fs::create_dir_all(&scratch_root).await?;
+    set_private_dir_permissions(&scratch_root).await?;
+    let recipe_dir = root.join("recipes");
+    let default_shell = install_default_shell_command(&recipe_dir, &requested_shell).await?;
+    let recipe_scripts = install_builtin_recipe_scripts(&recipe_dir).await?;
+    let recipes = Arc::new(load_recipes(&default_shell, recipe_scripts));
+
+    let app_state = App {
+        sessions: Arc::new(RwLock::new(HashMap::new())),
+        store,
+        recipes,
+        scratch_root,
+    };
+
+    {
+        let state = app_state.clone();
+        let attach_addr = attach_addr.clone();
+        tokio::spawn(async move {
+            if let Err(e) = run_attach_listener(state, &attach_addr).await {
+                eprintln!("dd-sessiond: attach listener exited: {e}");
+            }
+        });
+    }
+
+    let app = Router::new()
+        .route("/api/recipes", get(list_recipes))
+        .route("/api/sessions", get(list_sessions).post(create_session))
+        .route("/api/sessions/{id}/replay", get(replay_session))
+        .route("/api/sessions/{id}/resize", post(resize_session))
+        .route("/api/sessions/{id}/close", post(close_session))
+        .with_state(app_state);
+
+    eprintln!("dd-sessiond: http listening on {http_addr}");
+    let listener = TcpListener::bind(&http_addr).await?;
+    axum::serve(listener, app.into_make_service())
+        .await
+        .map_err(|e| Error::Internal(e.to_string()))
+}
+
+async fn list_recipes(State(app): State<App>) -> Json<Vec<Recipe>> {
+    Json((*app.recipes).clone())
+}
+
+async fn list_sessions(State(app): State<App>) -> Json<Vec<SessionMeta>> {
+    let sessions: Vec<Arc<Session>> = app.sessions.read().await.values().cloned().collect();
+    let mut out = Vec::with_capacity(sessions.len());
+    for session in sessions {
+        out.push(session.meta.read().await.clone());
+    }
+    out.sort_by_key(|s| Reverse(s.updated_at));
+    Json(out)
+}
+
+async fn create_session(
+    State(app): State<App>,
+    Json(req): Json<CreateSession>,
+) -> Result<Json<CreateSessionResponse>> {
+    let id = Uuid::new_v4().to_string();
+    let recipe = select_recipe(&app, req.recipe_id.as_deref(), req.command)?;
+    let command = recipe.command.clone();
+    let cwd = req.cwd.unwrap_or_else(|| recipe.cwd.clone());
+    let name = req.name.unwrap_or_else(|| session_name(&recipe, &id));
+    let now = unix_ts();
+    let scratch_dir = prepare_scratch_dir(&app, &id, &recipe.workspace_policy).await?;
+    let env = session_env(&id, scratch_dir.as_deref());
+
+    let (child, output, input, pgid) = spawn_pty(&command, &cwd, &env)?;
+    let master_fd = input.as_raw_fd();
+    let (tx, _) = broadcast::channel(512);
+
+    let meta = SessionMeta {
+        id: id.clone(),
+        name,
+        recipe_id: recipe.id,
+        recipe_title: recipe.title,
+        workspace_policy: recipe.workspace_policy,
+        command,
+        cwd,
+        terminal_mode: TerminalMode::ReadWrite,
+        integrity_state: IntegrityState::Controlled,
+        integrity_reason: "interactive_pty_control".into(),
+        created_at: now,
+        updated_at: now,
+        status: SessionStatus::Running,
+        exit_code: None,
+    };
+    app.store.append_meta(&meta).await?;
+
+    let session = Arc::new(Session {
+        meta: RwLock::new(meta),
+        input: Mutex::new(input),
+        master_fd,
+        child: Mutex::new(child),
+        pgid,
+        tx,
+        ring: Mutex::new(VecDeque::with_capacity(RING_LIMIT)),
+        scratch_dir,
+        cleanup_scratch_on_exit: true,
+    });
+
+    app.sessions
+        .write()
+        .await
+        .insert(id.clone(), session.clone());
+    spawn_reader(app.store.clone(), session.clone(), output, "pty");
+    spawn_waiter(app.store.clone(), session.clone());
+
+    Ok(Json(CreateSessionResponse { id }))
+}
+
+async fn replay_session(
+    State(app): State<App>,
+    AxPath(id): AxPath<String>,
+) -> Result<Json<ReplayResponse>> {
+    let bytes = app.store.replay(&id).await?;
+    Ok(Json(ReplayResponse {
+        id,
+        bytes_b64: base64::engine::general_purpose::STANDARD.encode(bytes),
+    }))
+}
+
+async fn resize_session(
+    State(app): State<App>,
+    AxPath(id): AxPath<String>,
+    Json(req): Json<ResizeSession>,
+) -> Result<StatusCode> {
+    if req.cols == 0 || req.rows == 0 {
+        return Err(Error::BadRequest("terminal size must be non-zero".into()));
+    }
+    let Some(session) = app.sessions.read().await.get(&id).cloned() else {
+        return Err(Error::NotFound);
+    };
+    let winsize = libc::winsize {
+        ws_row: req.rows,
+        ws_col: req.cols,
+        ws_xpixel: 0,
+        ws_ypixel: 0,
+    };
+    let rc = unsafe { libc::ioctl(session.master_fd, libc::TIOCSWINSZ, &winsize) };
+    if rc != 0 {
+        return Err(Error::Internal(format!(
+            "resize pty: {}",
+            std::io::Error::last_os_error()
+        )));
+    }
+    if session.pgid > 0 {
+        unsafe {
+            libc::kill(-session.pgid, libc::SIGWINCH);
+        }
+    }
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn close_session(State(app): State<App>, AxPath(id): AxPath<String>) -> Result<StatusCode> {
+    let Some(session) = app.sessions.write().await.remove(&id) else {
+        return Err(Error::NotFound);
+    };
+    let pgid = session.pgid;
+    mark_session_exited(&app.store, &session, None).await;
+    terminate_process_group(id, pgid);
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn run_attach_listener(app: App, addr: &str) -> Result<()> {
+    let listener = TcpListener::bind(addr).await?;
+    eprintln!("dd-sessiond: attach listening on {addr}");
+    loop {
+        let (stream, _) = listener.accept().await?;
+        let app = app.clone();
+        tokio::spawn(async move {
+            if let Err(e) = handle_attach(app, stream).await {
+                eprintln!("dd-sessiond: attach failed: {e}");
+            }
+        });
+    }
+}
+
+async fn handle_attach(app: App, stream: TcpStream) -> anyhow::Result<()> {
+    let mut reader = BufReader::new(stream);
+    let mut line = String::new();
+    reader.read_line(&mut line).await?;
+    let mut parts = line.split_whitespace();
+    let id = parts
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("missing session id"))?;
+    let tail = parts.next() != Some("notail");
+    let session = app
+        .sessions
+        .read()
+        .await
+        .get(id)
+        .cloned()
+        .ok_or_else(|| anyhow::anyhow!("unknown session: {id}"))?;
+    let stream = reader.into_inner();
+    attach_stream(stream, session, tail).await
+}
+
+async fn attach_stream(stream: TcpStream, session: Arc<Session>, tail: bool) -> anyhow::Result<()> {
+    let (mut reader, mut writer) = stream.into_split();
+
+    if tail {
+        let ring = session.ring.lock().await;
+        if !ring.is_empty() {
+            let bytes: Vec<u8> = ring.iter().copied().collect();
+            writer.write_all(&bytes).await?;
+        }
+    }
+
+    let mut output_rx = session.tx.subscribe();
+    let output = tokio::spawn(async move {
+        while let Ok(bytes) = output_rx.recv().await {
+            if writer.write_all(&bytes).await.is_err() {
+                break;
+            }
+        }
+    });
+
+    let mut buf = [0u8; 4096];
+    loop {
+        let n = reader.read(&mut buf).await?;
+        if n == 0 {
+            break;
+        }
+        session.input.lock().await.write_all(&buf[..n]).await?;
+    }
+    output.abort();
+    Ok(())
+}
+
+fn select_recipe(app: &App, recipe_id: Option<&str>, command: Option<String>) -> Result<Recipe> {
+    if let Some(command) = command {
+        let command = command.trim();
+        if command.is_empty() {
+            return Err(Error::BadRequest("command must not be empty".into()));
+        }
+        return Ok(Recipe {
+            id: "custom".into(),
+            title: "Custom".into(),
+            description: "Custom command".into(),
+            command: command.into(),
+            cwd: "/".into(),
+            workspace_policy: WorkspacePolicy::EphemeralScratch,
+        });
+    }
+
+    let id = recipe_id.unwrap_or("shell");
+    app.recipes
+        .iter()
+        .find(|recipe| recipe.id == id)
+        .cloned()
+        .ok_or_else(|| Error::BadRequest(format!("unknown recipe: {id}")))
+}
+
+async fn install_default_shell_command(dir: &Path, requested_shell: &str) -> Result<String> {
+    if executable_exists(requested_shell).await {
+        return Ok(requested_shell.into());
+    }
+    if executable_exists("/bin/sh").await {
+        return Ok("/bin/sh".into());
+    }
+    if executable_exists("/var/lib/easyenclave/bin/busybox").await {
+        tokio::fs::create_dir_all(dir).await?;
+        set_private_dir_permissions(dir).await?;
+        let path = dir.join("plain-shell");
+        tokio::fs::write(
+            &path,
+            "#!/var/lib/easyenclave/bin/busybox sh\nexec /var/lib/easyenclave/bin/busybox sh\n",
+        )
+        .await?;
+        set_private_file_permissions(&path).await?;
+        return Ok(path.display().to_string());
+    }
+    Ok(requested_shell.into())
+}
+
+async fn executable_exists(path: &str) -> bool {
+    match tokio::fs::metadata(path).await {
+        Ok(meta) => meta.is_file() && meta.permissions().mode() & 0o111 != 0,
+        Err(_) => false,
+    }
+}
+
+async fn install_builtin_recipe_scripts(dir: &Path) -> Result<Vec<Recipe>> {
+    tokio::fs::create_dir_all(dir).await?;
+    set_private_dir_permissions(dir).await?;
+
+    let mut recipes = Vec::new();
+    for seed in builtin_recipe_seeds() {
+        let path = dir.join(seed.script_name);
+        tokio::fs::write(&path, seed.script).await?;
+        set_private_file_permissions(&path).await?;
+        recipes.push(Recipe {
+            id: seed.id.into(),
+            title: seed.title.into(),
+            description: seed.description.into(),
+            command: path.display().to_string(),
+            cwd: "/".into(),
+            workspace_policy: WorkspacePolicy::EphemeralScratch,
+        });
+    }
+    Ok(recipes)
+}
+
+fn load_recipes(default_shell: &str, mut builtin_recipes: Vec<Recipe>) -> Vec<Recipe> {
+    let mut recipes = vec![Recipe {
+        id: "shell".into(),
+        title: "Shell".into(),
+        description: "Plain interactive shell with encrypted transcript history".into(),
+        command: default_shell.into(),
+        cwd: "/".into(),
+        workspace_policy: WorkspacePolicy::EphemeralScratch,
+    }];
+    recipes.append(&mut builtin_recipes);
+
+    if let Ok(command) = std::env::var("DD_SESSIOND_CODEX_COMMAND")
+        .or_else(|_| std::env::var("DD_SHELL_CODEX_COMMAND"))
+    {
+        let command = command.trim();
+        if !command.is_empty() {
+            upsert_recipe(
+                &mut recipes,
+                Recipe {
+                    id: "codex-podman".into(),
+                    title: "Codex".into(),
+                    description: "Podman-backed Codex development session".into(),
+                    command: command.into(),
+                    cwd: "/".into(),
+                    workspace_policy: WorkspacePolicy::EphemeralScratch,
+                },
+            );
+        }
+    }
+
+    recipes
+}
+
+fn upsert_recipe(recipes: &mut Vec<Recipe>, recipe: Recipe) {
+    if let Some(existing) = recipes.iter_mut().find(|r| r.id == recipe.id) {
+        *existing = recipe;
+    } else {
+        recipes.push(recipe);
+    }
+}
+
+fn builtin_recipe_seeds() -> Vec<RecipeSeed> {
+    vec![
+        RecipeSeed {
+            id: "codex-podman",
+            title: "Codex",
+            description: "Podman-backed Codex development session",
+            script_name: "codex-podman",
+            script: CODEX_PODMAN_RECIPE,
+        },
+        RecipeSeed {
+            id: "podman-ubuntu",
+            title: "Ubuntu",
+            description: "Podman Ubuntu 24.04 shell",
+            script_name: "podman-ubuntu",
+            script: PODMAN_UBUNTU_RECIPE,
+        },
+        RecipeSeed {
+            id: "podman-alpine",
+            title: "Alpine",
+            description: "Podman Alpine shell",
+            script_name: "podman-alpine",
+            script: PODMAN_ALPINE_RECIPE,
+        },
+    ]
+}
+
+async fn prepare_scratch_dir(
+    app: &App,
+    id: &str,
+    policy: &WorkspacePolicy,
+) -> Result<Option<PathBuf>> {
+    match policy {
+        WorkspacePolicy::EphemeralScratch => {
+            let root = app.scratch_root.join(id);
+            tokio::fs::create_dir_all(&root).await?;
+            set_private_dir_permissions(&root).await?;
+            for name in ["workspace", "home", "containers", "cache", "tmp"] {
+                let path = root.join(name);
+                tokio::fs::create_dir_all(&path).await?;
+                set_private_dir_permissions(&path).await?;
+            }
+            Ok(Some(root))
+        }
+    }
+}
+
+async fn set_private_dir_permissions(path: &Path) -> Result<()> {
+    let permissions = std::fs::Permissions::from_mode(0o700);
+    tokio::fs::set_permissions(path, permissions).await?;
+    Ok(())
+}
+
+async fn set_private_file_permissions(path: &Path) -> Result<()> {
+    let permissions = std::fs::Permissions::from_mode(0o700);
+    tokio::fs::set_permissions(path, permissions).await?;
+    Ok(())
+}
+
+fn session_env(id: &str, scratch_dir: Option<&Path>) -> Vec<(String, String)> {
+    let mut env = vec![("DD_SESSION_ID".into(), id.into())];
+    if let Some(root) = scratch_dir {
+        env.push(("DD_SESSION_DIR".into(), root.display().to_string()));
+        env.push((
+            "DD_WORKSPACE".into(),
+            root.join("workspace").display().to_string(),
+        ));
+        env.push(("DD_HOME".into(), root.join("home").display().to_string()));
+        env.push((
+            "DD_CONTAINER_ROOT".into(),
+            root.join("containers").display().to_string(),
+        ));
+        env.push(("DD_CACHE".into(), root.join("cache").display().to_string()));
+        env.push(("TMPDIR".into(), root.join("tmp").display().to_string()));
+    }
+    env
+}
+
+fn session_name(recipe: &Recipe, id: &str) -> String {
+    format!("{}-{}", recipe.id, &id[..8])
+}
+
+fn spawn_pty(
+    command: &str,
+    cwd: &str,
+    env_vars: &[(String, String)],
+) -> Result<(Child, TokioFile, TokioFile, i32)> {
+    let mut master = -1;
+    let mut slave = -1;
+    let winsize = libc::winsize {
+        ws_row: 24,
+        ws_col: 80,
+        ws_xpixel: 0,
+        ws_ypixel: 0,
+    };
+    let open_rc = unsafe {
+        libc::openpty(
+            &mut master,
+            &mut slave,
+            std::ptr::null_mut(),
+            std::ptr::null(),
+            &winsize,
+        )
+    };
+    if open_rc != 0 {
+        return Err(Error::Internal(format!(
+            "openpty: {}",
+            std::io::Error::last_os_error()
+        )));
+    }
+
+    let master = unsafe { StdFile::from_raw_fd(master) };
+    let output = TokioFile::from_std(
+        master
+            .try_clone()
+            .map_err(|e| Error::Internal(format!("pty master clone: {e}")))?,
+    );
+    let input = TokioFile::from_std(master);
+    let slave = unsafe { StdFile::from_raw_fd(slave) };
+    let slave_fd = slave.as_raw_fd();
+
+    let dup_slave = || -> std::io::Result<StdFile> {
+        let fd = unsafe { libc::dup(slave_fd) };
+        if fd < 0 {
+            Err(std::io::Error::last_os_error())
+        } else {
+            Ok(unsafe { StdFile::from_raw_fd(fd) })
+        }
+    };
+
+    let mut cmd = Command::new(command);
+    cmd.current_dir(cwd)
+        .env("TERM", "xterm-256color")
+        .env("COLORTERM", "truecolor")
+        .stdin(Stdio::from(
+            dup_slave().map_err(|e| Error::Internal(format!("pty stdin dup: {e}")))?,
+        ))
+        .stdout(Stdio::from(
+            dup_slave().map_err(|e| Error::Internal(format!("pty stdout dup: {e}")))?,
+        ))
+        .stderr(Stdio::from(
+            dup_slave().map_err(|e| Error::Internal(format!("pty stderr dup: {e}")))?,
+        ));
+    for (key, value) in env_vars {
+        cmd.env(key, value);
+    }
+    unsafe {
+        cmd.pre_exec(move || {
+            if libc::setsid() < 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            if libc::ioctl(slave_fd, libc::TIOCSCTTY, 0) < 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+    let child = cmd
+        .spawn()
+        .map_err(|e| Error::BadRequest(format!("spawn {command}: {e}")))?;
+    let pgid = child.id().map(|pid| pid as i32).unwrap_or_default();
+    drop(slave);
+    Ok((child, output, input, pgid))
+}
+
+fn terminate_process_group(id: String, pgid: i32) {
+    if pgid <= 0 {
+        return;
+    }
+    tokio::spawn(async move {
+        for (signal, delay) in [
+            (libc::SIGHUP, Duration::from_millis(250)),
+            (libc::SIGTERM, Duration::from_millis(1500)),
+            (libc::SIGKILL, Duration::ZERO),
+        ] {
+            let rc = unsafe { libc::kill(-pgid, signal) };
+            if rc != 0 {
+                let err = std::io::Error::last_os_error();
+                if err.raw_os_error() != Some(libc::ESRCH) {
+                    eprintln!("dd-sessiond: signal {signal} for {id}: {err}");
+                }
+                break;
+            }
+            if !delay.is_zero() {
+                tokio::time::sleep(delay).await;
+            }
+        }
+    });
+}
+
+fn spawn_reader<R>(store: TranscriptStore, session: Arc<Session>, mut reader: R, kind: &'static str)
+where
+    R: tokio::io::AsyncRead + Unpin + Send + 'static,
+{
+    tokio::spawn(async move {
+        let id = session.meta.read().await.id.clone();
+        let mut buf = [0u8; 4096];
+        loop {
+            match reader.read(&mut buf).await {
+                Ok(0) => break,
+                Ok(n) => {
+                    let bytes = buf[..n].to_vec();
+                    push_ring(&session, &bytes).await;
+                    let _ = session.tx.send(bytes.clone());
+                    if let Err(e) = store.append_bytes(&id, kind, &bytes).await {
+                        eprintln!("dd-sessiond: transcript append failed: {e}");
+                    }
+                    session.meta.write().await.updated_at = unix_ts();
+                }
+                Err(e) => {
+                    eprintln!("dd-sessiond: {kind} read failed: {e}");
+                    break;
+                }
+            }
+        }
+    });
+}
+
+fn spawn_waiter(store: TranscriptStore, session: Arc<Session>) {
+    tokio::spawn(async move {
+        let status = {
+            let mut child = session.child.lock().await;
+            child.wait().await
+        };
+        mark_session_exited(&store, &session, status.ok().and_then(|s| s.code())).await;
+        cleanup_session_scratch(&session).await;
+    });
+}
+
+async fn mark_session_exited(store: &TranscriptStore, session: &Session, exit_code: Option<i32>) {
+    let mut meta = session.meta.write().await;
+    if matches!(meta.status, SessionStatus::Exited) {
+        return;
+    }
+    meta.updated_at = unix_ts();
+    meta.status = SessionStatus::Exited;
+    meta.exit_code = exit_code;
+    if let Err(e) = store.append_meta(&meta).await {
+        eprintln!("dd-sessiond: exit meta append failed: {e}");
+    }
+}
+
+async fn cleanup_session_scratch(session: &Session) {
+    if !session.cleanup_scratch_on_exit {
+        return;
+    }
+    let Some(path) = &session.scratch_dir else {
+        return;
+    };
+    match tokio::fs::remove_dir_all(path).await {
+        Ok(()) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => eprintln!(
+            "dd-sessiond: scratch cleanup failed for {}: {e}",
+            path.display()
+        ),
+    }
+}
+
+async fn push_ring(session: &Session, bytes: &[u8]) {
+    let mut ring = session.ring.lock().await;
+    for b in bytes {
+        if ring.len() >= RING_LIMIT {
+            ring.pop_front();
+        }
+        ring.push_back(*b);
+    }
+}
+
+impl TranscriptStore {
+    async fn new(dir: PathBuf) -> Result<Self> {
+        tokio::fs::create_dir_all(&dir).await?;
+        let key = history_key(&dir).await?;
+        Ok(Self { dir, key })
+    }
+
+    async fn append_meta(&self, meta: &SessionMeta) -> Result<()> {
+        let bytes = serde_json::to_vec(meta).map_err(|e| Error::Internal(e.to_string()))?;
+        self.append_bytes(&meta.id, "meta", &bytes).await
+    }
+
+    async fn append_bytes(&self, id: &str, kind: &str, bytes: &[u8]) -> Result<()> {
+        let record = TranscriptRecord {
+            ts: unix_ts(),
+            kind: kind.to_string(),
+            data_b64: base64::engine::general_purpose::STANDARD.encode(bytes),
+        };
+        let plain = serde_json::to_vec(&record).map_err(|e| Error::Internal(e.to_string()))?;
+        let line = self.encrypt_line(&plain)?;
+        let path = self.path(id);
+        let mut f = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+            .await?;
+        f.write_all(line.as_bytes()).await?;
+        f.write_all(b"\n").await?;
+        Ok(())
+    }
+
+    async fn replay(&self, id: &str) -> Result<Vec<u8>> {
+        let path = self.path(id);
+        if !Path::new(&path).exists() {
+            return Err(Error::NotFound);
+        }
+        let text = tokio::fs::read_to_string(path).await?;
+        let mut out = Vec::new();
+        for line in text.lines().filter(|l| !l.trim().is_empty()) {
+            let plain = self.decrypt_line(line)?;
+            let record: TranscriptRecord =
+                serde_json::from_slice(&plain).map_err(|e| Error::Internal(e.to_string()))?;
+            if record.kind == "pty" || record.kind == "stdout" || record.kind == "stderr" {
+                let bytes = base64::engine::general_purpose::STANDARD
+                    .decode(record.data_b64)
+                    .map_err(|e| Error::Internal(e.to_string()))?;
+                out.extend_from_slice(&bytes);
+            }
+        }
+        Ok(out)
+    }
+
+    fn path(&self, id: &str) -> PathBuf {
+        self.dir.join(format!("{id}.log.enc"))
+    }
+
+    fn encrypt_line(&self, plain: &[u8]) -> Result<String> {
+        let cipher = ChaCha20Poly1305::new(Key::from_slice(&self.key));
+        let mut nonce = [0u8; 12];
+        rand::thread_rng().fill_bytes(&mut nonce);
+        let ciphertext = cipher
+            .encrypt(Nonce::from_slice(&nonce), plain)
+            .map_err(|e| Error::Internal(format!("encrypt transcript: {e}")))?;
+        let mut packed = nonce.to_vec();
+        packed.extend_from_slice(&ciphertext);
+        Ok(base64::engine::general_purpose::STANDARD.encode(packed))
+    }
+
+    fn decrypt_line(&self, line: &str) -> Result<Vec<u8>> {
+        let packed = base64::engine::general_purpose::STANDARD
+            .decode(line)
+            .map_err(|e| Error::Internal(e.to_string()))?;
+        if packed.len() < 13 {
+            return Err(Error::Internal("truncated transcript record".into()));
+        }
+        let (nonce, ciphertext) = packed.split_at(12);
+        let cipher = ChaCha20Poly1305::new(Key::from_slice(&self.key));
+        cipher
+            .decrypt(Nonce::from_slice(nonce), ciphertext)
+            .map_err(|e| Error::Internal(format!("decrypt transcript: {e}")))
+    }
+}
+
+async fn history_key(dir: &Path) -> Result<[u8; 32]> {
+    if let Ok(raw) =
+        std::env::var("DD_SESSIOND_HISTORY_KEY").or_else(|_| std::env::var("DD_SHELL_HISTORY_KEY"))
+    {
+        let bytes = base64::engine::general_purpose::STANDARD
+            .decode(raw.trim())
+            .or_else(|_| hex::decode(raw.trim()))
+            .map_err(|_| {
+                Error::BadRequest("DD_SESSIOND_HISTORY_KEY must be base64 or hex".into())
+            })?;
+        if bytes.len() != 32 {
+            return Err(Error::BadRequest(
+                "DD_SESSIOND_HISTORY_KEY must decode to 32 bytes".into(),
+            ));
+        }
+        let mut key = [0u8; 32];
+        key.copy_from_slice(&bytes);
+        return Ok(key);
+    }
+
+    let key_path = dir.join("history.key");
+    if let Ok(bytes) = tokio::fs::read(&key_path).await {
+        if bytes.len() == 32 {
+            let mut key = [0u8; 32];
+            key.copy_from_slice(&bytes);
+            return Ok(key);
+        }
+    }
+
+    let mut material = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut material);
+    tokio::fs::write(&key_path, material).await?;
+    let mut hasher = Sha256::new();
+    hasher.update(material);
+    hasher.update(b"dd-sessiond-history-v1");
+    Ok(hasher.finalize().into())
+}
+
+fn unix_ts() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or(Duration::ZERO)
+        .as_secs() as i64
+}

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -2,6 +2,7 @@
 //!
 //! One process per VM, multiple reconnectable PTY sessions, read-only workload
 //! terminals, and encrypted append-only transcripts on disk.
+#![allow(dead_code, unused_imports)]
 
 use std::cmp::Reverse;
 use std::collections::{HashMap, VecDeque};
@@ -30,6 +31,7 @@ use sha2::{Digest, Sha256};
 use tokio::fs::File as TokioFile;
 use tokio::fs::OpenOptions;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
 use tokio::process::{Child, Command};
 use tokio::sync::{broadcast, Mutex, RwLock};
 use uuid::Uuid;
@@ -143,6 +145,8 @@ struct App {
     ee: Arc<Ee>,
     http: reqwest::Client,
     agent_api: String,
+    sessiond_http_url: String,
+    sessiond_attach_addr: String,
     owner: crate::gh_oidc::Principal,
     auth: crate::auth::AuthConfig,
     hostname: String,
@@ -217,7 +221,7 @@ enum WorkspacePolicy {
     EphemeralScratch,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Serialize)]
 struct CreateSession {
     name: Option<String>,
     recipe_id: Option<String>,
@@ -230,7 +234,7 @@ struct CreateSessionResponse {
     id: String,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Serialize)]
 struct ResizeSession {
     cols: u16,
     rows: u16,
@@ -291,6 +295,10 @@ pub async fn run() -> Result<()> {
         .unwrap_or_else(|_| "/var/lib/easyenclave/agent.sock".into());
     let agent_api = std::env::var("DD_SHELL_AGENT_API_URL")
         .unwrap_or_else(|_| format!("http://127.0.0.1:{}", crate::cf::AGENT_API_PORT));
+    let sessiond_http_url =
+        std::env::var("DD_SESSIOND_HTTP_URL").unwrap_or_else(|_| "http://127.0.0.1:7683".into());
+    let sessiond_attach_addr =
+        std::env::var("DD_SESSIOND_ATTACH_ADDR").unwrap_or_else(|_| "127.0.0.1:7684".into());
     let shell_dir = PathBuf::from(&dir);
     let store = TranscriptStore::new(shell_dir.clone()).await?;
     tokio::fs::create_dir_all(&scratch_root).await?;
@@ -310,6 +318,8 @@ pub async fn run() -> Result<()> {
             .build()
             .unwrap_or_else(|_| crate::system_http_client()),
         agent_api,
+        sessiond_http_url,
+        sessiond_attach_addr,
         owner: common.owner,
         auth,
         hostname,
@@ -491,24 +501,18 @@ async fn list_recipes(
     State(app): State<App>,
     headers: HeaderMap,
     uri: Uri,
-) -> Result<Json<Vec<Recipe>>> {
+) -> Result<Json<Vec<crate::sessiond::Recipe>>> {
     ensure_shell_auth(&app, &headers, &uri)?;
-    Ok(Json((*app.recipes).clone()))
+    sessiond_get(&app, "/api/recipes").await.map(Json)
 }
 
 async fn list_sessions(
     State(app): State<App>,
     headers: HeaderMap,
     uri: Uri,
-) -> Result<Json<Vec<SessionMeta>>> {
+) -> Result<Json<Vec<crate::sessiond::SessionMeta>>> {
     ensure_shell_auth(&app, &headers, &uri)?;
-    let sessions: Vec<Arc<Session>> = app.sessions.read().await.values().cloned().collect();
-    let mut out = Vec::with_capacity(sessions.len());
-    for s in sessions {
-        out.push(s.meta.read().await.clone());
-    }
-    out.sort_by_key(|s| Reverse(s.updated_at));
-    Ok(Json(out))
+    sessiond_get(&app, "/api/sessions").await.map(Json)
 }
 
 async fn create_session(
@@ -516,59 +520,9 @@ async fn create_session(
     headers: HeaderMap,
     uri: Uri,
     Json(req): Json<CreateSession>,
-) -> Result<Json<CreateSessionResponse>> {
+) -> Result<Json<crate::sessiond::CreateSessionResponse>> {
     ensure_shell_auth(&app, &headers, &uri)?;
-    let id = Uuid::new_v4().to_string();
-    let recipe = select_recipe(&app, req.recipe_id.as_deref(), req.command)?;
-    let command = recipe.command.clone();
-    let cwd = req.cwd.unwrap_or_else(|| recipe.cwd.clone());
-    let name = req.name.unwrap_or_else(|| session_name(&recipe, &id));
-    let now = unix_ts();
-    let scratch_dir = prepare_scratch_dir(&app, &id, &recipe.workspace_policy).await?;
-    let env = session_env(&id, scratch_dir.as_deref());
-
-    let (child, output, input, pgid) = spawn_pty(&command, &cwd, &env)?;
-    let master_fd = input.as_raw_fd();
-    let (tx, _) = broadcast::channel(512);
-
-    let meta = SessionMeta {
-        id: id.clone(),
-        name,
-        recipe_id: recipe.id,
-        recipe_title: recipe.title,
-        workspace_policy: recipe.workspace_policy,
-        command,
-        cwd,
-        terminal_mode: TerminalMode::ReadWrite,
-        integrity_state: IntegrityState::Controlled,
-        integrity_reason: "interactive_pty_control",
-        created_at: now,
-        updated_at: now,
-        status: SessionStatus::Running,
-        exit_code: None,
-    };
-    app.store.append_meta(&meta).await?;
-
-    let session = Arc::new(Session {
-        meta: RwLock::new(meta),
-        input: Mutex::new(input),
-        master_fd,
-        child: Mutex::new(child),
-        pgid,
-        tx,
-        ring: Mutex::new(VecDeque::with_capacity(RING_LIMIT)),
-        scratch_dir,
-        cleanup_scratch_on_exit: true,
-    });
-
-    app.sessions
-        .write()
-        .await
-        .insert(id.clone(), session.clone());
-    spawn_reader(app.store.clone(), session.clone(), output, "pty");
-    spawn_waiter(app.store.clone(), session.clone());
-
-    Ok(Json(CreateSessionResponse { id }))
+    sessiond_post(&app, "/api/sessions", &req).await.map(Json)
 }
 
 fn select_recipe(app: &App, recipe_id: Option<&str>, command: Option<String>) -> Result<Recipe> {
@@ -853,13 +807,11 @@ async fn replay_session(
     headers: HeaderMap,
     uri: Uri,
     AxPath(id): AxPath<String>,
-) -> Result<Json<ReplayResponse>> {
+) -> Result<Json<crate::sessiond::ReplayResponse>> {
     ensure_shell_auth(&app, &headers, &uri)?;
-    let bytes = app.store.replay(&id).await?;
-    Ok(Json(ReplayResponse {
-        id,
-        bytes_b64: base64::engine::general_purpose::STANDARD.encode(bytes),
-    }))
+    sessiond_get(&app, &format!("/api/sessions/{id}/replay"))
+        .await
+        .map(Json)
 }
 
 async fn list_workloads(
@@ -1048,6 +1000,63 @@ async fn agent_get<T: DeserializeOwned>(app: &App, path: &str) -> Result<T> {
     Ok(resp.json().await?)
 }
 
+async fn sessiond_get<T: DeserializeOwned>(app: &App, path: &str) -> Result<T> {
+    let url = format!("{}{}", app.sessiond_http_url.trim_end_matches('/'), path);
+    let resp = app.http.get(url).send().await?;
+    decode_sessiond_response(path, resp).await
+}
+
+async fn sessiond_post<T: DeserializeOwned, B: Serialize>(
+    app: &App,
+    path: &str,
+    body: &B,
+) -> Result<T> {
+    let url = format!("{}{}", app.sessiond_http_url.trim_end_matches('/'), path);
+    let resp = app.http.post(url).json(body).send().await?;
+    decode_sessiond_response(path, resp).await
+}
+
+async fn sessiond_post_empty(app: &App, path: &str) -> Result<StatusCode> {
+    let url = format!("{}{}", app.sessiond_http_url.trim_end_matches('/'), path);
+    let resp = app.http.post(url).send().await?;
+    decode_sessiond_empty(path, resp).await
+}
+
+async fn sessiond_post_empty_json<B: Serialize>(
+    app: &App,
+    path: &str,
+    body: &B,
+) -> Result<StatusCode> {
+    let url = format!("{}{}", app.sessiond_http_url.trim_end_matches('/'), path);
+    let resp = app.http.post(url).json(body).send().await?;
+    decode_sessiond_empty(path, resp).await
+}
+
+async fn decode_sessiond_response<T: DeserializeOwned>(
+    path: &str,
+    resp: reqwest::Response,
+) -> Result<T> {
+    let status = resp.status();
+    if !status.is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        return Err(Error::Upstream(format!(
+            "sessiond {path}: HTTP {status}: {body}"
+        )));
+    }
+    Ok(resp.json().await?)
+}
+
+async fn decode_sessiond_empty(path: &str, resp: reqwest::Response) -> Result<StatusCode> {
+    let status = resp.status();
+    if !status.is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        return Err(Error::Upstream(format!(
+            "sessiond {path}: HTTP {status}: {body}"
+        )));
+    }
+    Ok(StatusCode::NO_CONTENT)
+}
+
 async fn replay_workload(
     State(app): State<App>,
     headers: HeaderMap,
@@ -1080,13 +1089,7 @@ async fn close_session(
     AxPath(id): AxPath<String>,
 ) -> Result<StatusCode> {
     ensure_shell_auth(&app, &headers, &uri)?;
-    let Some(session) = app.sessions.write().await.remove(&id) else {
-        return Err(Error::NotFound);
-    };
-    let pgid = session.pgid;
-    mark_session_exited(&app.store, &session, None).await;
-    terminate_process_group(id, pgid);
-    Ok(StatusCode::NO_CONTENT)
+    sessiond_post_empty(&app, &format!("/api/sessions/{id}/close")).await
 }
 
 fn terminate_process_group(id: String, pgid: i32) {
@@ -1133,31 +1136,7 @@ async fn resize_session(
     Json(req): Json<ResizeSession>,
 ) -> Result<StatusCode> {
     ensure_shell_auth(&app, &headers, &uri)?;
-    if req.cols == 0 || req.rows == 0 {
-        return Err(Error::BadRequest("terminal size must be non-zero".into()));
-    }
-    let Some(session) = app.sessions.read().await.get(&id).cloned() else {
-        return Err(Error::NotFound);
-    };
-    let winsize = libc::winsize {
-        ws_row: req.rows,
-        ws_col: req.cols,
-        ws_xpixel: 0,
-        ws_ypixel: 0,
-    };
-    let rc = unsafe { libc::ioctl(session.master_fd, libc::TIOCSWINSZ, &winsize) };
-    if rc != 0 {
-        return Err(Error::Internal(format!(
-            "resize pty: {}",
-            std::io::Error::last_os_error()
-        )));
-    }
-    if session.pgid > 0 {
-        unsafe {
-            libc::kill(-session.pgid, libc::SIGWINCH);
-        }
-    }
-    Ok(StatusCode::NO_CONTENT)
+    sessiond_post_empty_json(&app, &format!("/api/sessions/{id}/resize"), &req).await
 }
 
 async fn attach_session(
@@ -1169,11 +1148,9 @@ async fn attach_session(
     ws: WebSocketUpgrade,
 ) -> Result<Response> {
     ensure_shell_auth(&app, &headers, &uri)?;
-    let Some(session) = app.sessions.read().await.get(&id).cloned() else {
-        return Err(Error::NotFound);
-    };
+    let attach_addr = app.sessiond_attach_addr.clone();
     Ok(ws.on_upgrade(move |socket| async move {
-        if let Err(e) = attach(socket, session, query.tail.unwrap_or(true)).await {
+        if let Err(e) = attach(socket, attach_addr, id, query.tail.unwrap_or(true)).await {
             eprintln!("dd-shell: attach ended: {e:#}");
         }
     }))
@@ -1184,21 +1161,33 @@ struct AttachQuery {
     tail: Option<bool>,
 }
 
-async fn attach(socket: WebSocket, session: Arc<Session>, tail: bool) -> anyhow::Result<()> {
+async fn attach(
+    socket: WebSocket,
+    attach_addr: String,
+    id: String,
+    tail: bool,
+) -> anyhow::Result<()> {
+    let mut stream = TcpStream::connect(&attach_addr).await?;
+    let tail_arg = if tail { "tail" } else { "notail" };
+    stream
+        .write_all(format!("{id} {tail_arg}\n").as_bytes())
+        .await?;
+    let (mut tcp_rx, mut tcp_tx) = stream.into_split();
     let (mut ws_tx, mut ws_rx) = socket.split();
 
-    if tail {
-        let ring = session.ring.lock().await;
-        if !ring.is_empty() {
-            let bytes: Vec<u8> = ring.iter().copied().collect();
-            ws_tx.send(Message::Binary(bytes.into())).await?;
-        }
-    }
-
-    let mut output_rx = session.tx.subscribe();
     let output = tokio::spawn(async move {
-        while let Ok(bytes) = output_rx.recv().await {
-            if ws_tx.send(Message::Binary(bytes.into())).await.is_err() {
+        let mut buf = [0u8; 4096];
+        loop {
+            let n = match tcp_rx.read(&mut buf).await {
+                Ok(0) => break,
+                Ok(n) => n,
+                Err(_) => break,
+            };
+            if ws_tx
+                .send(Message::Binary(buf[..n].to_vec().into()))
+                .await
+                .is_err()
+            {
                 break;
             }
         }
@@ -1207,15 +1196,10 @@ async fn attach(socket: WebSocket, session: Arc<Session>, tail: bool) -> anyhow:
     while let Some(msg) = ws_rx.next().await {
         match msg? {
             Message::Binary(bytes) => {
-                session.input.lock().await.write_all(&bytes).await?;
+                tcp_tx.write_all(&bytes).await?;
             }
             Message::Text(text) => {
-                session
-                    .input
-                    .lock()
-                    .await
-                    .write_all(text.as_bytes())
-                    .await?;
+                tcp_tx.write_all(text.as_bytes()).await?;
             }
             Message::Close(_) => break,
             Message::Ping(_) | Message::Pong(_) => {}
@@ -1721,11 +1705,16 @@ function metricsHtml(data) {
   const uptime = data.system_uptime_secs ?? data.uptime_secs;
   const load = data.load_1m;
   const disks = Array.isArray(data.disks) ? data.disks : [];
+  const nets = Array.isArray(data.nets) ? data.nets : [];
   const disk = disks.find(d => d.mount === "/var/lib/easyenclave/data") || disks.find(d => d.mount === "/") || disks[0];
+  const netRx = nets.reduce((sum, n) => sum + Number(n.rx_bytes || 0), 0);
+  const netTx = nets.reduce((sum, n) => sum + Number(n.tx_bytes || 0), 0);
+  const netNames = nets.map(n => n.iface).filter(Boolean).join(", ");
   return `<div class="metrics">
     ${metricHtml("CPU", cpu === undefined ? "unknown" : `${cpu}%`, load === undefined ? "load unknown" : `load ${Number(load).toFixed(2)}`)}
     ${metricHtml("Memory", memUsed === undefined || memTotal === undefined ? "unknown" : `${memUsed}/${memTotal} MB`, memTotal ? `${Math.round((memUsed / memTotal) * 100)}% used` : "")}
     ${metricHtml("Disk", disk ? `${formatBytes(disk.used_bytes)} / ${formatBytes(disk.total_bytes)}` : "unknown", disk ? disk.mount : "no disk data")}
+    ${metricHtml("Network", nets.length ? `${formatBytes(netRx)} / ${formatBytes(netTx)}` : "unknown", nets.length ? `rx / tx ${netNames}` : "no net data")}
     ${metricHtml("Uptime", uptime === undefined ? "unknown" : formatDuration(uptime), data.vm_name || "agent")}
   </div>`;
 }


### PR DESCRIPTION
## Summary
- add DD_MODE=sessiond as a local PTY/session supervisor
- make dd-shell proxy session list/create/attach/resize/close/replay to sessiond
- add browser-auth-gated dd-agent session gateway routes backed by local sessiond
- wire dd-sessiond into local/dogfood and CP shell boot workloads
- render aggregate network RX/TX in the shell metrics panel
- save the written sessiond + central UI plan under docs/

## Notes
- This is the intentional disruptive dogfood backend upgrade slice. Existing live dogfood sessions will not survive the redeploy that installs sessiond, but future dd-shell/web UI restarts should no longer own the PTYs.
- CP-centralized shell/mobile UI is documented as the next slice; this PR adds the agent/session backend it will target.

## Checks
- cargo fmt --check
- cargo check
- cargo clippy --all-targets -- -D warnings
- cargo test
- bash -n apps/_infra/local-agents.sh
- bash -n apps/_infra/dd-dogfood.sh
- local dd-sessiond smoke: list recipes, create session, list session, close session