### PR TITLE
Bound session replay responses

### DIFF
--- a/.github/workflows/deploy-cp.yml
+++ b/.github/workflows/deploy-cp.yml
@@ -269,7 +269,6 @@ jobs:
               DD_AUTH_COOKIE_DOMAIN="$DD_AUTH_COOKIE_DOMAIN" \
               DD_AUTH_COOKIE_SECRET="$DD_AUTH_COOKIE_SECRET" \
               bake apps/dd-shell/workload.json.tmpl
-            bake apps/ee-proxy/workload.json.tmpl
           } | jq -cs '.')
 
           # EE_CAPTURE_SOCKET tells EE (post-capture-socket patch) to tee

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -386,6 +386,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "tokio-tungstenite",
  "urlencoding",
  "uuid",
  "x25519-dalek",
@@ -755,7 +756,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -1448,7 +1449,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -1908,8 +1909,12 @@ checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
 dependencies = [
  "futures-util",
  "log",
+ "rustls",
+ "rustls-pki-types",
  "tokio",
+ "tokio-rustls",
  "tungstenite",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -1996,6 +2001,8 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.9.2",
+ "rustls",
+ "rustls-pki-types",
  "sha1",
  "thiserror",
  "utf-8",
@@ -2226,6 +2233,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,8 @@ sha2 = "0.10"
 snow = { version = "0.9", default-features = false, features = ["default-resolver"] }
 sysinfo = { version = "0.33", default-features = false, features = ["system", "disk", "network"] }
 thiserror = "2"
-tokio = { version = "1", features = ["macros", "process", "rt-multi-thread", "signal", "time", "fs", "net", "io-util", "sync"] }
+tokio = { version = "1", features = ["macros", "process", "rt-multi-thread", "signal", "time", "fs", "net", "io-util", "io-std", "sync"] }
+tokio-tungstenite = { version = "0.28", features = ["rustls-tls-webpki-roots"] }
 urlencoding = "2"
 uuid = { version = "1", features = ["v4"] }
 x25519-dalek = { version = "2", features = ["static_secrets"] }

--- a/README.md
+++ b/README.md
@@ -139,11 +139,10 @@ The CLI uses `DD_ITA_API_KEY` for quote appraisal. `DD_ITA_BASE_URL`,
 production endpoints and can be overridden when needed. Local preview/dev runs
 without ITA credentials must pass `--insecure-skip-quote-verify` explicitly.
 
-The web shell should become another client implementation of the same protocol:
-it keeps its own paired device identity, asks CP for current routes, and opens
-Noise directly to the agent. The existing cookie-auth browser shell is
-transitional compatibility only; new shell features should land on the Noise
-client protocol.
+The native CLI is the protocol reference for the future desktop/mobile app. The
+browser remains dashboard and enrollment UI only; the existing cookie-auth
+browser shell is transitional compatibility while the native app takes over
+shell/session workflows.
 
 ## STONITH
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,8 @@ Trust Authority, checks that the quote binds `noise.pubkey_hex` into TDX
 `shell.replay_session`, `shell.resize_session`, `shell.close_session`, and the
 streaming `shell.attach_session` method. Session control and PTY bytes flow
 inside the Noise transport to the agent and then to local `dd-sessiond`; the CP
-is used for enrollment and route discovery, not for shell/log/session bytes.
+is used for enrollment brokering and route discovery, not for shell/log/session
+bytes or paired-device trust storage.
 
 The bundled native CLI exercises that path directly:
 

--- a/README.md
+++ b/README.md
@@ -140,8 +140,9 @@ without ITA credentials must pass `--insecure-skip-quote-verify` explicitly.
 
 The web shell should become another client implementation of the same protocol:
 it keeps its own paired device identity, asks CP for current routes, and opens
-Noise directly to the agent. The existing cookie-auth browser shell remains a
-compatibility surface while that client-side Noise implementation lands.
+Noise directly to the agent. The existing cookie-auth browser shell is
+transitional compatibility only; new shell features should land on the Noise
+client protocol.
 
 ## STONITH
 

--- a/README.md
+++ b/README.md
@@ -111,12 +111,37 @@ The agent verifies the OIDC token against GitHub's JWKS, checks `repository_owne
 
 ## Terminal access
 
-Each VM runs `dd-shell` as a workload on a `-shell` labelled subdomain (for example `app-shell.devopsdefender.com` or `<agent>-shell.devopsdefender.com`). DD gates it behind the same GitHub App broker session as the dashboards. The shell UI separates observed read-only workload logs from controlled read-write PTY sessions. Read-only viewing does not change integrity state because it cannot send input or signals; read-write PTYs are controlled as soon as they exist and keep encrypted transcript history inside the enclave.
+Each VM runs `dd-sessiond` as the local session supervisor. `dd-sessiond` owns
+PTYs, child process groups, resize/close control, and encrypted transcript
+history inside the enclave.
 
-The shell is installable as a small PWA. Browser notifications are always
-delivered by default when permission is granted; on mobile, install the shell
-from the browser so the service worker can present notifications through the
-platform notification surface while the shell is active.
+Native clients use a paired device key against the agent's `/noise/ws` endpoint.
+The bootstrap flow fetches `/health`, appraises `noise.quote_b64` with Intel
+Trust Authority, checks that the quote binds `noise.pubkey_hex` into TDX
+`report_data`, and then runs Noise_IK over WebSocket. The exposed session RPC surface is
+`shell.list_recipes`, `shell.list_sessions`, `shell.create_session`,
+`shell.replay_session`, `shell.resize_session`, `shell.close_session`, and the
+streaming `shell.attach_session` method. Session control and PTY bytes flow
+inside the Noise transport to the agent and then to local `dd-sessiond`; the CP
+is used for enrollment and route discovery, not for shell/log/session bytes.
+
+The bundled native CLI exercises that path directly:
+
+```bash
+devopsdefender noise keygen --cp-url https://app.devopsdefender.com --label laptop
+devopsdefender noise recipes --url https://<agent-host>
+devopsdefender noise shell --url https://<agent-host> --recipe shell
+```
+
+The CLI uses `DD_ITA_API_KEY` for quote appraisal. `DD_ITA_BASE_URL`,
+`DD_ITA_JWKS_URL`, and `DD_ITA_ISSUER` default to Intel Trust Authority's
+production endpoints and can be overridden when needed. Local preview/dev runs
+without ITA credentials must pass `--insecure-skip-quote-verify` explicitly.
+
+The web shell should become another client implementation of the same protocol:
+it keeps its own paired device identity, asks CP for current routes, and opens
+Noise directly to the agent. The existing cookie-auth browser shell remains a
+compatibility surface while that client-side Noise implementation lands.
 
 ## STONITH
 

--- a/apps/README.md
+++ b/apps/README.md
@@ -132,7 +132,8 @@ The shell UI treats both as terminal views, but only read-write sessions get
 WebSocket input, resize, and close controls. Workloads do not opt into
 read-write access by putting metadata in `workload.json`; the boundary is the
 session protocol exposed by `dd-agent` over Noise. The current browser shell
-HTTP/WebSocket APIs are compatibility only while web/PWA moves to direct Noise.
+HTTP/WebSocket APIs are compatibility only while the native app takes over
+shell/session workflows.
 Internally DD may still call this taint tracking, but the API/UI should speak in
 integrity terms: clean for observed-only logs, controlled for interactive PTYs
 or other human control paths.
@@ -145,8 +146,8 @@ printf '\033]9;%s\033\\' 'job finished'
 printf '\033]777;notify;%s;%s\033\\' 'oracle' 'new result available'
 ```
 
-For mobile web, this is the first step toward a PWA-style shell inbox: read-only
-workload cards, read-write Codex/Claude session cards, and push-backed
+The native desktop/mobile app is the target for shell inbox workflows:
+read-only workload cards, read-write Codex/Claude session cards, and
 notifications for long-running jobs.
 
 Per-workload ingress is **boot-time only** today. Workloads POSTed later via

--- a/apps/README.md
+++ b/apps/README.md
@@ -175,7 +175,8 @@ inline in two places so both lifecycle points behave identically:
 | `busybox` | | ✅ | ✅ |
 | `cloudflared` | ✅ | ✅ | ✅ |
 | `dd-agent` | | ✅ | ✅ |
-| `dd-shell` | | ✅ | ✅ |
+| `dd-sessiond` | ✅ | ✅ | ✅ |
+| `dd-shell` | ✅ | ✅ | ✅ |
 | `human-readonly` | | ✅ | |
 | `dd-management` | ✅ | | |
 | `podman-static` | | ✅ | ✅ |
@@ -190,24 +191,16 @@ Additional examples:
   is a shell workload recipe, not a `devopsdefender` binary subcommand.
 - `apps/oracle-readonly`: standalone oracle example with the same scraper and
   vanity-address metadata; copy this shape into real oracle app repos.
-- `apps/confidential-shell`: runs dd-shell with
-  `DD_SHELL_DIR=/var/lib/easyenclave/data/dd-shell` so read-write PTY
-  transcript history survives on the workload disk.
+- `apps/confidential-shell`: legacy standalone shell workload for deployments
+  that still run the browser shell and PTY supervisor in one process.
 - `apps/codex-podman-shell`: alternative read-write shell workload. It exposes
-  the normal `-shell` label, stores encrypted dd-shell history under
-  `/var/lib/easyenclave/data/dd-shell`, and advertises a Codex recipe in the
-  shell UI. The normal shell recipe remains available. Launching Codex starts a
-  Podman-backed Node container with per-session home, workspace, cache, and tmp
-  directories supplied by dd-shell. The container installs `@openai/codex` on
-  first use, so `codex login` can be completed interactively from the browser
-  terminal. Session scratch is intentionally ephemeral in this first slice; the
-  encrypted transcript remains under `DD_SHELL_DIR`. Use this instead of
-  `dd-shell`, not alongside it, unless you give one of them a different
-  `hostname_label`.
+  the normal `-shell` label and carries an older self-contained Codex recipe
+  path. New deployments should prefer `dd-sessiond` + `dd-shell`.
 
-CP stays slim: just `cloudflared` + `dd-management`. Preview agent VMs run a
-small read-only oracle plus agent + podman for CI to prove registration,
-scraping, vanity ingress, and dashboards end-to-end. Prod agent VMs use the
+CP stays slim: `cloudflared` + `dd-management` + `dd-sessiond` + `dd-shell`.
+Preview agent VMs run a small read-only oracle plus agent + podman for CI to
+prove registration, scraping, vanity ingress, and dashboards end-to-end. Prod
+agent VMs use the
 same CPU-only boot shape without demo workloads for now. `dd-local-dogfood`
 uses that same prod boot chain but is manually managed, sized larger by
 default, and not relaunched by CI.

--- a/apps/README.md
+++ b/apps/README.md
@@ -117,23 +117,25 @@ it does not create a read-write terminal or any input path into the workload.
 
 DD separates terminal access by capability:
 
-- **Read-only workload terminals** show workload logs in the dd-shell xterm UI.
+- **Read-only workload terminals** show workload logs in the terminal UI.
   They are for oracle-style services where an operator should be able to inspect
   output without sending input, resizing a PTY, interrupting, or closing the
   process. Opening a read-only terminal is observation only, so it leaves the
   workload's user-facing integrity state clean.
-- **Read-write PTY sessions** are created inside `dd-shell`. They are for
+- **Read-write PTY sessions** are owned by `dd-sessiond`. They are for
   confidential shells and ZDR coding agents such as Codex or Claude. These
-  sessions are reconnectable and write encrypted transcript records under
-  `DD_SHELL_DIR`. A read-write PTY is controlled as soon as it exists because
-  the holder can send stdin, resize the terminal, and deliver terminal signals.
+  sessions are reconnectable and write encrypted transcript records. A
+  read-write PTY is controlled as soon as it exists because the holder can send
+  stdin, resize the terminal, and deliver terminal signals.
 
 The shell UI treats both as terminal views, but only read-write sessions get
 WebSocket input, resize, and close controls. Workloads do not opt into
 read-write access by putting metadata in `workload.json`; the boundary is the
-dd-shell API surface. Internally DD may still call this taint tracking, but the
-API/UI should speak in integrity terms: clean for observed-only logs,
-controlled for interactive PTYs or other human control paths.
+session protocol exposed by `dd-agent` over Noise. The current browser shell
+HTTP/WebSocket APIs are compatibility only while web/PWA moves to direct Noise.
+Internally DD may still call this taint tracking, but the API/UI should speak in
+integrity terms: clean for observed-only logs, controlled for interactive PTYs
+or other human control paths.
 
 The renderer uses vendored xterm assets and recognizes WezTerm-compatible
 notification escapes after the user grants browser notification permission:
@@ -192,12 +194,14 @@ Additional examples:
 - `apps/oracle-readonly`: standalone oracle example with the same scraper and
   vanity-address metadata; copy this shape into real oracle app repos.
 - `apps/confidential-shell`: legacy standalone shell workload for deployments
-  that still run the browser shell and PTY supervisor in one process.
-- `apps/codex-podman-shell`: alternative read-write shell workload. It exposes
-  the normal `-shell` label and carries an older self-contained Codex recipe
-  path. New deployments should prefer `dd-sessiond` + `dd-shell`.
+  that still run the browser shell and PTY supervisor in one process. Scheduled
+  for removal once all clients use `dd-sessiond` over Noise.
+- `apps/codex-podman-shell`: legacy read-write shell workload. It exposes the
+  normal `-shell` label and carries an older self-contained Codex recipe path.
+  Scheduled for removal; new deployments should use `dd-sessiond`.
 
-CP stays slim: `cloudflared` + `dd-management` + `dd-sessiond` + `dd-shell`.
+CP stays slim: `cloudflared` + `dd-management` + static/web client assets as
+needed. It must not carry shell, log, transcript, or PTY bytes.
 Preview agent VMs run a small read-only oracle plus agent + podman for CI to
 prove registration, scraping, vanity ingress, and dashboards end-to-end. Prod
 agent VMs use the

--- a/apps/_infra/local-cp.sh
+++ b/apps/_infra/local-cp.sh
@@ -153,6 +153,9 @@ build_config_iso() {
       DD_OWNER_ID="$EE_OWNER_ID" \
       DD_OWNER_KIND="$EE_OWNER_KIND" \
       bake "$REPO_ROOT/apps/dd-management/workload.json.tmpl"
+    DD_SESSIOND_DIR=/tmp/dd-shell \
+      DD_SESSIOND_SCRATCH_DIR=/tmp/dd-shell/sessions \
+      bake "$REPO_ROOT/apps/dd-sessiond/workload.json.tmpl"
     DD_DOMAIN="$DD_DOMAIN" \
       DD_HOSTNAME="$HOSTNAME" \
       DD_ENV="$ENV_LABEL" \

--- a/apps/dd-agent/workload.json.tmpl
+++ b/apps/dd-agent/workload.json.tmpl
@@ -28,6 +28,7 @@
     "DD_CONFIDENTIAL=${DD_CONFIDENTIAL}",
     "DD_PORT=8080",
     "DD_EXTRA_INGRESS=${DD_EXTRA_INGRESS}",
+    "DD_AGENT_DEVICES_PATH=/var/lib/easyenclave/data/dd-agent/devices.json",
     "DD_ORACLES_B64=${DD_ORACLES_B64}"
   ]
 }

--- a/docs/sessiond-central-ui-plan.md
+++ b/docs/sessiond-central-ui-plan.md
@@ -3,16 +3,15 @@
 ## Goal
 
 Accept one disruptive dogfood redeploy to install a durable session backend.
-After that, iterate on desktop/mobile/assistant UI from the centralized fleet
-control plane without restarting the dogfood VM or killing active Codex/Claude
-sessions.
+After that, iterate on desktop/mobile/assistant clients without restarting the
+dogfood VM or killing active Codex/Claude sessions.
 
 ## Target Shape
 
 ```text
-browser
-  -> app.devopsdefender.com fleet UI
-  -> selected agent session gateway
+native/web/mobile client
+  -> CP route discovery + device enrollment
+  -> selected agent /noise/ws
   -> dd-sessiond Unix socket on that VM
   -> PTY + child process group
 ```
@@ -28,10 +27,15 @@ Agent VM responsibilities:
 
 Control-plane responsibilities:
 
-- Serve the desktop shell UI, mobile UI, and Claude-style assistant view.
-- Let users select a fleet agent and attach to sessions through that agent's
-  session API.
-- Ship UI updates via normal CP/web deploys, without touching agent VMs.
+- Own device enrollment, revocation, policy, and route discovery.
+- Optionally serve static web/PWA assets.
+- Never carry shell, log, transcript, or PTY bytes.
+
+Client responsibilities:
+
+- Hold a paired device identity.
+- Ask CP for current routes and capabilities.
+- Connect directly to the selected agent over Noise for runtime data.
 
 ## Non-Goals
 
@@ -39,7 +43,9 @@ Control-plane responsibilities:
 - No hot-swappable UI directory as the primary mechanism.
 - No fallback in-process PTY mode once `dd-sessiond` is introduced.
 - No CRIU/checkpoint work in the first implementation.
-- No full browser-side Noise handshake in the first implementation.
+- No CP relay or mailbox relay for shell/log/session bytes.
+- No full browser-side Noise handshake in the first implementation; native CLI
+  is the first protocol exerciser.
 
 ## Phase 1: One Disruptive Dogfood Upgrade
 
@@ -52,8 +58,8 @@ Deliverables:
 - Add a `dd-sessiond` boot workload for dogfood agents. Implemented in this branch.
 - Change interactive sessions so `dd-sessiond` owns PTYs. Implemented for `dd-shell`
   by proxying session create/list/attach/resize/close/replay to sessiond.
-- Change `dd-agent` to proxy session APIs to `dd-sessiond`. Implemented with
-  browser-auth-gated routes for the first cut.
+- Change `dd-agent` to proxy session APIs to `dd-sessiond`. Implemented over
+  paired-device Noise for the first durable client path.
 - Keep Codex launch working through the session manager.
 - Preserve persistent disk state, including Codex/npm/login state.
 
@@ -91,57 +97,74 @@ Implementation notes:
 - Transcript and events are canonical session state, not UI state.
 - Mobile clients should not resize the canonical PTY by default.
 
-## Phase 3: Centralized Fleet UI
+## Phase 3: Client-Side Fleet UI
 
-Move active shell UI development to the CP/fleet dashboard.
+Move active shell UI development to clients that use CP only for routes and
+agent/device policy.
 
 Deliverables:
 
-- Add CP route for agent sessions.
+- Add CP route discovery for agent sessions.
 - UI lists sessions for the selected agent.
-- UI can create, attach, input, resize, close, and replay sessions.
+- UI can create, attach, input, resize, close, and replay sessions by opening
+  Noise directly to the selected agent.
 - Desktop terminal view remains raw PTY-first.
 - Mobile view can add touch controls, smart sizing, and assistant-style
   rendering without changing agent-side session ownership.
+- The web/PWA interface becomes a client implementation of the same protocol,
+  not a server-side shell proxy.
 
 Acceptance:
 
-- Updating CP UI via PR/release updates the shell/mobile experience.
+- Updating static web/PWA assets updates the browser shell/mobile experience.
 - No dogfood agent restart is needed for UI-only changes.
-- Active dogfood Codex sessions survive CP UI updates.
+- Active dogfood Codex sessions survive web/client updates.
 
 Status:
 
-- Not implemented in the first branch slice. The agent-side session gateway is
-  present so the CP UI can target it next.
+- Not implemented in the first branch slice. The native CLI is present so the
+  client-side protocol can be tested before replacing the browser shell proxy.
 
 ## Phase 4: Auth, Attestation, And Noise
 
 Start simple:
 
-- CP issues short-lived scoped session tokens.
-- Tokens bind user, agent id, session/action scope, and expiry.
-- `dd-agent` validates tokens before proxying to `dd-sessiond`.
+- CP enrolls paired device public keys and exposes current routes.
+- Agents poll CP for the trusted device set and route/policy freshness.
+- Native CLI/desktop/mobile clients use direct `/noise/ws` channels for
+  session RPCs.
 
 Then strengthen:
 
-- Bind session authorization to the attested agent Noise public key.
-- CP tracks agent attestation and `noise_pubkey`.
-- Desktop/CLI clients can eventually use a direct Noise channel.
-- Browser UI can stay token-over-HTTPS until custom browser crypto is worth it.
+- Clients verify the agent quote and pin the attested Noise public key.
+- Browser/PWA uses the same direct agent Noise path once the browser crypto or
+  WASM client is in place.
+
+Implemented first slice:
+
+- `/health` exposes the quote and Noise public key that clients verify and pin.
+- A paired device can send `shell.list_recipes`, `shell.list_sessions`,
+  `shell.create_session`, `shell.replay_session`, `shell.resize_session`, and
+  `shell.close_session` JSON requests over Noise.
+- `shell.attach_session` returns one JSON ack, then switches the same Noise
+  session into encrypted raw PTY byte streaming to local `dd-sessiond`.
+- CP Noise endpoints reject shell methods because they have no local sessiond
+  adapter; agent Noise endpoints wire the adapter in.
 
 Design rule:
 
 ```text
 remote clients never trust naked tunnel DNS
-remote clients trust CP-issued scoped authorization and, later, attested keys
+remote clients trust CP-enrolled device identity plus attested agent keys
+CP is route/key authority only, never a session data plane
 dd-sessiond stays local-only
 dd-agent is the policy/encryption gateway
 ```
 
 ## Risks And Open Questions
 
-- Whether to keep a minimal agent-local shell UI for emergency access.
+- Whether to keep a minimal cookie-auth shell UI only as temporary emergency
+  compatibility.
 - How to model recipes so CP UI and `dd-sessiond` agree on available launchers.
 - How to represent "input requested" events for Codex/Claude without making
   terminal parsing authoritative.
@@ -149,3 +172,4 @@ dd-agent is the policy/encryption gateway
   passing or exec handoff.
 - How much of the existing transcript encryption format should move unchanged
   into `dd-sessiond`.
+- Browser Noise implementation choice: pure JS library versus small WASM client.

--- a/docs/sessiond-central-ui-plan.md
+++ b/docs/sessiond-central-ui-plan.md
@@ -131,8 +131,8 @@ Status:
 
 Start simple:
 
-- CP enrolls paired device public keys and exposes current routes.
-- Agents poll CP for the trusted device set and route/policy freshness.
+- CP brokers enrollment and exposes current routes.
+- Agents hold the trusted device set they enforce for direct Noise sessions.
 - Native CLI/desktop/mobile clients use direct `/noise/ws` channels for
   session RPCs.
 
@@ -141,8 +141,9 @@ Then strengthen:
 - Clients verify the agent quote and pin the attested Noise public key.
 - Browser/PWA uses the same direct agent Noise path once the browser crypto or
   WASM client is in place.
-- CP device enrollment survives CP redeploys. A paired native/web/mobile client
-  must not need to re-pair just because preview or production CP was relaunched.
+- Pairing survives CP redeploys without putting shell/session state in CP. A
+  paired native/web/mobile client must not need to re-pair just because preview
+  or production CP was relaunched.
 
 Implemented first slice:
 
@@ -163,7 +164,7 @@ Design rule:
 
 ```text
 remote clients never trust naked tunnel DNS
-remote clients trust CP-enrolled device identity plus attested agent keys
+remote clients trust paired device identity plus attested agent keys
 CP is route/key authority only, never a session data plane
 dd-sessiond stays local-only
 dd-agent is the policy/encryption gateway
@@ -179,9 +180,9 @@ direct Noise, remove the old shell stack in this order:
    client speaks Noise directly.
 2. Remove old env compatibility names. `DD_SESSIOND_HISTORY_KEY` is the only
    transcript-key override; do not continue accepting `DD_SHELL_HISTORY_KEY`.
-3. Fix device registry durability. The CP trusted-device list must survive a
-   CP redeploy or hydrate from the predecessor before clients depend on it as
-   their only route to shell sessions.
+3. Fix pairing durability without making CP a shell/session state owner. If CP
+   participates in enrollment, it should broker or cache trust material rather
+   than become the only durable source needed to reach shell sessions.
 4. Move web/PWA to direct Noise. Store a paired device key in browser storage,
    use CP only for enrollment and route discovery, then connect to the selected
    agent `/noise/ws` for session RPCs and PTY bytes.
@@ -203,7 +204,7 @@ Keep these pieces:
 - `shell_unavailable` on CP Noise endpoints. It is an explicit rejection for a
   process that intentionally has no local sessiond.
 - CP route discovery and enrollment. CP stays in the trust/control path, not
-  the shell data path.
+  the shell data path or shell state path.
 
 ## Risks And Open Questions
 
@@ -215,5 +216,5 @@ Keep these pieces:
 - How much of the existing transcript encryption format should move unchanged
   into `dd-sessiond`.
 - Browser Noise implementation choice: pure JS library versus small WASM client.
-- CP device registry storage location for SSH/preview CPs, since `/tmp` state
-  can disappear across relaunches if predecessor hydration does not run.
+- Where durable paired-device trust should live if CP only brokers enrollment
+  and route discovery.

--- a/docs/sessiond-central-ui-plan.md
+++ b/docs/sessiond-central-ui-plan.md
@@ -10,7 +10,7 @@ dogfood VM or killing active Codex/Claude sessions.
 
 ```text
 native/web/mobile client
-  -> CP route discovery + device enrollment
+  -> CP route discovery + enrollment broker
   -> selected agent /noise/ws
   -> dd-sessiond Unix socket on that VM
   -> PTY + child process group
@@ -27,7 +27,7 @@ Agent VM responsibilities:
 
 Control-plane responsibilities:
 
-- Own device enrollment, revocation, policy, and route discovery.
+- Broker device enrollment and own route discovery.
 - Optionally serve static web/PWA assets.
 - Never carry shell, log, transcript, or PTY bytes.
 
@@ -131,7 +131,8 @@ Status:
 
 Start simple:
 
-- CP brokers enrollment and exposes current routes.
+- CP brokers enrollment by redirecting to the selected agent and exposes
+  current routes.
 - Agents hold the trusted device set they enforce for direct Noise sessions.
 - Native CLI/desktop/mobile clients use direct `/noise/ws` channels for
   session RPCs.
@@ -180,9 +181,9 @@ direct Noise, remove the old shell stack in this order:
    client speaks Noise directly.
 2. Remove old env compatibility names. `DD_SESSIOND_HISTORY_KEY` is the only
    transcript-key override; do not continue accepting `DD_SHELL_HISTORY_KEY`.
-3. Fix pairing durability without making CP a shell/session state owner. If CP
-   participates in enrollment, it should broker or cache trust material rather
-   than become the only durable source needed to reach shell sessions.
+3. Fix pairing durability without making CP a shell/session state owner. CP can
+   broker enrollment, but durable paired-device trust must live with the
+   enforcement point or an explicitly chosen non-CP store.
 4. Move web/PWA to direct Noise. Store a paired device key in browser storage,
    use CP only for enrollment and route discovery, then connect to the selected
    agent `/noise/ws` for session RPCs and PTY bytes.
@@ -203,8 +204,8 @@ Keep these pieces:
 - `dd-sessiond` and its local-only API. It is the session owner, not a fallback.
 - `shell_unavailable` on CP Noise endpoints. It is an explicit rejection for a
   process that intentionally has no local sessiond.
-- CP route discovery and enrollment. CP stays in the trust/control path, not
-  the shell data path or shell state path.
+- CP route discovery and enrollment brokering. CP stays in the trust/control
+  path, not the shell data path or shell state path.
 
 ## Risks And Open Questions
 

--- a/docs/sessiond-central-ui-plan.md
+++ b/docs/sessiond-central-ui-plan.md
@@ -156,8 +156,8 @@ Implemented first slice:
   session into encrypted raw PTY byte streaming to local `dd-sessiond`.
 - Native `exec`, `replay`, `resize`, and `close` commands exercise the same
   direct Noise path as `shell`.
-- CP Noise endpoints reject shell methods because they have no local sessiond
-  adapter; agent Noise endpoints wire the adapter in.
+- CP does not run the client Noise gateway. Agent Noise endpoints wire the
+  sessiond adapter in.
 - The native CLI appraises the agent quote with Intel Trust Authority by
   default and requires an explicit insecure flag for local preview/dev.
 
@@ -202,8 +202,6 @@ direct Noise, remove the old shell stack in this order:
 Keep these pieces:
 
 - `dd-sessiond` and its local-only API. It is the session owner, not a fallback.
-- `shell_unavailable` on CP Noise endpoints. It is an explicit rejection for a
-  process that intentionally has no local sessiond.
 - CP route discovery and enrollment brokering. CP stays in the trust/control
   path, not the shell data path or shell state path.
 

--- a/docs/sessiond-central-ui-plan.md
+++ b/docs/sessiond-central-ui-plan.md
@@ -1,4 +1,4 @@
-# Sessiond + Central UI Plan
+# Sessiond + Native Client Plan
 
 ## Goal
 
@@ -9,7 +9,7 @@ dogfood VM or killing active Codex/Claude sessions.
 ## Target Shape
 
 ```text
-native/web/mobile client
+native desktop/mobile client or CLI
   -> CP route discovery + enrollment broker
   -> selected agent /noise/ws
   -> dd-sessiond Unix socket on that VM
@@ -28,7 +28,7 @@ Agent VM responsibilities:
 Control-plane responsibilities:
 
 - Broker device enrollment and own route discovery.
-- Optionally serve static web/PWA assets.
+- Serve dashboards and enrollment broker pages.
 - Never carry shell, log, transcript, or PTY bytes.
 
 Client responsibilities:
@@ -44,8 +44,8 @@ Client responsibilities:
 - No fallback in-process PTY mode once `dd-sessiond` is introduced.
 - No CRIU/checkpoint work in the first implementation.
 - No CP relay or mailbox relay for shell/log/session bytes.
-- No full browser-side Noise handshake in the first implementation; native CLI
-  is the first protocol exerciser.
+- No browser/PWA shell client. Browser stays dashboard/enrollment only; the
+  session client is native app/CLI.
 
 ## Phase 1: One Disruptive Dogfood Upgrade
 
@@ -99,33 +99,33 @@ Implementation notes:
 - The existing `/api/sessions*` and `/ws/sessions*` browser-shell routes are
   transitional compatibility only. Do not add new client features there.
 
-## Phase 3: Client-Side Fleet UI
+## Phase 3: Native Fleet Client
 
-Move active shell UI development to clients that use CP only for routes and
-agent/device policy.
+Move active shell UI development to a native client that uses CP only for
+routes and enrollment brokering.
 
 Deliverables:
 
 - Add CP route discovery for agent sessions.
-- UI lists sessions for the selected agent.
-- UI can create, attach, input, resize, close, and replay sessions by opening
-  Noise directly to the selected agent.
+- Native app lists sessions for the selected agent.
+- Native app can create, attach, input, resize, close, and replay sessions by
+  opening Noise directly to the selected agent.
 - Desktop terminal view remains raw PTY-first.
-- Mobile view can add touch controls, smart sizing, and assistant-style
-  rendering without changing agent-side session ownership.
-- The web/PWA interface becomes a client implementation of the same protocol,
-  not a server-side shell proxy.
+- Mobile app can add touch controls, smart sizing, notifications, and
+  assistant-style rendering without changing agent-side session ownership.
+- Browser dashboard links users to the native app/CLI enrollment and route
+  discovery flows; it does not become a terminal/PWA client.
 
 Acceptance:
 
-- Updating static web/PWA assets updates the browser shell/mobile experience.
-- No dogfood agent restart is needed for UI-only changes.
+- Updating the native app updates shell/mobile experience without changing the
+  agent/sessiond data plane.
 - Active dogfood Codex sessions survive web/client updates.
 
 Status:
 
 - Not implemented in the first branch slice. The native CLI is present so the
-  client-side protocol can be tested before replacing the browser shell proxy.
+  client protocol can be tested before replacing the browser shell proxy.
 
 ## Phase 4: Auth, Attestation, And Noise
 
@@ -140,8 +140,7 @@ Start simple:
 Then strengthen:
 
 - Clients verify the agent quote and pin the attested Noise public key.
-- Browser/PWA uses the same direct agent Noise path once the browser crypto or
-  WASM client is in place.
+- Native desktop/mobile apps reuse the same direct agent Noise path as the CLI.
 - Pairing survives CP redeploys without putting shell/session state in CP. A
   paired native/web/mobile client must not need to re-pair just because preview
   or production CP was relaunched.
@@ -177,21 +176,22 @@ Now that the durable session owner is `dd-sessiond` and native clients can use
 direct Noise, remove the old shell stack in this order:
 
 1. Freeze cookie-auth browser shell APIs. Treat `src/shell.rs` routes
-   `/api/sessions*` and `/ws/sessions*` as compatibility only until the web/PWA
-   client speaks Noise directly.
+   `/api/sessions*` and `/ws/sessions*` as compatibility only until the native
+   app covers the workflow.
 2. Remove old env compatibility names. `DD_SESSIOND_HISTORY_KEY` is the only
    transcript-key override; do not continue accepting `DD_SHELL_HISTORY_KEY`.
 3. Fix pairing durability without making CP a shell/session state owner. CP can
    broker enrollment, but durable paired-device trust must live with the
    enforcement point or an explicitly chosen non-CP store.
-4. Move web/PWA to direct Noise. Store a paired device key in browser storage,
-   use CP only for enrollment and route discovery, then connect to the selected
-   agent `/noise/ws` for session RPCs and PTY bytes.
+4. Extract the native Noise client into a reusable app library. Store paired
+   device keys in OS secure storage, use CP only for enrollment and route
+   discovery, then connect to the selected agent `/noise/ws` for session RPCs
+   and PTY bytes.
 5. Delete server-side browser shell proxying. Remove `src/shell.rs` session
-   proxy routes and WebSocket attach path once the web/PWA client uses direct
-   Noise. Keep only static asset serving if needed.
+   proxy routes and WebSocket attach path once the native app covers
+   create/attach/replay/resize/close.
 6. Delete agent HTTP session proxying. Remove `/api/sessions*` from `dd-agent`
-   once native and web clients both use Noise for session control.
+   once native clients use Noise for session control.
 7. Retire legacy combined shell workloads. Remove `apps/confidential-shell` and
    `apps/codex-podman-shell` after deploy templates and docs no longer point at
    `DD_MODE=shell` as a PTY owner.
@@ -214,6 +214,7 @@ Keep these pieces:
   passing or exec handoff.
 - How much of the existing transcript encryption format should move unchanged
   into `dd-sessiond`.
-- Browser Noise implementation choice: pure JS library versus small WASM client.
 - Where durable paired-device trust should live if CP only brokers enrollment
   and route discovery.
+- Native app shell: Tauri/Rust shell versus platform-native UI around the Rust
+  Noise client library.

--- a/docs/sessiond-central-ui-plan.md
+++ b/docs/sessiond-central-ui-plan.md
@@ -141,6 +141,8 @@ Then strengthen:
 - Clients verify the agent quote and pin the attested Noise public key.
 - Browser/PWA uses the same direct agent Noise path once the browser crypto or
   WASM client is in place.
+- CP device enrollment survives CP redeploys. A paired native/web/mobile client
+  must not need to re-pair just because preview or production CP was relaunched.
 
 Implemented first slice:
 
@@ -177,18 +179,21 @@ direct Noise, remove the old shell stack in this order:
    client speaks Noise directly.
 2. Remove old env compatibility names. `DD_SESSIOND_HISTORY_KEY` is the only
    transcript-key override; do not continue accepting `DD_SHELL_HISTORY_KEY`.
-3. Move web/PWA to direct Noise. Store a paired device key in browser storage,
+3. Fix device registry durability. The CP trusted-device list must survive a
+   CP redeploy or hydrate from the predecessor before clients depend on it as
+   their only route to shell sessions.
+4. Move web/PWA to direct Noise. Store a paired device key in browser storage,
    use CP only for enrollment and route discovery, then connect to the selected
    agent `/noise/ws` for session RPCs and PTY bytes.
-4. Delete server-side browser shell proxying. Remove `src/shell.rs` session
+5. Delete server-side browser shell proxying. Remove `src/shell.rs` session
    proxy routes and WebSocket attach path once the web/PWA client uses direct
    Noise. Keep only static asset serving if needed.
-5. Delete agent HTTP session proxying. Remove `/api/sessions*` from `dd-agent`
+6. Delete agent HTTP session proxying. Remove `/api/sessions*` from `dd-agent`
    once native and web clients both use Noise for session control.
-6. Retire legacy combined shell workloads. Remove `apps/confidential-shell` and
+7. Retire legacy combined shell workloads. Remove `apps/confidential-shell` and
    `apps/codex-podman-shell` after deploy templates and docs no longer point at
    `DD_MODE=shell` as a PTY owner.
-7. Rename remaining storage paths only with an explicit data migration. The
+8. Rename remaining storage paths only with an explicit data migration. The
    current `dd-shell` path names are confusing but may contain persistent
    transcripts; do not silently strand them.
 
@@ -210,3 +215,5 @@ Keep these pieces:
 - How much of the existing transcript encryption format should move unchanged
   into `dd-sessiond`.
 - Browser Noise implementation choice: pure JS library versus small WASM client.
+- CP device registry storage location for SSH/preview CPs, since `/tmp` state
+  can disappear across relaunches if predecessor hydration does not run.

--- a/docs/sessiond-central-ui-plan.md
+++ b/docs/sessiond-central-ui-plan.md
@@ -70,32 +70,34 @@ Acceptance:
 - Existing session metadata and transcripts are visible through the session API.
 - Restarting only the web/UI layer does not kill a running Codex session.
 
-## Phase 2: Stable Session API
+## Phase 2: Stable Client Protocol
 
-Expose session functionality through `dd-agent`, backed by local
-`dd-sessiond`.
+Expose session functionality through `dd-agent` Noise, backed by local
+`dd-sessiond`. The stable remote surface is the paired-device protocol, not
+cookie-auth HTTP session routes.
 
-Initial API:
+Initial protocol:
 
 ```text
-GET  /api/sessions
-POST /api/sessions
-GET  /api/sessions/:id
-WS   /api/sessions/:id/attach
-POST /api/sessions/:id/input
-POST /api/sessions/:id/resize
-POST /api/sessions/:id/close
-GET  /api/sessions/:id/transcript
-WS   /api/session-events
+shell.list_recipes
+shell.list_sessions
+shell.create_session
+shell.replay_session
+shell.resize_session
+shell.close_session
+shell.attach_session
+exec
 ```
 
 Implementation notes:
 
 - `dd-sessiond` listens only on a Unix socket on the VM.
-- `dd-agent` is the only remote gateway.
+- `dd-agent` is the only remote session gateway.
 - Multiple clients may attach to the same session.
 - Transcript and events are canonical session state, not UI state.
 - Mobile clients should not resize the canonical PTY by default.
+- The existing `/api/sessions*` and `/ws/sessions*` browser-shell routes are
+  transitional compatibility only. Do not add new client features there.
 
 ## Phase 3: Client-Side Fleet UI
 
@@ -148,8 +150,12 @@ Implemented first slice:
   `shell.close_session` JSON requests over Noise.
 - `shell.attach_session` returns one JSON ack, then switches the same Noise
   session into encrypted raw PTY byte streaming to local `dd-sessiond`.
+- Native `exec`, `replay`, `resize`, and `close` commands exercise the same
+  direct Noise path as `shell`.
 - CP Noise endpoints reject shell methods because they have no local sessiond
   adapter; agent Noise endpoints wire the adapter in.
+- The native CLI appraises the agent quote with Intel Trust Authority by
+  default and requires an explicit insecure flag for local preview/dev.
 
 Design rule:
 
@@ -161,10 +167,41 @@ dd-sessiond stays local-only
 dd-agent is the policy/encryption gateway
 ```
 
+## Removal Plan
+
+Now that the durable session owner is `dd-sessiond` and native clients can use
+direct Noise, remove the old shell stack in this order:
+
+1. Freeze cookie-auth browser shell APIs. Treat `src/shell.rs` routes
+   `/api/sessions*` and `/ws/sessions*` as compatibility only until the web/PWA
+   client speaks Noise directly.
+2. Remove old env compatibility names. `DD_SESSIOND_HISTORY_KEY` is the only
+   transcript-key override; do not continue accepting `DD_SHELL_HISTORY_KEY`.
+3. Move web/PWA to direct Noise. Store a paired device key in browser storage,
+   use CP only for enrollment and route discovery, then connect to the selected
+   agent `/noise/ws` for session RPCs and PTY bytes.
+4. Delete server-side browser shell proxying. Remove `src/shell.rs` session
+   proxy routes and WebSocket attach path once the web/PWA client uses direct
+   Noise. Keep only static asset serving if needed.
+5. Delete agent HTTP session proxying. Remove `/api/sessions*` from `dd-agent`
+   once native and web clients both use Noise for session control.
+6. Retire legacy combined shell workloads. Remove `apps/confidential-shell` and
+   `apps/codex-podman-shell` after deploy templates and docs no longer point at
+   `DD_MODE=shell` as a PTY owner.
+7. Rename remaining storage paths only with an explicit data migration. The
+   current `dd-shell` path names are confusing but may contain persistent
+   transcripts; do not silently strand them.
+
+Keep these pieces:
+
+- `dd-sessiond` and its local-only API. It is the session owner, not a fallback.
+- `shell_unavailable` on CP Noise endpoints. It is an explicit rejection for a
+  process that intentionally has no local sessiond.
+- CP route discovery and enrollment. CP stays in the trust/control path, not
+  the shell data path.
+
 ## Risks And Open Questions
 
-- Whether to keep a minimal cookie-auth shell UI only as temporary emergency
-  compatibility.
 - How to model recipes so CP UI and `dd-sessiond` agree on available launchers.
 - How to represent "input requested" events for Codex/Claude without making
   terminal parsing authoritative.

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -196,17 +196,22 @@ pub async fn run() -> Result<()> {
         std::path::PathBuf::from(noise_gateway::upstream::DEFAULT_EE_AGENT_SOCK),
         ee_token,
     ));
-    let ng_state = noise_gateway::State {
-        attest: attestor.clone(),
-        trust,
-        upstream,
-    };
-
-    let gh = gh_oidc::Verifier::new(cfg.common.owner.clone(), "dd-agent".into());
     let sessiond_http_url =
         std::env::var("DD_SESSIOND_HTTP_URL").unwrap_or_else(|_| "http://127.0.0.1:7683".into());
     let sessiond_attach_addr =
         std::env::var("DD_SESSIOND_ATTACH_ADDR").unwrap_or_else(|_| "127.0.0.1:7684".into());
+    let shell = Arc::new(noise_gateway::upstream::Sessiond::new(
+        sessiond_http_url.clone(),
+        sessiond_attach_addr.clone(),
+    ));
+    let ng_state = noise_gateway::State {
+        attest: attestor.clone(),
+        trust,
+        upstream,
+        shell: Some(shell),
+    };
+
+    let gh = gh_oidc::Verifier::new(cfg.common.owner.clone(), "dd-agent".into());
 
     // Seed taint set. Boot-time facts go in now; runtime events
     // (CustomerOwnerEnabled, CustomerWorkloadDeployed) are appended

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -192,7 +192,7 @@ pub async fn run() -> Result<()> {
         attest: attestor.clone(),
         trust,
         upstream,
-        shell: Some(shell),
+        shell,
     };
 
     let gh = gh_oidc::Verifier::new(cfg.common.owner.clone(), "dd-agent".into());

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -7,9 +7,9 @@
 //! Auth after registration:
 //!   - Browser routes (`/`, `/workload/*`) require a DD-signed
 //!     GitHub App session cookie. Cloudflare only routes traffic.
-//!   - Terminal access is provided by the `dd-shell` workload on the
-//!     `shell` label. It exposes read-only workload logs and read-write
-//!     PTY sessions as separate capabilities.
+//!   - Terminal access is provided by direct paired-device Noise sessions
+//!     to this agent, with browser shell HTTP routes kept as transitional
+//!     compatibility.
 //!   - `/deploy` and `/exec` are gated in-code by a GitHub Actions
 //!     OIDC token — any CI workflow whose
 //!     principal matches `DD_OWNER`/`DD_OWNER_ID`/`DD_OWNER_KIND`
@@ -25,7 +25,7 @@ use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
 use axum::extract::{Path, Query, State};
 use axum::http::{HeaderMap, Uri};
 use axum::response::{Html, IntoResponse, Response};
-use axum::routing::{get, post};
+use axum::routing::{delete, get, post};
 use axum::{Json, Router};
 use base64::Engine as _;
 use futures_util::{SinkExt, StreamExt};
@@ -52,10 +52,6 @@ use crate::units::{self, AgentMode, ManagedUnit, UnitKind};
 /// minutes; refresh well before so `/health` always serves a live
 /// token to the CP's collector.
 const ITA_REFRESH: Duration = Duration::from_secs(180);
-
-/// Poll interval for syncing the device trust list from the CP.
-/// Tuned so a revoke propagates within ~30s.
-const DEVICES_POLL: Duration = Duration::from_secs(30);
 
 const EE_READY_TIMEOUT: Duration = Duration::from_secs(90);
 
@@ -110,6 +106,9 @@ struct St {
     /// Local raw attach socket used to proxy PTY bytes over WebSocket.
     sessiond_attach_addr: String,
     http: reqwest::Client,
+    /// Agent-local paired-device store. This is the trust source enforced by
+    /// the local Noise gateway.
+    devices: Arc<crate::devices::Store>,
 }
 
 pub async fn run() -> Result<()> {
@@ -162,24 +161,9 @@ pub async fn run() -> Result<()> {
     // CLIs can attach directly to the agent's EE instance without
     // going through the CP.
     let trust = noise_gateway::new_trust_handle();
-
-    // Background poll for the device trust list. Mutates `trust`
-    // in place so the local Noise responder picks up revocations
-    // within ~DEVICES_POLL.
-    {
-        let cp_url = cfg.cp_url.clone();
-        let token = ita_token.clone();
-        let trust = trust.clone();
-        tokio::spawn(async move {
-            let http = crate::system_http_client();
-            loop {
-                if let Err(e) = sync_trusted_devices(&http, &cp_url, &token, &trust).await {
-                    eprintln!("agent: device sync failed: {e}");
-                }
-                tokio::time::sleep(DEVICES_POLL).await;
-            }
-        });
-    }
+    let devices = crate::devices::Store::load(cfg.devices_path.clone(), trust.clone())
+        .await
+        .map_err(|e| Error::Internal(format!("agent devices store load: {e}")))?;
 
     // Attestation keypair + upstream EE client for the Noise gateway.
     let noise_key_path: std::path::PathBuf = std::env::var("DD_NOISE_KEY_PATH")
@@ -238,6 +222,7 @@ pub async fn run() -> Result<()> {
         sessiond_http_url,
         sessiond_attach_addr,
         http: crate::system_http_client(),
+        devices,
     };
     let api_state = state.clone();
     let api_ng_state = ng_state.clone();
@@ -259,6 +244,9 @@ pub async fn run() -> Result<()> {
         .route("/api/sessions/{id}/resize", post(resize_session))
         .route("/api/sessions/{id}/close", post(close_session))
         .route("/api/sessions/{id}/attach", get(attach_session))
+        .route("/api/v1/devices", post(create_device))
+        .route("/api/v1/devices/{pubkey}", delete(revoke_device))
+        .route("/admin/enroll", get(enroll_page))
         .route("/workload/{id}", get(workload_page))
         .route("/logs/{app}", get(logs));
     if !cfg.confidential {
@@ -372,51 +360,6 @@ async fn log_http(
     let res = next.run(req).await;
     eprintln!("agent: OUT {method} {path} -> {}", res.status().as_u16());
     res
-}
-
-/// Pull the CP's device registry (`{"pubkeys": ["<hex>", ...]}`) and
-/// atomically replace the local `TrustHandle`. The local Noise
-/// responder reads this set directly; revocations propagate within
-/// one `DEVICES_POLL` tick.
-async fn sync_trusted_devices(
-    http: &reqwest::Client,
-    cp_url: &str,
-    ita_token: &Arc<RwLock<String>>,
-    trust: &noise_gateway::TrustHandle,
-) -> Result<()> {
-    // `/api/v1/devices/trusted` is reachable over the public tunnel.
-    // Auth is in-code: loopback / GH-OIDC / ITA,
-    // same three-way policy as `/api/agents`.
-    let url = format!("{}/api/v1/devices/trusted", cp_url.trim_end_matches('/'));
-    let token = ita_token.read().await.clone();
-    let resp = http
-        .get(&url)
-        .bearer_auth(token)
-        .send()
-        .await
-        .map_err(|e| Error::Upstream(format!("devices GET {url}: {e}")))?;
-    if !resp.status().is_success() {
-        return Err(Error::Upstream(format!(
-            "devices GET {url} → {}",
-            resp.status()
-        )));
-    }
-    let body: serde_json::Value = resp.json().await?;
-    let mut fresh: std::collections::HashSet<[u8; 32]> = std::collections::HashSet::new();
-    if let Some(arr) = body["pubkeys"].as_array() {
-        for v in arr {
-            let Some(s) = v.as_str() else { continue };
-            let Ok(bytes) = hex::decode(s) else { continue };
-            if bytes.len() != 32 {
-                continue;
-            }
-            let mut k = [0u8; 32];
-            k.copy_from_slice(&bytes);
-            fresh.insert(k);
-        }
-    }
-    *trust.write().await = fresh;
-    Ok(())
 }
 
 #[derive(Debug, serde::Deserialize)]
@@ -995,6 +938,154 @@ async fn attach_session(
             eprintln!("agent: session attach ended: {e:#}");
         }
     }))
+}
+
+#[derive(Debug, Deserialize)]
+struct CreateDeviceReq {
+    pubkey: String,
+    label: String,
+}
+
+/// POST /api/v1/devices — enroll a device pubkey on this agent.
+/// Idempotent on pubkey: re-posting with a new label replaces the record.
+async fn create_device(
+    State(s): State<St>,
+    headers: HeaderMap,
+    uri: Uri,
+    Json(req): Json<CreateDeviceReq>,
+) -> Result<(axum::http::StatusCode, Json<crate::devices::Device>)> {
+    ensure_browser_auth(&s, &headers, &uri)?;
+    let pubkey = req.pubkey.to_lowercase();
+    crate::devices::validate_hex_pubkey(&pubkey).map_err(|e| Error::BadRequest(e.to_string()))?;
+    let label = req.label.trim().to_string();
+    if label.is_empty() || label.len() > 128 {
+        return Err(Error::BadRequest("label must be 1..=128 chars".into()));
+    }
+    let device = crate::devices::Device {
+        pubkey,
+        label,
+        created_at_ms: chrono::Utc::now().timestamp_millis(),
+        revoked_at_ms: None,
+    };
+    s.devices
+        .upsert(device.clone())
+        .await
+        .map_err(|e| Error::Internal(format!("devices upsert: {e}")))?;
+    Ok((axum::http::StatusCode::CREATED, Json(device)))
+}
+
+/// DELETE /api/v1/devices/{pubkey} — revoke a paired device on this agent.
+async fn revoke_device(
+    State(s): State<St>,
+    headers: HeaderMap,
+    uri: Uri,
+    Path(pubkey): Path<String>,
+) -> Result<Json<serde_json::Value>> {
+    ensure_browser_auth(&s, &headers, &uri)?;
+    let pubkey = pubkey.to_lowercase();
+    let now = chrono::Utc::now().timestamp_millis();
+    let ok = s
+        .devices
+        .revoke(&pubkey, now)
+        .await
+        .map_err(|e| Error::Internal(format!("devices revoke: {e}")))?;
+    if !ok {
+        return Err(Error::NotFound);
+    }
+    Ok(Json(serde_json::json!({
+        "revoked": pubkey,
+        "at_ms": now,
+    })))
+}
+
+/// GET /admin/enroll?pubkey=...&label=... — authenticated confirmation
+/// page. The mutation lands on this agent, so CP does not own paired-device
+/// trust.
+async fn enroll_page(
+    State(s): State<St>,
+    headers: HeaderMap,
+    uri: Uri,
+    Query(q): Query<std::collections::HashMap<String, String>>,
+) -> Response {
+    if let Some(resp) = require_browser_auth(&s, &headers, &uri) {
+        return resp;
+    }
+    let pubkey = q.get("pubkey").cloned().unwrap_or_default();
+    let label = q.get("label").cloned().unwrap_or_default();
+
+    if let Err(e) = crate::devices::validate_hex_pubkey(&pubkey) {
+        return Html(shell(
+            "Enroll device",
+            "",
+            &format!(
+                r#"<div class="card"><h1>Invalid pubkey</h1><p class="dim">{}</p></div>"#,
+                html::escape(&e.to_string())
+            ),
+        ))
+        .into_response();
+    }
+    if label.trim().is_empty() || label.len() > 128 {
+        return Html(shell(
+            "Enroll device",
+            "",
+            r#"<div class="card"><h1>Invalid label</h1><p class="dim">label must be 1..=128 chars</p></div>"#,
+        ))
+        .into_response();
+    }
+
+    let short = &pubkey[..16];
+    let body = format!(
+        r#"<div class="card">
+  <h1>Enroll this device?</h1>
+  <div class="row"><span>Label</span><span>{label}</span></div>
+  <div class="row"><span>Pubkey</span><code>{short}...</code></div>
+  <p class="dim">
+    Confirming adds this X25519 public key to this agent's trust list. A
+    client holding the matching private key can open Noise_IK sessions to this
+    enclave. Revoke with <code>DELETE /api/v1/devices/&lt;pubkey&gt;</code>.
+  </p>
+  <p id="status"></p>
+  <div style="display:flex;gap:8px">
+    <button id="confirm" class="ok">Confirm</button>
+    <a href="/" class="btn">Cancel</a>
+  </div>
+</div>
+<script>
+  const pubkey = {pubkey_js};
+  const label  = {label_js};
+  const status = document.getElementById("status");
+  document.getElementById("confirm").addEventListener("click", async (ev) => {{
+    ev.target.disabled = true;
+    status.textContent = "Enrolling...";
+    try {{
+      const resp = await fetch("/api/v1/devices", {{
+        method: "POST",
+        credentials: "same-origin",
+        headers: {{ "Content-Type": "application/json" }},
+        body: JSON.stringify({{ pubkey, label }}),
+      }});
+      if (!resp.ok) {{
+        const text = await resp.text();
+        status.innerHTML = "<span class='err'>Enrollment failed: " +
+          resp.status + " " + text.slice(0, 400).replace(/</g, "&lt;") +
+          "</span>";
+        ev.target.disabled = false;
+        return;
+      }}
+      status.innerHTML = "<span class='ok'>Enrolled - you can close this tab</span>";
+    }} catch (e) {{
+      status.innerHTML = "<span class='err'>Network error: " + String(e) + "</span>";
+      ev.target.disabled = false;
+    }}
+  }});
+</script>"#,
+        label = html::escape(&label),
+        short = html::escape(short),
+        pubkey_js = serde_json::to_string(&pubkey).unwrap_or_else(|_| "\"\"".into()),
+        label_js = serde_json::to_string(&label).unwrap_or_else(|_| "\"\"".into()),
+    );
+
+    Html(shell("Enroll device", "", &body)).into_response()
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/cf.rs
+++ b/src/cf.rs
@@ -506,7 +506,6 @@ pub async fn delete_cp_access_apps(
         [
             "/health",
             "/api/agents",
-            "/api/v1/devices/trusted",
             "/api/v1/admin/export",
             "/noise/ws",
             "/register",
@@ -533,7 +532,7 @@ pub async fn delete_cp_access_apps(
 ///   - `{agent}.{domain}/owner` — fleet-GH-OIDC-gated in code
 ///   - `{agent}.{domain}/logs/*` — GH-OIDC-gated in code
 ///   - `{agent}.{domain}/noise/ws` — Noise_IK-gated in code
-///     against the CP-trusted paired device pubkey set
+///     against the agent-local paired device pubkey set
 ///   - `{label}.{agent}.{domain}` — workload URL, DD/agent-owned
 pub async fn delete_agent_access_apps(
     http: &Client,

--- a/src/cf.rs
+++ b/src/cf.rs
@@ -484,9 +484,8 @@ async fn delete_access_apps_for_domains(
 ///   - `{hostname}` — dashboard, app-layer GitHub auth
 ///   - `{hostname}-shell` — dd-shell, app-layer GitHub auth
 ///   - `{hostname}/health` — public (read-only fleet health;
-///     also carries the Noise pre-handshake `{quote_b64, pubkey_hex}`)
+///     CP does not expose shell/client Noise)
 ///   - `{hostname}/api/agents` — read-only agent list
-///   - `{hostname}/noise/ws` — Noise_IK-gated in code
 ///   - `{hostname}/register` — ITA-gated in code
 ///   - `{hostname}/ingress/replace` — ITA-gated in code
 pub async fn delete_cp_access_apps(
@@ -507,7 +506,6 @@ pub async fn delete_cp_access_apps(
             "/health",
             "/api/agents",
             "/api/v1/admin/export",
-            "/noise/ws",
             "/register",
             "/ingress/replace",
             // Legacy route from the old two-step Noise pre-handshake.

--- a/src/config.rs
+++ b/src/config.rs
@@ -168,9 +168,6 @@ pub struct Cp {
     pub scraper_shard_index: u64,
     pub scraper_shard_total: u64,
     pub ita: Ita,
-    /// Where the Noise gateway persists its X25519 static private key
-    /// (tmpfs). Fresh per-boot when missing.
-    pub noise_key_path: std::path::PathBuf,
 }
 
 impl Cp {
@@ -204,9 +201,6 @@ impl Cp {
                 "DD_SCRAPER_SHARD_INDEX ({scraper_shard_index}) must be less than DD_SCRAPER_SHARD_TOTAL ({scraper_shard_total})"
             )));
         }
-        let noise_key_path = std::env::var("DD_NOISE_KEY_PATH")
-            .unwrap_or_else(|_| "/run/devopsdefender/noise.key".into())
-            .into();
         let ita = Ita::from_env(&common.env_label)?;
         Ok(Self {
             common,
@@ -218,7 +212,6 @@ impl Cp {
             scraper_shard_index,
             scraper_shard_total,
             ita,
-            noise_key_path,
         })
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -168,9 +168,6 @@ pub struct Cp {
     pub scraper_shard_index: u64,
     pub scraper_shard_total: u64,
     pub ita: Ita,
-    /// Source-of-truth file for the device registry (JSON). Survives
-    /// CP restart; mutations fsync through to disk.
-    pub devices_path: std::path::PathBuf,
     /// Where the Noise gateway persists its X25519 static private key
     /// (tmpfs). Fresh per-boot when missing.
     pub noise_key_path: std::path::PathBuf,
@@ -207,17 +204,6 @@ impl Cp {
                 "DD_SCRAPER_SHARD_INDEX ({scraper_shard_index}) must be less than DD_SCRAPER_SHARD_TOTAL ({scraper_shard_total})"
             )));
         }
-        // `/tmp/` (tmpfs) is the only universally-writable path in the
-        // EE workload sandbox — the root FS is RO, and `/var/lib/` +
-        // `/data/` are both unavailable on the CP VM (no mount-data
-        // in the CP boot set; root FS read-only for workloads).
-        // Ephemeral across CP restarts is OK: the zero-downtime
-        // boot hydrates devices from the predecessor CP via
-        // `/api/v1/admin/export` before flipping DNS, so the on-disk
-        // copy is a cache, not source of truth.
-        let devices_path = std::env::var("DD_CP_DEVICES_PATH")
-            .unwrap_or_else(|_| "/tmp/devopsdefender/devices.json".into())
-            .into();
         let noise_key_path = std::env::var("DD_NOISE_KEY_PATH")
             .unwrap_or_else(|_| "/run/devopsdefender/noise.key".into())
             .into();
@@ -232,7 +218,6 @@ impl Cp {
             scraper_shard_index,
             scraper_shard_total,
             ita,
-            devices_path,
             noise_key_path,
         })
     }
@@ -285,6 +270,9 @@ pub struct Agent {
     /// third parties that the code is sealed. Backward-compatible:
     /// unset = default (mutation endpoints enabled).
     pub confidential: bool,
+    /// Source-of-truth file for paired-device pubkeys enforced by this
+    /// agent's Noise gateway.
+    pub devices_path: std::path::PathBuf,
     /// Read-only oracle endpoints baked into the boot workload set.
     /// `apps/_infra/local-agents.sh` extracts DD-level `oracle`
     /// metadata from workload JSON and injects it here as base64 JSON
@@ -310,6 +298,9 @@ impl Agent {
             .unwrap_or_else(|_| "/var/lib/easyenclave/agent.sock".into());
         let extra_ingress = parse_extra_ingress()?;
         let confidential = parse_truthy("DD_CONFIDENTIAL");
+        let devices_path = std::env::var("DD_AGENT_DEVICES_PATH")
+            .unwrap_or_else(|_| "/var/lib/easyenclave/data/dd-agent/devices.json".into())
+            .into();
         let oracles = parse_oracles()?;
         let ita = Ita::from_env(&common.env_label)?;
         Ok(Self {
@@ -320,6 +311,7 @@ impl Agent {
             auth,
             extra_ingress,
             confidential,
+            devices_path,
             oracles,
         })
     }

--- a/src/cp.rs
+++ b/src/cp.rs
@@ -353,6 +353,7 @@ pub async fn run() -> Result<()> {
         attest: attestor.clone(),
         trust: trust.clone(),
         upstream,
+        shell: None,
     };
 
     let state = St {

--- a/src/cp.rs
+++ b/src/cp.rs
@@ -29,7 +29,6 @@ use crate::error::{Error, Result};
 use crate::html::{self, shell};
 use crate::ita;
 use crate::metrics;
-use crate::noise_gateway;
 use crate::stonith;
 use crate::taint::IntegrityState;
 use crate::units::{AgentMode, UnitKind};
@@ -54,13 +53,6 @@ struct St {
     /// GH OIDC verifier for `/api/agents` callers (CI, humans). Same
     /// audience as dd-agent, shared owner claim.
     gh: Arc<crate::gh_oidc::Verifier>,
-    /// TDX-quote + Noise-static-pubkey bundle. Surfaced by `/health`
-    /// as `{ noise: { quote_b64, pubkey_hex } }` so a bastion-app
-    /// bootstraps in one fetch (the former standalone `/attest`
-    /// endpoint was folded in). Shared `Arc` with the Noise gateway
-    /// module's handshake responder — one keypair / one quote per
-    /// boot.
-    attest: Arc<noise_gateway::attest::Attestor>,
 }
 
 pub async fn run() -> Result<()> {
@@ -135,7 +127,6 @@ pub async fn run() -> Result<()> {
     // safe to run unconditionally — it doesn't touch the poisonable
     // hostname at all.
     let store: Store = Arc::new(Mutex::new(HashMap::new()));
-    let trust = noise_gateway::new_trust_handle();
     let predecessor_prefix = cf::cp_prefix(&cfg.common.env_label);
     let has_predecessor = match cf::list(&http, &cfg.cf).await {
         Ok(tunnels) => tunnels.iter().any(|t| {
@@ -330,26 +321,6 @@ pub async fn run() -> Result<()> {
 
     let gh = crate::gh_oidc::Verifier::new(cfg.common.owner.clone(), "dd-agent".into());
 
-    // CP serves its attested Noise key for management methods, but it does not
-    // own paired-device trust for shell sessions.
-    let attestor = Arc::new(
-        noise_gateway::attest::Attestor::load_or_mint(&cfg.noise_key_path)
-            .await
-            .map_err(|e| Error::Internal(format!("noise keypair: {e}")))?,
-    );
-    eprintln!("cp: noise_pubkey={}", hex::encode(attestor.public_key()));
-    let ee_token = std::env::var("EE_TOKEN").ok();
-    let upstream = Arc::new(noise_gateway::upstream::EeAgent::new(
-        std::path::PathBuf::from(noise_gateway::upstream::DEFAULT_EE_AGENT_SOCK),
-        ee_token,
-    ));
-    let ng_state = noise_gateway::State {
-        attest: attestor.clone(),
-        trust: trust.clone(),
-        upstream,
-        shell: None,
-    };
-
     let state = St {
         cfg: cfg.clone(),
         ee,
@@ -359,7 +330,6 @@ pub async fn run() -> Result<()> {
         verifier,
         cp_ita_token,
         gh,
-        attest: attestor,
     };
 
     let app = Router::new()
@@ -374,8 +344,7 @@ pub async fn run() -> Result<()> {
         .route("/api/agents", get(api_agents))
         .route("/api/v1/admin/export", get(export_state))
         .route("/admin/enroll", get(enroll_page))
-        .with_state(state)
-        .merge(noise_gateway::router(ng_state));
+        .with_state(state);
 
     let addr = format!("0.0.0.0:{}", cfg.common.port);
     eprintln!("cp: listening on {addr}");
@@ -484,7 +453,6 @@ async fn health(
     State(s): State<St>,
     Query(q): Query<HashMap<String, String>>,
 ) -> Json<serde_json::Value> {
-    use base64::Engine as _;
     let agents = s.store.lock().await;
     let mut body = serde_json::json!({
         "ok": true,
@@ -496,21 +464,9 @@ async fn health(
         "agent_count": agents.len(),
         "healthy_count": agents.values().filter(|a| a.status == "healthy").count(),
         "oracle_count": agents.values().map(|a| a.oracles.len()).sum::<usize>(),
-        // Pre-Noise-handshake bundle — the former `GET /attest`
-        // endpoint folded in here so bastion-app bootstraps in one
-        // fetch and keep Cloudflare routing app count lower. Stable
-        // per boot; `Arc` clones are effectively free
-        // per request. `quote_b64` binds the raw Noise pubkey into
-        // TDX `report_data`, self-authenticating via ITA.
-        "noise": {
-            "quote_b64": base64::engine::general_purpose::STANDARD.encode(s.attest.quote()),
-            "pubkey_hex": hex::encode(s.attest.public_key()),
-        },
     });
     // `?verbose=1` folds in the CP's current ITA token so operators
-    // can inspect the CP VM's TDX measurement without a second route
-    // (the old `/cp/ita` + `/cp/attest` paths were removed; the
-    // TDX quote for the Noise pubkey is also above, unconditionally).
+    // can inspect the CP VM's TDX measurement without a second route.
     if q.get("verbose").map(|v| v.as_str()) == Some("1") {
         if let Some(obj) = body.as_object_mut() {
             obj.insert(

--- a/src/cp.rs
+++ b/src/cp.rs
@@ -14,7 +14,7 @@ use std::time::{Duration, Instant};
 
 use axum::extract::{Path, Query, State};
 use axum::http::{HeaderMap, Uri};
-use axum::response::{Html, IntoResponse, Response};
+use axum::response::{Html, IntoResponse, Redirect, Response};
 use axum::routing::{get, post};
 use axum::{Json, Router};
 use serde::Deserialize;
@@ -54,9 +54,6 @@ struct St {
     /// GH OIDC verifier for `/api/agents` callers (CI, humans). Same
     /// audience as dd-agent, shared owner claim.
     gh: Arc<crate::gh_oidc::Verifier>,
-    /// Paired device pubkeys. Mutations persist to disk and emit a
-    /// runtime view for the local ee-proxy workload.
-    devices: Arc<crate::devices::Store>,
     /// TDX-quote + Noise-static-pubkey bundle. Surfaced by `/health`
     /// as `{ noise: { quote_b64, pubkey_hex } }` so a bastion-app
     /// bootstraps in one fetch (the former standalone `/attest`
@@ -139,9 +136,6 @@ pub async fn run() -> Result<()> {
     // hostname at all.
     let store: Store = Arc::new(Mutex::new(HashMap::new()));
     let trust = noise_gateway::new_trust_handle();
-    let devices = crate::devices::Store::load(cfg.devices_path.clone(), trust.clone())
-        .await
-        .map_err(|e| Error::Internal(format!("devices store load: {e}")))?;
     let predecessor_prefix = cf::cp_prefix(&cfg.common.env_label);
     let has_predecessor = match cf::list(&http, &cfg.cf).await {
         Ok(tunnels) => tunnels.iter().any(|t| {
@@ -159,7 +153,7 @@ pub async fn run() -> Result<()> {
         }
     };
     if has_predecessor {
-        hydrate_from_peer(&http, &cfg.hostname, &initial_token, &devices, &store).await;
+        hydrate_from_peer(&http, &cfg.hostname, &initial_token, &store).await;
     } else {
         eprintln!("cp: no predecessor {predecessor_prefix}* tunnel — skipping hydrate (fresh env)");
     }
@@ -336,8 +330,8 @@ pub async fn run() -> Result<()> {
 
     let gh = crate::gh_oidc::Verifier::new(cfg.common.owner.clone(), "dd-agent".into());
 
-    // Noise gateway state. `devices` already loaded in Stage 2 + any
-    // inherited records merged in; `trust` is already populated.
+    // CP serves its attested Noise key for management methods, but it does not
+    // own paired-device trust for shell sessions.
     let attestor = Arc::new(
         noise_gateway::attest::Attestor::load_or_mint(&cfg.noise_key_path)
             .await
@@ -365,7 +359,6 @@ pub async fn run() -> Result<()> {
         verifier,
         cp_ita_token,
         gh,
-        devices,
         attest: attestor,
     };
 
@@ -379,12 +372,6 @@ pub async fn run() -> Result<()> {
         .route("/agent/{id}", get(agent_detail))
         .route("/agent/{id}/logs/{app}", get(agent_logs))
         .route("/api/agents", get(api_agents))
-        .route("/api/v1/devices", post(create_device))
-        .route("/api/v1/devices/trusted", get(list_trusted_devices))
-        .route(
-            "/api/v1/devices/{pubkey}",
-            axum::routing::delete(revoke_device),
-        )
         .route("/api/v1/admin/export", get(export_state))
         .route("/admin/enroll", get(enroll_page))
         .with_state(state)
@@ -436,8 +423,8 @@ fn spawn_cloudflared(token: String) {
     });
 }
 
-/// Try to pull devices + agent snapshot from a predecessor CP still
-/// serving at `hostname`. The CNAME hasn't flipped yet when this runs,
+/// Try to pull an agent snapshot from a predecessor CP still serving
+/// at `hostname`. The CNAME hasn't flipped yet when this runs,
 /// so any existing DNS record still points at the old CP's tunnel.
 /// Failures (first boot, DNS miss, old code, timeout) are logged and
 /// swallowed — deploy still proceeds as if fresh.
@@ -445,7 +432,6 @@ async fn hydrate_from_peer(
     http: &reqwest::Client,
     hostname: &str,
     ita_token: &str,
-    devices: &crate::devices::Store,
     agents: &Store,
 ) {
     let url = format!("https://{hostname}/api/v1/admin/export");
@@ -475,21 +461,6 @@ async fn hydrate_from_peer(
         }
     };
 
-    let mut imported_devices = 0usize;
-    if let Some(arr) = body.get("devices").cloned() {
-        match serde_json::from_value::<Vec<crate::devices::Device>>(arr) {
-            Ok(devs) => {
-                let n = devs.len();
-                if let Err(e) = devices.import_merge(devs).await {
-                    eprintln!("cp: hydrate devices.import_merge: {e}");
-                } else {
-                    imported_devices = n;
-                }
-            }
-            Err(e) => eprintln!("cp: hydrate devices shape mismatch: {e}"),
-        }
-    }
-
     let mut imported_agents = 0usize;
     if let Some(arr) = body.get("agents").cloned() {
         match serde_json::from_value::<Vec<collector::Agent>>(arr) {
@@ -504,9 +475,7 @@ async fn hydrate_from_peer(
         }
     }
 
-    eprintln!(
-        "cp: hydrated from {hostname} — {imported_devices} device(s), {imported_agents} agent(s)"
-    );
+    eprintln!("cp: hydrated from {hostname} — {imported_agents} agent(s)");
 }
 
 // ── Routes ──────────────────────────────────────────────────────────────
@@ -992,20 +961,17 @@ async fn fleet(State(s): State<St>, headers: HeaderMap, uri: Uri) -> Response {
     .into_response()
 }
 
-// ── Devices API ─────────────────────────────────────────────────────────
+// ── Enrollment broker ───────────────────────────────────────────────────
 //
-// Paired client-device X25519 pubkeys that the local Noise gateway
-// accepts during the handshake. POST + DELETE are behind DD browser
-// auth (admin enrollment); the machine-readable `/trusted` view is
-// gated in-code for cross-VM agent polls.
+// CP keeps enrollment stateless: it authenticates the browser and redirects
+// to a read-write agent. The agent stores and enforces paired-device trust.
 
 /// GET /api/v1/admin/export — full state snapshot for a successor CP
-/// to hydrate from during a zero-downtime deploy. Returns the
-/// device registry (full records, including revoked) and the live
+/// to hydrate from during a zero-downtime deploy. Returns the live
 /// agents HashMap. Gated in-code by a valid owner-scoped ITA Bearer
-/// (any attested enclave in the
-/// fleet can authenticate). The new CP calls this against the old
-/// CP's still-pointed DNS before flipping CNAMEs.
+/// (any attested enclave in the fleet can authenticate). The new CP
+/// calls this against the old CP's still-pointed DNS before flipping
+/// CNAMEs.
 async fn export_state(
     State(s): State<St>,
     headers: axum::http::HeaderMap,
@@ -1019,110 +985,16 @@ async fn export_state(
     // MRTD list once we stop rotating measurements every dev push.
     let _ = s.verifier.verify(bearer).await?;
 
-    let devices = s.devices.export_full().await;
     let agents: Vec<collector::Agent> = s.store.lock().await.values().cloned().collect();
     Ok(Json(serde_json::json!({
-        "devices": devices,
         "agents": agents,
     })))
 }
 
-/// GET /api/v1/devices/trusted — minimal, machine-readable view:
-/// `{ "pubkeys": ["<hex>", ...] }` with only currently-trusted keys.
-/// Reachable by cross-VM dd-agent callers over the public tunnel;
-/// gated in-code by the same three-way policy as
-/// `/api/agents`. This is the agent's poll target for mirroring the
-/// trust list into its in-memory `TrustHandle`.
-async fn list_trusted_devices(
-    State(s): State<St>,
-    axum::extract::ConnectInfo(peer): axum::extract::ConnectInfo<std::net::SocketAddr>,
-    headers: axum::http::HeaderMap,
-) -> Result<Json<serde_json::Value>> {
-    if !agents_auth_ok(&s, peer, &headers).await {
-        return Err(Error::Unauthorized);
-    }
-    let devices = s.devices.list().await;
-    let pubkeys: Vec<String> = devices
-        .into_iter()
-        .filter(|d| d.revoked_at_ms.is_none())
-        .map(|d| d.pubkey)
-        .collect();
-    Ok(Json(serde_json::json!({ "pubkeys": pubkeys })))
-}
-
-#[derive(Debug, Deserialize)]
-struct CreateDeviceReq {
-    pubkey: String,
-    label: String,
-}
-
-/// POST /api/v1/devices — enroll a device pubkey. Idempotent on
-/// pubkey: re-posting with a new label replaces the record in place.
-async fn create_device(
-    State(s): State<St>,
-    headers: HeaderMap,
-    uri: Uri,
-    Json(req): Json<CreateDeviceReq>,
-) -> Result<(axum::http::StatusCode, Json<crate::devices::Device>)> {
-    if require_browser_auth(&s, &headers, &uri).is_some() {
-        return Err(Error::Unauthorized);
-    }
-    let pubkey = req.pubkey.to_lowercase();
-    crate::devices::validate_hex_pubkey(&pubkey).map_err(|e| Error::BadRequest(e.to_string()))?;
-    let label = req.label.trim().to_string();
-    if label.is_empty() || label.len() > 128 {
-        return Err(Error::BadRequest("label must be 1..=128 chars".into()));
-    }
-    let device = crate::devices::Device {
-        pubkey,
-        label,
-        created_at_ms: chrono::Utc::now().timestamp_millis(),
-        revoked_at_ms: None,
-    };
-    s.devices
-        .upsert(device.clone())
-        .await
-        .map_err(|e| Error::Internal(format!("devices upsert: {e}")))?;
-    Ok((axum::http::StatusCode::CREATED, Json(device)))
-}
-
-/// DELETE /api/v1/devices/{pubkey} — revoke. Returns 404 if the
-/// pubkey isn't known or was already revoked.
-async fn revoke_device(
-    State(s): State<St>,
-    headers: HeaderMap,
-    uri: Uri,
-    Path(pubkey): Path<String>,
-) -> Result<Json<serde_json::Value>> {
-    if require_browser_auth(&s, &headers, &uri).is_some() {
-        return Err(Error::Unauthorized);
-    }
-    let pubkey = pubkey.to_lowercase();
-    let now = chrono::Utc::now().timestamp_millis();
-    let ok = s
-        .devices
-        .revoke(&pubkey, now)
-        .await
-        .map_err(|e| Error::Internal(format!("devices revoke: {e}")))?;
-    if !ok {
-        return Err(Error::NotFound);
-    }
-    Ok(Json(serde_json::json!({
-        "revoked": pubkey,
-        "at_ms": now,
-    })))
-}
-
 /// GET /admin/enroll?pubkey=…&label=… — human-facing confirmation
-/// page that a `bastion-app` (CLI or desktop) bounces the operator
-/// to. Behind DD browser auth: by the time this handler renders, the
-/// browser has a valid DD session cookie. The rendered page POSTs to `/api/v1/devices` with the
-/// same cookie via `credentials: "same-origin"`, completing the
-/// enrollment that headless clients can't do themselves.
-///
-/// Intent-over-GET: we deliberately don't enroll on page load —
-/// the user clicks Confirm so a copy-pasted link can't silently
-/// add a pubkey.
+/// broker. CP does not store paired-device trust; it redirects the
+/// authenticated browser to a healthy read-write agent, where the
+/// agent-local enrollment page performs the mutation.
 async fn enroll_page(
     State(s): State<St>,
     headers: HeaderMap,
@@ -1155,61 +1027,26 @@ async fn enroll_page(
         .into_response();
     }
 
-    let short = &pubkey[..16];
-    let body = format!(
-        r#"<div class="card">
-  <h1>Enroll this device?</h1>
-  <div class="row"><span>Label</span><span>{label}</span></div>
-  <div class="row"><span>Pubkey</span><code>{short}…</code></div>
-  <p class="dim">
-    Confirming adds this X25519 public key to the trust list. Every
-    DD agent mirrors that list within 30&nbsp;s; thereafter, a client
-    holding the matching private key can open Noise_IK sessions to
-    any enclave in the fleet. Revoke any time with
-    <code>DELETE /api/v1/devices/&lt;pubkey&gt;</code>.
-  </p>
-  <p id="status"></p>
-  <div style="display:flex;gap:8px">
-    <button id="confirm" class="ok">Confirm</button>
-    <a href="/" class="btn">Cancel</a>
-  </div>
-</div>
-<script>
-  const pubkey = {pubkey_js};
-  const label  = {label_js};
-  const status = document.getElementById("status");
-  document.getElementById("confirm").addEventListener("click", async (ev) => {{
-    ev.target.disabled = true;
-    status.textContent = "Enrolling…";
-    try {{
-      const resp = await fetch("/api/v1/devices", {{
-        method: "POST",
-        credentials: "same-origin",
-        headers: {{ "Content-Type": "application/json" }},
-        body: JSON.stringify({{ pubkey, label }}),
-      }});
-      if (!resp.ok) {{
-        const text = await resp.text();
-        status.innerHTML = "<span class='err'>Enrollment failed: " +
-          resp.status + " " + text.slice(0, 400).replace(/</g, "&lt;") +
-          "</span>";
-        ev.target.disabled = false;
-        return;
-      }}
-      status.innerHTML = "<span class='ok'>Enrolled ✓ — you can close this tab</span>";
-    }} catch (e) {{
-      status.innerHTML = "<span class='err'>Network error: " + String(e) + "</span>";
-      ev.target.disabled = false;
-    }}
-  }});
-</script>"#,
-        label = html::escape(&label),
-        short = html::escape(short),
-        pubkey_js = serde_json::to_string(&pubkey).unwrap_or_else(|_| "\"\"".into()),
-        label_js = serde_json::to_string(&label).unwrap_or_else(|_| "\"\"".into()),
+    let agents = s.store.lock().await;
+    let Some(agent) = agents.values().find(|a| {
+        a.status == "healthy"
+            && a.agent_mode == AgentMode::ReadWrite
+            && a.agent_id != "control-plane"
+    }) else {
+        return Html(shell(
+            "Enroll device",
+            "",
+            r#"<div class="card"><h1>No read-write agent available</h1><p class="dim">Try again after an agent registers.</p></div>"#,
+        ))
+        .into_response();
+    };
+    let url = format!(
+        "https://{}/admin/enroll?pubkey={}&label={}",
+        agent.hostname,
+        urlencoding::encode(&pubkey),
+        urlencoding::encode(&label),
     );
-
-    Html(shell("Enroll device", "", &body)).into_response()
+    Redirect::temporary(&url).into_response()
 }
 
 /// GET /api/agents — JSON list of

--- a/src/devices.rs
+++ b/src/devices.rs
@@ -1,11 +1,12 @@
 //! Device pubkey registry.
 //!
-//! Holds the X25519 pubkeys of paired client devices. Source of truth
-//! lives on the CP's disk at [`Store::path`] (JSON, pretty-printed for
-//! human editability in a pinch). The live set of *non-revoked*
-//! pubkeys is also mirrored into a [`noise_gateway::TrustHandle`] so
-//! the locally-running Noise gateway can read it directly from shared
-//! memory — no on-disk runtime view, no cross-process file contract.
+//! Holds the X25519 pubkeys of paired client devices. The store lives
+//! next to the process that enforces trust, normally `dd-agent`
+//! (JSON, pretty-printed for human editability in a pinch). The live
+//! set of *non-revoked* pubkeys is mirrored into a
+//! [`noise_gateway::TrustHandle`] so the locally-running Noise gateway
+//! can read it directly from shared memory — no on-disk runtime view,
+//! no cross-process file contract.
 //!
 //! Wire format on disk:
 //! ```json

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ pub mod gh_oidc;
 pub mod html;
 pub mod ita;
 pub mod metrics;
+pub mod noise_client;
 pub mod noise_gateway;
 pub mod oracle;
 pub mod sessiond;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,10 +4,11 @@
 //!   DD_MODE=agent   devopsdefender    # in-VM agent
 //!   DD_MODE=shell   devopsdefender    # shell web service
 //!   DD_MODE=sessiond devopsdefender   # local session supervisor
+//!   devopsdefender noise ...          # native Noise client
 //!
 //! (Also accepts `devopsdefender cp` / `devopsdefender agent` for local dev.)
 
-use devopsdefender::{agent, cp, sessiond, shell};
+use devopsdefender::{agent, cp, noise_client, sessiond, shell};
 
 #[tokio::main]
 async fn main() {
@@ -20,8 +21,9 @@ async fn main() {
         Some("agent") => agent::run().await.map_err(Into::into),
         Some("shell") => shell::run().await.map_err(Into::into),
         Some("sessiond") => sessiond::run().await.map_err(Into::into),
+        Some("noise") | Some("cli") => noise_client::run_cli().await,
         _ => {
-            eprintln!("usage: devopsdefender <cp|agent|shell|sessiond>");
+            eprintln!("usage: devopsdefender <cp|agent|shell|sessiond|noise>");
             eprintln!("   or: DD_MODE=<mode> devopsdefender");
             std::process::exit(2);
         }

--- a/src/noise_client.rs
+++ b/src/noise_client.rs
@@ -1,0 +1,721 @@
+//! Native Noise client for operator shell sessions.
+//!
+//! This is intentionally small and dependency-light: it speaks the same
+//! Noise_IK-over-WebSocket framing as `noise_gateway`, then sends the
+//! shell/session RPCs that the gateway forwards to local `dd-sessiond`.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{anyhow, Context};
+use base64::Engine as _;
+use futures_util::{SinkExt, StreamExt};
+use rand::rngs::OsRng;
+use serde_json::Value;
+use snow::{Builder, TransportState};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+use tokio_tungstenite::tungstenite::Message as WsMessage;
+use tokio_tungstenite::{connect_async, MaybeTlsStream, WebSocketStream};
+use x25519_dalek::{PublicKey, StaticSecret};
+
+const NOISE_PATTERN: &str = "Noise_IK_25519_ChaChaPoly_BLAKE2s";
+const MAX_NOISE_MSG: usize = 65535;
+const ATTACH_CHUNK: usize = 4096;
+
+type WsStream = WebSocketStream<MaybeTlsStream<TcpStream>>;
+type WsSink = futures_util::stream::SplitSink<WsStream, WsMessage>;
+type WsRead = futures_util::stream::SplitStream<WsStream>;
+
+pub async fn run_cli() -> anyhow::Result<()> {
+    let mut args: Vec<String> = std::env::args().skip(2).collect();
+    if args.is_empty() || args[0] == "-h" || args[0] == "--help" {
+        print_usage();
+        return Ok(());
+    }
+
+    let command = args.remove(0);
+    match command.as_str() {
+        "keygen" => {
+            let opts = parse_opts(args)?;
+            let key_path = opts.key_path();
+            let secret = load_or_create_key(&key_path).await?;
+            let pubkey = public_hex(&secret);
+            println!("{pubkey}");
+            if let Some(cp_url) = opts.cp_url.as_deref() {
+                let label = opts.label.unwrap_or_else(default_label);
+                println!("{}", enrollment_url(cp_url, &pubkey, &label));
+            }
+        }
+        "pubkey" => {
+            let opts = parse_opts(args)?;
+            let secret = load_or_create_key(&opts.key_path()).await?;
+            println!("{}", public_hex(&secret));
+        }
+        "recipes" => {
+            let opts = parse_opts(args)?;
+            let mut conn = connect(&opts).await?;
+            print_json(
+                conn.call(serde_json::json!({"method": "shell.list_recipes"}))
+                    .await?,
+            )?;
+        }
+        "sessions" => {
+            let opts = parse_opts(args)?;
+            let mut conn = connect(&opts).await?;
+            print_json(
+                conn.call(serde_json::json!({"method": "shell.list_sessions"}))
+                    .await?,
+            )?;
+        }
+        "create" => {
+            let opts = parse_opts(args)?;
+            let mut conn = connect(&opts).await?;
+            let session = create_session(&mut conn, &opts).await?;
+            print_json(session)?;
+        }
+        "replay" => {
+            let opts = parse_opts(args)?;
+            let id = opts
+                .id
+                .as_deref()
+                .ok_or_else(|| anyhow!("replay requires --id"))?;
+            let mut conn = connect(&opts).await?;
+            print_json(
+                conn.call(serde_json::json!({
+                    "method": "shell.replay_session",
+                    "id": id,
+                }))
+                .await?,
+            )?;
+        }
+        "resize" => {
+            let opts = parse_opts(args)?;
+            let id = opts
+                .id
+                .as_deref()
+                .ok_or_else(|| anyhow!("resize requires --id"))?;
+            let cols = opts.cols.ok_or_else(|| anyhow!("resize requires --cols"))?;
+            let rows = opts.rows.ok_or_else(|| anyhow!("resize requires --rows"))?;
+            let mut conn = connect(&opts).await?;
+            print_json(
+                conn.call(serde_json::json!({
+                    "method": "shell.resize_session",
+                    "id": id,
+                    "cols": cols,
+                    "rows": rows,
+                }))
+                .await?,
+            )?;
+        }
+        "close" => {
+            let opts = parse_opts(args)?;
+            let id = opts
+                .id
+                .as_deref()
+                .ok_or_else(|| anyhow!("close requires --id"))?;
+            let mut conn = connect(&opts).await?;
+            print_json(
+                conn.call(serde_json::json!({
+                    "method": "shell.close_session",
+                    "id": id,
+                }))
+                .await?,
+            )?;
+        }
+        "attach" => {
+            let opts = parse_opts(args)?;
+            let id = opts
+                .id
+                .as_deref()
+                .ok_or_else(|| anyhow!("attach requires --id"))?;
+            let conn = connect(&opts).await?;
+            attach_session(conn, id).await?;
+        }
+        "shell" => {
+            let opts = parse_opts(args)?;
+            let mut conn = connect(&opts).await?;
+            let session = create_session(&mut conn, &opts).await?;
+            let id = session_id(&session)?;
+            attach_session(conn, &id).await?;
+        }
+        "exec" => {
+            let (opts, cmd) = parse_exec_opts(args)?;
+            let mut conn = connect(&opts).await?;
+            print_json(
+                conn.call(serde_json::json!({
+                    "method": "exec",
+                    "cmd": cmd,
+                    "timeout_secs": opts.timeout_secs.unwrap_or(60),
+                }))
+                .await?,
+            )?;
+        }
+        other => {
+            anyhow::bail!("unknown noise command `{other}`");
+        }
+    }
+    Ok(())
+}
+
+fn print_usage() {
+    eprintln!(
+        "usage:
+  devopsdefender noise keygen [--key PATH] [--cp-url URL] [--label LABEL]
+  devopsdefender noise pubkey [--key PATH]
+  devopsdefender noise recipes --url AGENT_URL [--key PATH]
+  devopsdefender noise sessions --url AGENT_URL [--key PATH]
+  devopsdefender noise create --url AGENT_URL [--key PATH] [--recipe ID] [--name NAME] [--command PATH]
+  devopsdefender noise replay --url AGENT_URL [--key PATH] --id SESSION_ID
+  devopsdefender noise resize --url AGENT_URL [--key PATH] --id SESSION_ID --cols N --rows N
+  devopsdefender noise close --url AGENT_URL [--key PATH] --id SESSION_ID
+  devopsdefender noise attach --url AGENT_URL [--key PATH] --id SESSION_ID
+  devopsdefender noise shell --url AGENT_URL [--key PATH] [--recipe ID] [--name NAME] [--command PATH]
+  devopsdefender noise exec --url AGENT_URL [--key PATH] [--timeout SECS] -- CMD [ARG...]
+
+Quote verification is enabled by default and uses DD_ITA_API_KEY plus optional
+DD_ITA_BASE_URL, DD_ITA_JWKS_URL, and DD_ITA_ISSUER. Local dev can pass
+--insecure-skip-quote-verify explicitly."
+    );
+}
+
+#[derive(Default)]
+struct Opts {
+    url: Option<String>,
+    key: Option<PathBuf>,
+    cp_url: Option<String>,
+    label: Option<String>,
+    recipe: Option<String>,
+    name: Option<String>,
+    command: Option<String>,
+    id: Option<String>,
+    cols: Option<u64>,
+    rows: Option<u64>,
+    timeout_secs: Option<u64>,
+    insecure_skip_quote_verify: bool,
+    ita_api_key: Option<String>,
+    ita_base_url: Option<String>,
+    ita_jwks_url: Option<String>,
+    ita_issuer: Option<String>,
+}
+
+impl Opts {
+    fn key_path(&self) -> PathBuf {
+        self.key
+            .clone()
+            .or_else(|| std::env::var_os("DD_NOISE_CLIENT_KEY").map(PathBuf::from))
+            .unwrap_or_else(default_key_path)
+    }
+
+    fn agent_url(&self) -> anyhow::Result<&str> {
+        self.url
+            .as_deref()
+            .ok_or_else(|| anyhow!("missing --url AGENT_URL"))
+    }
+}
+
+fn parse_opts(args: Vec<String>) -> anyhow::Result<Opts> {
+    let mut opts = Opts::default();
+    let mut i = 0;
+    while i < args.len() {
+        let key = args[i].as_str();
+        i += 1;
+        let mut take = |name: &str| -> anyhow::Result<String> {
+            let value = args
+                .get(i)
+                .cloned()
+                .ok_or_else(|| anyhow!("{name} requires a value"))?;
+            i += 1;
+            Ok(value)
+        };
+        match key {
+            "--url" => opts.url = Some(take("--url")?),
+            "--key" => opts.key = Some(PathBuf::from(take("--key")?)),
+            "--cp-url" => opts.cp_url = Some(take("--cp-url")?),
+            "--label" => opts.label = Some(take("--label")?),
+            "--recipe" => opts.recipe = Some(take("--recipe")?),
+            "--name" => opts.name = Some(take("--name")?),
+            "--command" => opts.command = Some(take("--command")?),
+            "--id" => opts.id = Some(take("--id")?),
+            "--cols" => opts.cols = Some(parse_u64("--cols", &take("--cols")?)?),
+            "--rows" => opts.rows = Some(parse_u64("--rows", &take("--rows")?)?),
+            "--timeout" => opts.timeout_secs = Some(parse_u64("--timeout", &take("--timeout")?)?),
+            "--ita-api-key" => opts.ita_api_key = Some(take("--ita-api-key")?),
+            "--ita-base-url" => opts.ita_base_url = Some(take("--ita-base-url")?),
+            "--ita-jwks-url" => opts.ita_jwks_url = Some(take("--ita-jwks-url")?),
+            "--ita-issuer" => opts.ita_issuer = Some(take("--ita-issuer")?),
+            "--insecure-skip-quote-verify" => opts.insecure_skip_quote_verify = true,
+            "-h" | "--help" => {
+                print_usage();
+                std::process::exit(0);
+            }
+            other => anyhow::bail!("unknown option `{other}`"),
+        }
+    }
+    Ok(opts)
+}
+
+fn parse_exec_opts(args: Vec<String>) -> anyhow::Result<(Opts, Vec<String>)> {
+    let split = args
+        .iter()
+        .position(|arg| arg == "--")
+        .ok_or_else(|| anyhow!("exec requires `-- CMD [ARG...]`"))?;
+    let opts = parse_opts(args[..split].to_vec())?;
+    let cmd = args[split + 1..].to_vec();
+    if cmd.is_empty() {
+        anyhow::bail!("exec requires a command after `--`");
+    }
+    Ok((opts, cmd))
+}
+
+fn parse_u64(name: &str, value: &str) -> anyhow::Result<u64> {
+    value
+        .parse()
+        .with_context(|| format!("{name} must be an unsigned integer"))
+}
+
+struct NoiseConnection {
+    transport: TransportState,
+    sink: WsSink,
+    stream: WsRead,
+}
+
+impl NoiseConnection {
+    async fn call(&mut self, request: Value) -> anyhow::Result<Value> {
+        let plain = serde_json::to_vec(&request)?;
+        send_encrypted(&mut self.transport, &mut self.sink, &plain).await?;
+        let cipher = next_binary(&mut self.stream)
+            .await?
+            .ok_or_else(|| anyhow!("Noise websocket closed before response"))?;
+        let mut out = vec![0u8; cipher.len()];
+        let n = self.transport.read_message(&cipher, &mut out)?;
+        out.truncate(n);
+        Ok(serde_json::from_slice(&out)?)
+    }
+}
+
+async fn connect(opts: &Opts) -> anyhow::Result<NoiseConnection> {
+    let base_url = opts.agent_url()?;
+    let secret = load_or_create_key(&opts.key_path()).await?;
+    let server_pubkey = fetch_and_verify_server_pubkey(base_url, opts).await?;
+    let ws_url = noise_ws_url(base_url);
+
+    let (ws, _response) = connect_async(&ws_url)
+        .await
+        .with_context(|| format!("connect {ws_url}"))?;
+    let (mut sink, mut stream) = ws.split();
+
+    let mut hs = Builder::new(NOISE_PATTERN.parse()?)
+        .local_private_key(secret.as_bytes())
+        .remote_public_key(&server_pubkey)
+        .build_initiator()?;
+
+    let mut first = [0u8; MAX_NOISE_MSG];
+    let n = hs.write_message(&[], &mut first)?;
+    sink.send(WsMessage::Binary(first[..n].to_vec().into()))
+        .await?;
+
+    let second = next_binary(&mut stream)
+        .await?
+        .ok_or_else(|| anyhow!("Noise websocket closed during handshake"))?;
+    let mut payload = [0u8; MAX_NOISE_MSG];
+    hs.read_message(&second, &mut payload)?;
+
+    Ok(NoiseConnection {
+        transport: hs.into_transport_mode()?,
+        sink,
+        stream,
+    })
+}
+
+async fn fetch_and_verify_server_pubkey(base_url: &str, opts: &Opts) -> anyhow::Result<[u8; 32]> {
+    let url = health_url(base_url);
+    let body: Value = reqwest::get(&url)
+        .await
+        .with_context(|| format!("GET {url}"))?
+        .error_for_status()
+        .with_context(|| format!("GET {url}"))?
+        .json()
+        .await
+        .with_context(|| format!("parse {url}"))?;
+    let pubkey_hex = body
+        .pointer("/noise/pubkey_hex")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow!("{url} did not include noise.pubkey_hex"))?;
+    let quote_b64 = body
+        .pointer("/noise/quote_b64")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow!("{url} did not include noise.quote_b64"))?;
+    let bytes = hex::decode(pubkey_hex).context("decode noise.pubkey_hex")?;
+    if bytes.len() != 32 {
+        anyhow::bail!(
+            "noise.pubkey_hex decoded to {} bytes, expected 32",
+            bytes.len()
+        );
+    }
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&bytes);
+    verify_quote_binding(quote_b64, &out, opts).await?;
+    Ok(out)
+}
+
+async fn verify_quote_binding(
+    quote_b64: &str,
+    pubkey: &[u8; 32],
+    opts: &Opts,
+) -> anyhow::Result<()> {
+    if opts.insecure_skip_quote_verify {
+        eprintln!("warning: skipping agent TDX quote verification by explicit request");
+        return Ok(());
+    }
+
+    let api_key = opt_or_env(opts.ita_api_key.as_deref(), "DD_ITA_API_KEY")
+        .ok_or_else(|| anyhow!("DD_ITA_API_KEY required for quote verification"))?;
+    let base_url = opt_or_env(opts.ita_base_url.as_deref(), "DD_ITA_BASE_URL")
+        .unwrap_or_else(|| "https://api.trustauthority.intel.com".into());
+    let jwks_url = opt_or_env(opts.ita_jwks_url.as_deref(), "DD_ITA_JWKS_URL")
+        .unwrap_or_else(|| "https://portal.trustauthority.intel.com/certs".into());
+    let issuer = opt_or_env(opts.ita_issuer.as_deref(), "DD_ITA_ISSUER")
+        .unwrap_or_else(|| "https://portal.trustauthority.intel.com".into());
+
+    let token = crate::ita::mint(&base_url, &api_key, quote_b64)
+        .await
+        .map_err(|e| anyhow!("ITA quote appraisal failed: {e}"))?;
+    let verifier = crate::ita::Verifier::new(jwks_url, issuer);
+    let claims = verifier
+        .verify(&token)
+        .await
+        .map_err(|e| anyhow!("ITA token verification failed: {e}"))?;
+    let report_data = claims
+        .report_data
+        .as_deref()
+        .ok_or_else(|| anyhow!("ITA token missing attester_held_data/report_data"))?;
+    verify_report_data(report_data, pubkey)
+}
+
+fn opt_or_env(opt: Option<&str>, env: &str) -> Option<String> {
+    opt.map(str::to_owned).or_else(|| {
+        std::env::var(env)
+            .ok()
+            .map(|v| v.trim().to_string())
+            .filter(|v| !v.is_empty())
+    })
+}
+
+fn verify_report_data(report_data: &str, pubkey: &[u8; 32]) -> anyhow::Result<()> {
+    let bytes = decode_report_data(report_data)?;
+    match bytes.len() {
+        32 if bytes.as_slice() == pubkey => Ok(()),
+        64 if bytes[..32] == pubkey[..] && bytes[32..].iter().all(|b| *b == 0) => Ok(()),
+        32 | 64 => anyhow::bail!("TDX report_data does not bind expected Noise public key"),
+        n => anyhow::bail!("TDX report_data decoded to {n} bytes, expected 32 or 64"),
+    }
+}
+
+fn decode_report_data(report_data: &str) -> anyhow::Result<Vec<u8>> {
+    let s = report_data.trim();
+    let hexish = s.strip_prefix("0x").unwrap_or(s);
+    if hexish.len().is_multiple_of(2) && hexish.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return hex::decode(hexish).context("decode ITA report_data hex");
+    }
+    for engine in [
+        &base64::engine::general_purpose::STANDARD,
+        &base64::engine::general_purpose::STANDARD_NO_PAD,
+        &base64::engine::general_purpose::URL_SAFE,
+        &base64::engine::general_purpose::URL_SAFE_NO_PAD,
+    ] {
+        if let Ok(bytes) = engine.decode(s) {
+            return Ok(bytes);
+        }
+    }
+    anyhow::bail!("ITA report_data is neither hex nor base64")
+}
+
+async fn create_session(conn: &mut NoiseConnection, opts: &Opts) -> anyhow::Result<Value> {
+    let mut request = serde_json::Map::from_iter([(
+        "method".to_string(),
+        Value::String("shell.create_session".into()),
+    )]);
+    if let Some(recipe) = opts.recipe.as_deref() {
+        request.insert("recipe_id".into(), Value::String(recipe.into()));
+    }
+    if let Some(name) = opts.name.as_deref() {
+        request.insert("name".into(), Value::String(name.into()));
+    }
+    if let Some(command) = opts.command.as_deref() {
+        request.insert("command".into(), Value::String(command.into()));
+    }
+    conn.call(Value::Object(request)).await
+}
+
+async fn attach_session(mut conn: NoiseConnection, id: &str) -> anyhow::Result<()> {
+    let ack = conn
+        .call(serde_json::json!({
+            "method": "shell.attach_session",
+            "id": id,
+            "tail": true,
+        }))
+        .await?;
+    if ack.get("error").is_some() {
+        anyhow::bail!("attach failed: {}", serde_json::to_string(&ack)?);
+    }
+
+    let _raw = RawMode::enter()?;
+    let mut stdin = tokio::io::stdin();
+    let mut stdout = tokio::io::stdout();
+    let mut in_buf = [0u8; ATTACH_CHUNK];
+
+    loop {
+        tokio::select! {
+            n = stdin.read(&mut in_buf) => {
+                let n = n?;
+                if n == 0 {
+                    break;
+                }
+                send_encrypted(&mut conn.transport, &mut conn.sink, &in_buf[..n]).await?;
+            }
+            frame = next_binary(&mut conn.stream) => {
+                let Some(cipher) = frame? else {
+                    break;
+                };
+                let mut plain = vec![0u8; cipher.len()];
+                let n = conn.transport.read_message(&cipher, &mut plain)?;
+                stdout.write_all(&plain[..n]).await?;
+                stdout.flush().await?;
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn send_encrypted(
+    transport: &mut TransportState,
+    sink: &mut WsSink,
+    plain: &[u8],
+) -> anyhow::Result<()> {
+    let mut cipher = vec![0u8; plain.len() + 16];
+    let n = transport.write_message(plain, &mut cipher)?;
+    cipher.truncate(n);
+    sink.send(WsMessage::Binary(cipher.into())).await?;
+    Ok(())
+}
+
+async fn next_binary(stream: &mut WsRead) -> anyhow::Result<Option<Vec<u8>>> {
+    while let Some(msg) = stream.next().await {
+        match msg? {
+            WsMessage::Binary(b) => return Ok(Some(b.to_vec())),
+            WsMessage::Close(_) => return Ok(None),
+            WsMessage::Text(_) | WsMessage::Ping(_) | WsMessage::Pong(_) | WsMessage::Frame(_) => {
+                continue
+            }
+        }
+    }
+    Ok(None)
+}
+
+fn session_id(value: &Value) -> anyhow::Result<String> {
+    if let Some(error) = value.get("error") {
+        anyhow::bail!("create failed: {error}");
+    }
+    value
+        .get("id")
+        .or_else(|| value.pointer("/session/id"))
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| anyhow!("create response did not include a session id: {value}"))
+}
+
+async fn load_or_create_key(path: &Path) -> anyhow::Result<StaticSecret> {
+    match tokio::fs::read(path).await {
+        Ok(bytes) if bytes.len() == 32 => {
+            let mut key = [0u8; 32];
+            key.copy_from_slice(&bytes);
+            Ok(StaticSecret::from(key))
+        }
+        Ok(bytes) => anyhow::bail!("{} is {} bytes, expected 32", path.display(), bytes.len()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            let secret = StaticSecret::random_from_rng(OsRng);
+            persist_key(path, secret.as_bytes()).await?;
+            Ok(secret)
+        }
+        Err(e) => Err(e).with_context(|| format!("read {}", path.display())),
+    }
+}
+
+async fn persist_key(path: &Path, bytes: &[u8; 32]) -> anyhow::Result<()> {
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent).await?;
+    }
+    let tmp = path.with_extension("key.tmp");
+    tokio::fs::write(&tmp, bytes).await?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        tokio::fs::set_permissions(&tmp, std::fs::Permissions::from_mode(0o600)).await?;
+    }
+    tokio::fs::rename(&tmp, path).await?;
+    Ok(())
+}
+
+fn public_hex(secret: &StaticSecret) -> String {
+    hex::encode(PublicKey::from(secret).as_bytes())
+}
+
+fn default_key_path() -> PathBuf {
+    if let Some(home) = std::env::var_os("HOME") {
+        return PathBuf::from(home)
+            .join(".config")
+            .join("devopsdefender")
+            .join("noise.key");
+    }
+    PathBuf::from(".devopsdefender-noise.key")
+}
+
+fn default_label() -> String {
+    std::env::var("HOSTNAME")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "native-cli".into())
+}
+
+fn enrollment_url(cp_url: &str, pubkey_hex: &str, label: &str) -> String {
+    format!(
+        "{}/admin/enroll?pubkey={}&label={}",
+        normalize_http_base(cp_url),
+        pubkey_hex,
+        urlencoding::encode(label)
+    )
+}
+
+fn health_url(base_url: &str) -> String {
+    format!("{}/health", normalize_http_base(base_url))
+}
+
+fn noise_ws_url(base_url: &str) -> String {
+    let base = normalize_http_base(base_url);
+    let ws_base = if let Some(rest) = base.strip_prefix("https://") {
+        format!("wss://{rest}")
+    } else if let Some(rest) = base.strip_prefix("http://") {
+        format!("ws://{rest}")
+    } else {
+        base
+    };
+    format!("{}/noise/ws", ws_base.trim_end_matches('/'))
+}
+
+fn normalize_http_base(base_url: &str) -> String {
+    let trimmed = base_url.trim().trim_end_matches('/');
+    if trimmed.starts_with("http://") || trimmed.starts_with("https://") {
+        trimmed.to_string()
+    } else {
+        format!("https://{trimmed}")
+    }
+}
+
+fn print_json(value: Value) -> anyhow::Result<()> {
+    println!("{}", serde_json::to_string_pretty(&value)?);
+    Ok(())
+}
+
+struct RawMode {
+    #[cfg(unix)]
+    original: Option<libc::termios>,
+}
+
+impl RawMode {
+    fn enter() -> anyhow::Result<Self> {
+        #[cfg(unix)]
+        {
+            if unsafe { libc::isatty(libc::STDIN_FILENO) } != 1 {
+                return Ok(Self { original: None });
+            }
+            let mut original = std::mem::MaybeUninit::<libc::termios>::uninit();
+            if unsafe { libc::tcgetattr(libc::STDIN_FILENO, original.as_mut_ptr()) } != 0 {
+                return Err(std::io::Error::last_os_error()).context("tcgetattr");
+            }
+            let original = unsafe { original.assume_init() };
+            let mut raw = original;
+            unsafe { libc::cfmakeraw(&mut raw) };
+            if unsafe { libc::tcsetattr(libc::STDIN_FILENO, libc::TCSANOW, &raw) } != 0 {
+                return Err(std::io::Error::last_os_error()).context("tcsetattr raw");
+            }
+            Ok(Self {
+                original: Some(original),
+            })
+        }
+        #[cfg(not(unix))]
+        {
+            Ok(Self {})
+        }
+    }
+}
+
+impl Drop for RawMode {
+    fn drop(&mut self) {
+        #[cfg(unix)]
+        if let Some(original) = &self.original {
+            let _ = unsafe { libc::tcsetattr(libc::STDIN_FILENO, libc::TCSANOW, original) };
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builds_urls_from_bare_host() {
+        assert_eq!(
+            health_url("agent.example.com/"),
+            "https://agent.example.com/health"
+        );
+        assert_eq!(
+            noise_ws_url("agent.example.com/"),
+            "wss://agent.example.com/noise/ws"
+        );
+    }
+
+    #[test]
+    fn keeps_local_http_scheme() {
+        assert_eq!(
+            health_url("http://127.0.0.1:8080"),
+            "http://127.0.0.1:8080/health"
+        );
+        assert_eq!(
+            noise_ws_url("http://127.0.0.1:8080"),
+            "ws://127.0.0.1:8080/noise/ws"
+        );
+    }
+
+    #[test]
+    fn enrollment_url_encodes_label() {
+        assert_eq!(
+            enrollment_url("https://cp.example.com/", "abcd", "me laptop"),
+            "https://cp.example.com/admin/enroll?pubkey=abcd&label=me%20laptop"
+        );
+    }
+
+    #[test]
+    fn report_data_accepts_64_byte_hex_binding() {
+        let mut report = [0u8; 64];
+        report[..32].fill(7);
+        let pubkey = [7u8; 32];
+        verify_report_data(&hex::encode(report), &pubkey).unwrap();
+    }
+
+    #[test]
+    fn report_data_rejects_wrong_key() {
+        let mut report = [0u8; 64];
+        report[..32].fill(7);
+        let pubkey = [8u8; 32];
+        assert!(verify_report_data(&hex::encode(report), &pubkey).is_err());
+    }
+
+    #[test]
+    fn report_data_accepts_base64_binding() {
+        let mut report = [0u8; 64];
+        report[..32].fill(9);
+        let pubkey = [9u8; 32];
+        let encoded = base64::engine::general_purpose::STANDARD.encode(report);
+        verify_report_data(&encoded, &pubkey).unwrap();
+    }
+}

--- a/src/noise_gateway/allowlist.rs
+++ b/src/noise_gateway/allowlist.rs
@@ -15,6 +15,13 @@ pub enum Method {
     Health,
     List,
     Logs,
+    ShellAttachSession,
+    ShellCloseSession,
+    ShellCreateSession,
+    ShellListRecipes,
+    ShellListSessions,
+    ShellReplaySession,
+    ShellResizeSession,
 }
 
 impl Method {
@@ -26,6 +33,13 @@ impl Method {
             Self::Health => "health",
             Self::List => "list",
             Self::Logs => "logs",
+            Self::ShellAttachSession => "shell.attach_session",
+            Self::ShellCloseSession => "shell.close_session",
+            Self::ShellCreateSession => "shell.create_session",
+            Self::ShellListRecipes => "shell.list_recipes",
+            Self::ShellListSessions => "shell.list_sessions",
+            Self::ShellReplaySession => "shell.replay_session",
+            Self::ShellResizeSession => "shell.resize_session",
         }
     }
 }
@@ -45,6 +59,13 @@ pub fn classify(raw: &serde_json::Value) -> Result<Method, ClassifyError> {
         "health" => Ok(Method::Health),
         "list" => Ok(Method::List),
         "logs" => Ok(Method::Logs),
+        "shell.attach_session" => Ok(Method::ShellAttachSession),
+        "shell.close_session" => Ok(Method::ShellCloseSession),
+        "shell.create_session" => Ok(Method::ShellCreateSession),
+        "shell.list_recipes" => Ok(Method::ShellListRecipes),
+        "shell.list_sessions" => Ok(Method::ShellListSessions),
+        "shell.replay_session" => Ok(Method::ShellReplaySession),
+        "shell.resize_session" => Ok(Method::ShellResizeSession),
         "deploy" => Err(ClassifyError::Disallowed("deploy".into())),
         other => Err(ClassifyError::Unknown(other.into())),
     }
@@ -74,6 +95,12 @@ mod tests {
     fn exec_allowed() {
         let r = classify(&serde_json::json!({"method": "exec", "argv": ["ls"]}));
         assert_eq!(r.unwrap(), Method::Exec);
+    }
+
+    #[test]
+    fn shell_attach_allowed() {
+        let r = classify(&serde_json::json!({"method": "shell.attach_session", "id": "abc"}));
+        assert_eq!(r.unwrap(), Method::ShellAttachSession);
     }
 
     #[test]

--- a/src/noise_gateway/mod.rs
+++ b/src/noise_gateway/mod.rs
@@ -45,6 +45,7 @@ pub struct State {
     pub attest: Arc<attest::Attestor>,
     pub trust: TrustHandle,
     pub upstream: Arc<upstream::EeAgent>,
+    pub shell: Option<Arc<upstream::Sessiond>>,
 }
 
 pub fn router(state: State) -> Router {

--- a/src/noise_gateway/mod.rs
+++ b/src/noise_gateway/mod.rs
@@ -44,7 +44,7 @@ pub struct State {
     pub attest: Arc<attest::Attestor>,
     pub trust: TrustHandle,
     pub upstream: Arc<upstream::EeAgent>,
-    pub shell: Option<Arc<upstream::Sessiond>>,
+    pub shell: Arc<upstream::Sessiond>,
 }
 
 pub fn router(state: State) -> Router {

--- a/src/noise_gateway/mod.rs
+++ b/src/noise_gateway/mod.rs
@@ -32,8 +32,7 @@ use axum::Router;
 use tokio::sync::RwLock;
 
 /// Live set of device pubkeys the local Noise responder will accept.
-/// Mutated by `devices::Store` (on the CP) or by the agent's
-/// `sync_trusted_devices` poll loop.
+/// Mutated by the local `devices::Store` next to the process enforcing trust.
 pub type TrustHandle = Arc<RwLock<HashSet<[u8; 32]>>>;
 
 pub fn new_trust_handle() -> TrustHandle {

--- a/src/noise_gateway/noise.rs
+++ b/src/noise_gateway/noise.rs
@@ -26,7 +26,7 @@ use axum::routing::get;
 use axum::Router;
 use futures_util::StreamExt;
 use snow::{Builder, HandshakeState, TransportState};
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
 use super::{allowlist, State as AppState};
 
@@ -122,6 +122,55 @@ async fn handle(mut socket: WebSocket, state: AppState) -> anyhow::Result<()> {
                     }
                 }
             }
+            Ok(allowlist::Method::ShellAttachSession) => {
+                let Some(shell) = &state.shell else {
+                    let resp = serde_json::json!({
+                        "error": "shell_unavailable",
+                        "detail": "this Noise endpoint is not connected to sessiond",
+                    });
+                    send_encrypted_json(&mut transport, &mut socket, &resp).await?;
+                    continue;
+                };
+                match shell.attach_stream(request).await {
+                    Ok((ack, stream)) => {
+                        send_encrypted_json(&mut transport, &mut socket, &ack).await?;
+                        bridge_attach(&mut transport, &mut socket, stream).await?;
+                        return Ok(());
+                    }
+                    Err(e) => {
+                        let resp = serde_json::json!({
+                            "error": "shell_attach_failed",
+                            "detail": e.to_string(),
+                        });
+                        send_encrypted_json(&mut transport, &mut socket, &resp).await?;
+                        continue;
+                    }
+                }
+            }
+            Ok(
+                allowlist::Method::ShellCloseSession
+                | allowlist::Method::ShellCreateSession
+                | allowlist::Method::ShellListRecipes
+                | allowlist::Method::ShellListSessions
+                | allowlist::Method::ShellReplaySession
+                | allowlist::Method::ShellResizeSession,
+            ) => {
+                let Some(shell) = &state.shell else {
+                    let resp = serde_json::json!({
+                        "error": "shell_unavailable",
+                        "detail": "this Noise endpoint is not connected to sessiond",
+                    });
+                    send_encrypted_json(&mut transport, &mut socket, &resp).await?;
+                    continue;
+                };
+                let response = shell.call(request).await.unwrap_or_else(|e| {
+                    serde_json::json!({
+                        "error": "shell_failed",
+                        "detail": e.to_string(),
+                    })
+                });
+                send_encrypted_json(&mut transport, &mut socket, &response).await?;
+            }
             Ok(_method) => {
                 let response = state.upstream.call(request).await.unwrap_or_else(|e| {
                     serde_json::json!({
@@ -172,28 +221,28 @@ async fn send_encrypted_bytes(
 async fn bridge_attach(
     transport: &mut TransportState,
     socket: &mut WebSocket,
-    ee_stream: tokio::net::UnixStream,
+    stream: impl AsyncRead + AsyncWrite + Unpin,
 ) -> anyhow::Result<()> {
-    let (mut ee_rd, mut ee_wr) = ee_stream.into_split();
+    let (mut stream_rd, mut stream_wr) = tokio::io::split(stream);
     let mut ee_buf = [0u8; ATTACH_CHUNK];
 
     loop {
         tokio::select! {
             biased;
-            // EE → client: raw PTY bytes, encrypted and forwarded.
-            n = ee_rd.read(&mut ee_buf) => {
+            // Upstream → client: raw PTY bytes, encrypted and forwarded.
+            n = stream_rd.read(&mut ee_buf) => {
                 match n? {
-                    0 => break, // EE closed (shell exited)
+                    0 => break, // Upstream closed (shell exited)
                     n => send_encrypted_bytes(transport, socket, &ee_buf[..n]).await?,
                 }
             }
-            // Client → EE: decrypt and write stdin.
+            // Client → upstream: decrypt and write stdin.
             frame = next_binary(socket) => {
                 match frame? {
                     Some(cipher) => {
                         let mut plain = vec![0u8; cipher.len()];
                         let n = transport.read_message(&cipher, &mut plain)?;
-                        ee_wr.write_all(&plain[..n]).await?;
+                        stream_wr.write_all(&plain[..n]).await?;
                     }
                     None => break, // WS closed
                 }

--- a/src/noise_gateway/noise.rs
+++ b/src/noise_gateway/noise.rs
@@ -123,15 +123,7 @@ async fn handle(mut socket: WebSocket, state: AppState) -> anyhow::Result<()> {
                 }
             }
             Ok(allowlist::Method::ShellAttachSession) => {
-                let Some(shell) = &state.shell else {
-                    let resp = serde_json::json!({
-                        "error": "shell_unavailable",
-                        "detail": "this Noise endpoint is not connected to sessiond",
-                    });
-                    send_encrypted_json(&mut transport, &mut socket, &resp).await?;
-                    continue;
-                };
-                match shell.attach_stream(request).await {
+                match state.shell.attach_stream(request).await {
                     Ok((ack, stream)) => {
                         send_encrypted_json(&mut transport, &mut socket, &ack).await?;
                         bridge_attach(&mut transport, &mut socket, stream).await?;
@@ -155,15 +147,7 @@ async fn handle(mut socket: WebSocket, state: AppState) -> anyhow::Result<()> {
                 | allowlist::Method::ShellReplaySession
                 | allowlist::Method::ShellResizeSession,
             ) => {
-                let Some(shell) = &state.shell else {
-                    let resp = serde_json::json!({
-                        "error": "shell_unavailable",
-                        "detail": "this Noise endpoint is not connected to sessiond",
-                    });
-                    send_encrypted_json(&mut transport, &mut socket, &resp).await?;
-                    continue;
-                };
-                let response = shell.call(request).await.unwrap_or_else(|e| {
+                let response = state.shell.call(request).await.unwrap_or_else(|e| {
                     serde_json::json!({
                         "error": "shell_failed",
                         "detail": e.to_string(),

--- a/src/noise_gateway/upstream.rs
+++ b/src/noise_gateway/upstream.rs
@@ -11,9 +11,10 @@
 //! and the caller is responsible for byte-bridging.
 
 use std::path::PathBuf;
+use std::time::Duration;
 
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
-use tokio::net::UnixStream;
+use tokio::net::{TcpStream, UnixStream};
 
 pub const DEFAULT_EE_AGENT_SOCK: &str = "/var/lib/easyenclave/agent.sock";
 
@@ -92,6 +93,140 @@ impl EeAgent {
             }
         }
     }
+}
+
+pub struct Sessiond {
+    http_url: String,
+    attach_addr: String,
+    http: reqwest::Client,
+}
+
+impl Sessiond {
+    pub fn new(http_url: String, attach_addr: String) -> Self {
+        let http = reqwest::Client::builder()
+            .timeout(Duration::from_secs(10))
+            .no_hickory_dns()
+            .build()
+            .unwrap_or_else(|_| crate::system_http_client());
+        Self {
+            http_url,
+            attach_addr,
+            http,
+        }
+    }
+
+    pub async fn call(&self, req: serde_json::Value) -> anyhow::Result<serde_json::Value> {
+        let method = req
+            .get("method")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow::anyhow!("shell request missing method"))?;
+        match method {
+            "shell.list_recipes" => self.get_json("/api/recipes").await,
+            "shell.list_sessions" => self.get_json("/api/sessions").await,
+            "shell.create_session" => self.post_json("/api/sessions", &session_body(req)).await,
+            "shell.replay_session" => {
+                let id = required_str(&req, "id")?;
+                self.get_json(&format!("/api/sessions/{id}/replay")).await
+            }
+            "shell.resize_session" => {
+                let id = required_str(&req, "id")?;
+                self.post_empty(
+                    &format!("/api/sessions/{id}/resize"),
+                    &serde_json::json!({
+                        "cols": req.get("cols").and_then(|v| v.as_u64()).unwrap_or(80),
+                        "rows": req.get("rows").and_then(|v| v.as_u64()).unwrap_or(24),
+                    }),
+                )
+                .await
+            }
+            "shell.close_session" => {
+                let id = required_str(&req, "id")?;
+                self.post_empty(&format!("/api/sessions/{id}/close"), &serde_json::json!({}))
+                    .await
+            }
+            other => anyhow::bail!("unsupported shell method: {other}"),
+        }
+    }
+
+    pub async fn attach_stream(
+        &self,
+        req: serde_json::Value,
+    ) -> anyhow::Result<(serde_json::Value, TcpStream)> {
+        let id = required_str(&req, "id")?;
+        let tail = req.get("tail").and_then(|v| v.as_bool()).unwrap_or(true);
+        let mut stream = TcpStream::connect(&self.attach_addr).await?;
+        let tail_arg = if tail { "tail" } else { "notail" };
+        stream
+            .write_all(format!("{id} {tail_arg}\n").as_bytes())
+            .await?;
+        Ok((
+            serde_json::json!({
+                "ok": true,
+                "method": "shell.attach_session",
+                "id": id,
+                "tail": tail,
+            }),
+            stream,
+        ))
+    }
+
+    async fn get_json(&self, path: &str) -> anyhow::Result<serde_json::Value> {
+        let resp = self.http.get(self.url(path)).send().await?;
+        decode_json(path, resp).await
+    }
+
+    async fn post_json(
+        &self,
+        path: &str,
+        body: &serde_json::Value,
+    ) -> anyhow::Result<serde_json::Value> {
+        let resp = self.http.post(self.url(path)).json(body).send().await?;
+        decode_json(path, resp).await
+    }
+
+    async fn post_empty(
+        &self,
+        path: &str,
+        body: &serde_json::Value,
+    ) -> anyhow::Result<serde_json::Value> {
+        let resp = self.http.post(self.url(path)).json(body).send().await?;
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            anyhow::bail!("sessiond {path}: HTTP {status}: {body}");
+        }
+        Ok(serde_json::json!({"ok": true}))
+    }
+
+    fn url(&self, path: &str) -> String {
+        format!("{}{}", self.http_url.trim_end_matches('/'), path)
+    }
+}
+
+fn session_body(req: serde_json::Value) -> serde_json::Value {
+    let mut body = serde_json::Map::new();
+    for key in ["name", "recipe_id", "command", "cwd"] {
+        if let Some(value) = req.get(key) {
+            body.insert(key.to_string(), value.clone());
+        }
+    }
+    serde_json::Value::Object(body)
+}
+
+fn required_str<'a>(req: &'a serde_json::Value, key: &str) -> anyhow::Result<&'a str> {
+    req.get(key)
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| anyhow::anyhow!("shell request missing `{key}`"))
+}
+
+async fn decode_json(path: &str, resp: reqwest::Response) -> anyhow::Result<serde_json::Value> {
+    let status = resp.status();
+    if !status.is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        anyhow::bail!("sessiond {path}: HTTP {status}: {body}");
+    }
+    Ok(resp.json().await?)
 }
 
 #[cfg(test)]

--- a/src/noise_gateway/upstream.rs
+++ b/src/noise_gateway/upstream.rs
@@ -126,7 +126,12 @@ impl Sessiond {
             "shell.create_session" => self.post_json("/api/sessions", &session_body(req)).await,
             "shell.replay_session" => {
                 let id = required_str(&req, "id")?;
-                self.get_json(&format!("/api/sessions/{id}/replay")).await
+                let path = if let Some(max_bytes) = req.get("max_bytes").and_then(|v| v.as_u64()) {
+                    format!("/api/sessions/{id}/replay?max_bytes={max_bytes}")
+                } else {
+                    format!("/api/sessions/{id}/replay")
+                };
+                self.get_json(&path).await
             }
             "shell.resize_session" => {
                 let id = required_str(&req, "id")?;

--- a/src/sessiond.rs
+++ b/src/sessiond.rs
@@ -996,9 +996,7 @@ impl TranscriptStore {
 }
 
 async fn history_key(dir: &Path) -> Result<[u8; 32]> {
-    if let Ok(raw) =
-        std::env::var("DD_SESSIOND_HISTORY_KEY").or_else(|_| std::env::var("DD_SHELL_HISTORY_KEY"))
-    {
+    if let Ok(raw) = std::env::var("DD_SESSIOND_HISTORY_KEY") {
         let bytes = base64::engine::general_purpose::STANDARD
             .decode(raw.trim())
             .or_else(|_| hex::decode(raw.trim()))

--- a/src/sessiond.rs
+++ b/src/sessiond.rs
@@ -14,7 +14,7 @@ use std::process::Stdio;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use axum::extract::{Path as AxPath, State};
+use axum::extract::{Path as AxPath, Query, State};
 use axum::http::StatusCode;
 use axum::routing::{get, post};
 use axum::{Json, Router};
@@ -41,6 +41,8 @@ const DEFAULT_DIR: &str = "/var/lib/devopsdefender/sessiond";
 const EE_DATA_MOUNT: &str = "/var/lib/easyenclave/data";
 const DATA_MOUNT_WAIT_SECS: u64 = 60;
 const RING_LIMIT: usize = 256 * 1024;
+const DEFAULT_REPLAY_MAX_BYTES: usize = 48 * 1024;
+const ABSOLUTE_REPLAY_MAX_BYTES: usize = 48 * 1024;
 
 const CODEX_PODMAN_RECIPE: &str = r#"#!/var/lib/easyenclave/bin/busybox sh
 set -eu
@@ -226,6 +228,12 @@ pub struct ResizeSession {
 pub struct ReplayResponse {
     pub id: String,
     pub bytes_b64: String,
+    pub truncated: bool,
+}
+
+#[derive(Deserialize)]
+struct ReplayQuery {
+    max_bytes: Option<usize>,
 }
 
 struct RecipeSeed {
@@ -413,11 +421,17 @@ async fn create_session(
 async fn replay_session(
     State(app): State<App>,
     AxPath(id): AxPath<String>,
+    Query(query): Query<ReplayQuery>,
 ) -> Result<Json<ReplayResponse>> {
-    let bytes = app.store.replay(&id).await?;
+    let max_bytes = query
+        .max_bytes
+        .unwrap_or(DEFAULT_REPLAY_MAX_BYTES)
+        .min(ABSOLUTE_REPLAY_MAX_BYTES);
+    let (bytes, truncated) = app.store.replay(&id, max_bytes).await?;
     Ok(Json(ReplayResponse {
         id,
         bytes_b64: base64::engine::general_purpose::STANDARD.encode(bytes),
+        truncated,
     }))
 }
 
@@ -943,13 +957,14 @@ impl TranscriptStore {
         Ok(())
     }
 
-    async fn replay(&self, id: &str) -> Result<Vec<u8>> {
+    async fn replay(&self, id: &str, max_bytes: usize) -> Result<(Vec<u8>, bool)> {
         let path = self.path(id);
         if !Path::new(&path).exists() {
             return Err(Error::NotFound);
         }
         let text = tokio::fs::read_to_string(path).await?;
         let mut out = Vec::new();
+        let mut truncated = false;
         for line in text.lines().filter(|l| !l.trim().is_empty()) {
             let plain = self.decrypt_line(line)?;
             let record: TranscriptRecord =
@@ -959,9 +974,14 @@ impl TranscriptStore {
                     .decode(record.data_b64)
                     .map_err(|e| Error::Internal(e.to_string()))?;
                 out.extend_from_slice(&bytes);
+                if out.len() > max_bytes {
+                    let drop_len = out.len() - max_bytes;
+                    out.drain(..drop_len);
+                    truncated = true;
+                }
             }
         }
-        Ok(out)
+        Ok((out, truncated))
     }
 
     fn path(&self, id: &str) -> PathBuf {

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -115,9 +115,6 @@ pub async fn run() -> Result<()> {
     let app = Router::new()
         .route("/", get(index))
         .route("/favicon.ico", get(favicon))
-        .route("/manifest.webmanifest", get(manifest))
-        .route("/sw.js", get(service_worker))
-        .route("/icon.svg", get(icon_svg))
         .route("/assets/xterm/xterm.css", get(xterm_css))
         .route("/assets/xterm/xterm.js", get(xterm_js))
         .route("/assets/xterm/addon-fit.js", get(xterm_fit_js))
@@ -174,82 +171,6 @@ async fn index(State(app): State<App>, headers: HeaderMap, uri: Uri) -> Response
 
 async fn favicon() -> StatusCode {
     StatusCode::NO_CONTENT
-}
-
-async fn manifest() -> impl IntoResponse {
-    (
-        [
-            ("content-type", "application/manifest+json; charset=utf-8"),
-            ("cache-control", "no-cache"),
-        ],
-        r##"{
-  "name": "DD Shell",
-  "short_name": "DD Shell",
-  "description": "DevOps Defender confidential shell",
-  "start_url": "/",
-  "scope": "/",
-  "display": "standalone",
-  "background_color": "#05070a",
-  "theme_color": "#111520",
-  "icons": [
-    {"src": "/icon.svg", "sizes": "any", "type": "image/svg+xml", "purpose": "any maskable"}
-  ]
-}"##,
-    )
-}
-
-async fn service_worker() -> impl IntoResponse {
-    (
-        [
-            ("content-type", "application/javascript; charset=utf-8"),
-            ("cache-control", "no-cache"),
-        ],
-        r#"self.addEventListener("install", event => {
-  event.waitUntil(self.skipWaiting());
-});
-self.addEventListener("activate", event => {
-  event.waitUntil(self.clients.claim());
-});
-self.addEventListener("notificationclick", event => {
-  event.notification.close();
-  event.waitUntil((async () => {
-    const allClients = await self.clients.matchAll({type: "window", includeUncontrolled: true});
-    if (allClients.length) {
-      await allClients[0].focus();
-      return;
-    }
-    await self.clients.openWindow("/");
-  })());
-});
-self.addEventListener("message", event => {
-  const data = event.data || {};
-  if (data.type !== "notify") return;
-  const title = data.title || "DD Shell";
-  const body = data.body || "";
-  event.waitUntil(self.registration.showNotification(title, {
-    body,
-    tag: data.tag || "dd-shell",
-    renotify: true,
-    icon: "/icon.svg",
-    badge: "/icon.svg"
-  }));
-});
-"#,
-    )
-}
-
-async fn icon_svg() -> impl IntoResponse {
-    (
-        [
-            ("content-type", "image/svg+xml; charset=utf-8"),
-            ("cache-control", "public, max-age=31536000, immutable"),
-        ],
-        r##"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
-  <rect width="128" height="128" rx="24" fill="#05070a"/>
-  <path fill="#7aa2f7" d="M25 28h37c25 0 42 14 42 36S87 100 62 100H25V28Zm20 18v36h17c14 0 22-7 22-18s-8-18-22-18H45Z"/>
-  <path fill="#9ece6a" d="M38 55h23v18H38z"/>
-</svg>"##,
-    )
 }
 
 async fn xterm_css() -> impl IntoResponse {
@@ -886,9 +807,6 @@ let promptRequests = loadPromptHistory();
 let promptScanBuffer = "";
 let lastPromptKey = "";
 const decoder = new TextDecoder();
-let serviceWorkerReady = null;
-installPwaMetadata();
-registerServiceWorker();
 
 async function api(path, opts) {
   const res = await fetch(path, opts);
@@ -1021,8 +939,7 @@ function notificationHtml() {
   const supported = "Notification" in window;
   const permission = supported ? Notification.permission : "unavailable";
   const enabled = supported && permission === "granted" && notifyMode !== "off";
-  const sw = "serviceWorker" in navigator ? "service worker ready" : "service worker unavailable";
-  const detail = supported ? `native ${permission}; ${sw}; in-app history on` : `in-app history on; native unavailable; ${sw}`;
+  const detail = supported ? `native ${permission}; in-app history on` : "in-app history on; native unavailable";
   return `<div class="probe"><div class="row"><span class="name">Notifications</span><span class="pill ${enabled ? "ok" : "bad"}">${enabled ? "native" : "in-app"}</span></div><div class="meta">${escapeHtml(detail)}</div></div>`;
 }
 
@@ -1173,7 +1090,6 @@ document.getElementById("close").onclick = async () => {
   await refresh();
 };
 document.getElementById("notify").onclick = async () => {
-  await registerServiceWorker();
   if (!("Notification" in window)) {
     document.getElementById("status").textContent = "Notifications unavailable";
     return;
@@ -1445,38 +1361,14 @@ function notify(title, body) {
   showToast(item);
   deliverNativeNotification(item);
 }
-function registerServiceWorker() {
-  if (!("serviceWorker" in navigator) || !window.isSecureContext) return Promise.resolve(null);
-  if (!serviceWorkerReady) {
-    serviceWorkerReady = navigator.serviceWorker.register("/sw.js")
-      .then(() => navigator.serviceWorker.ready)
-      .catch(() => null);
-  }
-  return serviceWorkerReady;
-}
 async function deliverNativeNotification(item) {
   if (!("Notification" in window) || Notification.permission !== "granted") return;
   if (notifyMode !== "always" && document.hasFocus()) return;
   const title = item.title || "DD Shell";
   const body = item.body || "";
   const tag = current ? `dd-shell-${current}` : "dd-shell";
-  const registration = await registerServiceWorker();
-  if (registration && "showNotification" in registration) {
-    await registration.showNotification(title, {body, tag, renotify: true, icon: "/icon.svg", badge: "/icon.svg"});
-    return;
-  }
   const n = new Notification(title, {body, tag});
   n.onclick = () => { window.focus(); term.focus(); n.close(); };
-}
-function installPwaMetadata() {
-  const manifest = document.createElement("link");
-  manifest.rel = "manifest";
-  manifest.href = "/manifest.webmanifest";
-  document.head.appendChild(manifest);
-  const theme = document.createElement("meta");
-  theme.name = "theme-color";
-  theme.content = "#111520";
-  document.head.appendChild(theme);
 }
 function loadNotificationHistory() {
   try {

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -2,17 +2,10 @@
 //!
 //! One process per VM, multiple reconnectable PTY sessions, read-only workload
 //! terminals, and encrypted append-only transcripts on disk.
-#![allow(dead_code, unused_imports)]
 
-use std::cmp::Reverse;
-use std::collections::{HashMap, VecDeque};
-use std::fs::File as StdFile;
-use std::os::fd::{AsRawFd, FromRawFd};
-use std::os::unix::fs::PermissionsExt;
-use std::path::{Path, PathBuf};
-use std::process::Stdio;
+use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::Duration;
 
 use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
 use axum::extract::{Path as AxPath, Query, State};
@@ -21,20 +14,11 @@ use axum::response::{Html, IntoResponse, Response};
 use axum::routing::{get, post};
 use axum::{Json, Router};
 use base64::Engine as _;
-use chacha20poly1305::aead::{Aead, KeyInit};
-use chacha20poly1305::{ChaCha20Poly1305, Key, Nonce};
 use futures_util::{SinkExt, StreamExt};
-use rand::RngCore;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
-use tokio::fs::File as TokioFile;
-use tokio::fs::OpenOptions;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
-use tokio::process::{Child, Command};
-use tokio::sync::{broadcast, Mutex, RwLock};
-use uuid::Uuid;
 
 use crate::ee::Ee;
 use crate::error::{Error, Result};
@@ -44,104 +28,9 @@ use crate::taint::IntegrityState;
 use crate::units::{self, AgentMode, ManagedUnit, UnitKind};
 
 const DEFAULT_PORT: u16 = 7681;
-const DEFAULT_DIR: &str = "/var/lib/devopsdefender/shell";
-const RING_LIMIT: usize = 256 * 1024;
-const CODEX_PODMAN_RECIPE: &str = r#"#!/var/lib/easyenclave/bin/busybox sh
-set -eu
-BB=/var/lib/easyenclave/bin/busybox
-BIN=/var/lib/easyenclave/bin
-PODMAN=$BIN/podman
-SESSION_ID=${DD_SESSION_ID:-manual-$$}
-SESSION_DIR=${DD_SESSION_DIR:-/var/lib/easyenclave/data/dd-shell/sessions/$SESSION_ID}
-WORKSPACE=${DD_WORKSPACE:-$SESSION_DIR/workspace}
-HOME_DIR=${DD_HOME:-$SESSION_DIR/home}
-CACHE_DIR=${DD_CACHE:-$SESSION_DIR/cache}
-TMP_DIR=${TMPDIR:-$SESSION_DIR/tmp}
-until [ -x "$PODMAN" ]; do echo "codex-podman: waiting for podman"; $BB sleep 2; done
-$BB mkdir -p "$HOME_DIR" "$WORKSPACE" "$CACHE_DIR" "$TMP_DIR"
-$BB chmod 1777 "$TMP_DIR"
-SAFE_SESSION=$(printf '%s' "$SESSION_ID" | $BB tr -c 'A-Za-z0-9_.-' '-')
-exec "$PODMAN" run --rm --replace -it --pull=missing \
-  --cgroups=disabled \
-  --network=host \
-  --name "codex-shell-$SAFE_SESSION" \
-  -e HOME=/root \
-  -e TERM=xterm-256color \
-  -e COLORTERM=truecolor \
-  -e NPM_CONFIG_PREFIX=/root/.npm-global \
-  -v "$HOME_DIR:/root" \
-  -v "$WORKSPACE:/workspace" \
-  -v "$CACHE_DIR:/root/.cache" \
-  -v "$TMP_DIR:/tmp" \
-  -w /workspace \
-  docker.io/library/node:22-bookworm \
-  sh -lc 'set -e; mkdir -p "$HOME/.npm-global/bin" "$HOME/.local/bin"; printf "%s\n" "export NPM_CONFIG_PREFIX=\${NPM_CONFIG_PREFIX:-\$HOME/.npm-global}" "export PATH=\"\$HOME/.npm-global/bin:\$HOME/.local/bin:\$PATH\"" > "$HOME/.bashrc"; printf "%s\n" "[ -r \"\$HOME/.bashrc\" ] && . \"\$HOME/.bashrc\"" > "$HOME/.bash_profile"; export PATH="$HOME/.npm-global/bin:$HOME/.local/bin:$PATH"; if ! command -v codex >/dev/null 2>&1; then npm install -g @openai/codex; fi; exec bash -l'
-"#;
-const PODMAN_UBUNTU_RECIPE: &str = r#"#!/var/lib/easyenclave/bin/busybox sh
-set -eu
-BB=/var/lib/easyenclave/bin/busybox
-BIN=/var/lib/easyenclave/bin
-PODMAN=$BIN/podman
-SESSION_ID=${DD_SESSION_ID:-manual-$$}
-SESSION_DIR=${DD_SESSION_DIR:-/var/lib/easyenclave/data/dd-shell/sessions/$SESSION_ID}
-WORKSPACE=${DD_WORKSPACE:-$SESSION_DIR/workspace}
-HOME_DIR=${DD_HOME:-$SESSION_DIR/home}
-CACHE_DIR=${DD_CACHE:-$SESSION_DIR/cache}
-TMP_DIR=${TMPDIR:-$SESSION_DIR/tmp}
-until [ -x "$PODMAN" ]; do echo "podman-ubuntu: waiting for podman"; $BB sleep 2; done
-$BB mkdir -p "$HOME_DIR" "$WORKSPACE" "$CACHE_DIR" "$TMP_DIR"
-$BB chmod 1777 "$TMP_DIR"
-SAFE_SESSION=$(printf '%s' "$SESSION_ID" | $BB tr -c 'A-Za-z0-9_.-' '-')
-exec "$PODMAN" run --rm --replace -it --pull=missing \
-  --cgroups=disabled \
-  --network=host \
-  --name "ubuntu-shell-$SAFE_SESSION" \
-  -e HOME=/root \
-  -e TERM=xterm-256color \
-  -e COLORTERM=truecolor \
-  -v "$HOME_DIR:/root" \
-  -v "$WORKSPACE:/workspace" \
-  -v "$CACHE_DIR:/root/.cache" \
-  -v "$TMP_DIR:/tmp" \
-  -w /workspace \
-  docker.io/library/ubuntu:24.04 \
-  bash -l
-"#;
-const PODMAN_ALPINE_RECIPE: &str = r#"#!/var/lib/easyenclave/bin/busybox sh
-set -eu
-BB=/var/lib/easyenclave/bin/busybox
-BIN=/var/lib/easyenclave/bin
-PODMAN=$BIN/podman
-SESSION_ID=${DD_SESSION_ID:-manual-$$}
-SESSION_DIR=${DD_SESSION_DIR:-/var/lib/easyenclave/data/dd-shell/sessions/$SESSION_ID}
-WORKSPACE=${DD_WORKSPACE:-$SESSION_DIR/workspace}
-HOME_DIR=${DD_HOME:-$SESSION_DIR/home}
-CACHE_DIR=${DD_CACHE:-$SESSION_DIR/cache}
-TMP_DIR=${TMPDIR:-$SESSION_DIR/tmp}
-until [ -x "$PODMAN" ]; do echo "podman-alpine: waiting for podman"; $BB sleep 2; done
-$BB mkdir -p "$HOME_DIR" "$WORKSPACE" "$CACHE_DIR" "$TMP_DIR"
-$BB chmod 1777 "$TMP_DIR"
-SAFE_SESSION=$(printf '%s' "$SESSION_ID" | $BB tr -c 'A-Za-z0-9_.-' '-')
-exec "$PODMAN" run --rm --replace -it --pull=missing \
-  --cgroups=disabled \
-  --network=host \
-  --name "alpine-shell-$SAFE_SESSION" \
-  -e HOME=/root \
-  -e TERM=xterm-256color \
-  -e COLORTERM=truecolor \
-  -v "$HOME_DIR:/root" \
-  -v "$WORKSPACE:/workspace" \
-  -v "$CACHE_DIR:/root/.cache" \
-  -v "$TMP_DIR:/tmp" \
-  -w /workspace \
-  docker.io/library/alpine:3.20 \
-  /bin/sh
-"#;
 
 #[derive(Clone)]
 struct App {
-    sessions: Arc<RwLock<HashMap<String, Arc<Session>>>>,
-    store: TranscriptStore,
     ee: Arc<Ee>,
     http: reqwest::Client,
     agent_api: String,
@@ -150,75 +39,6 @@ struct App {
     owner: crate::gh_oidc::Principal,
     auth: crate::auth::AuthConfig,
     hostname: String,
-    recipes: Arc<Vec<Recipe>>,
-    scratch_root: PathBuf,
-}
-
-struct Session {
-    meta: RwLock<SessionMeta>,
-    input: Mutex<TokioFile>,
-    master_fd: i32,
-    child: Mutex<Child>,
-    pgid: i32,
-    tx: broadcast::Sender<Vec<u8>>,
-    ring: Mutex<VecDeque<u8>>,
-    scratch_dir: Option<PathBuf>,
-    cleanup_scratch_on_exit: bool,
-}
-
-#[derive(Clone, Serialize)]
-struct SessionMeta {
-    id: String,
-    name: String,
-    recipe_id: String,
-    recipe_title: String,
-    workspace_policy: WorkspacePolicy,
-    command: String,
-    cwd: String,
-    terminal_mode: TerminalMode,
-    integrity_state: IntegrityState,
-    integrity_reason: &'static str,
-    created_at: i64,
-    updated_at: i64,
-    status: SessionStatus,
-    exit_code: Option<i32>,
-}
-
-#[derive(Clone, Serialize)]
-#[serde(rename_all = "snake_case")]
-enum TerminalMode {
-    ReadWrite,
-}
-
-#[derive(Clone, Serialize)]
-#[serde(rename_all = "snake_case")]
-enum SessionStatus {
-    Running,
-    Exited,
-}
-
-#[derive(Clone, Serialize)]
-struct Recipe {
-    id: String,
-    title: String,
-    description: String,
-    command: String,
-    cwd: String,
-    workspace_policy: WorkspacePolicy,
-}
-
-struct RecipeSeed {
-    id: &'static str,
-    title: &'static str,
-    description: &'static str,
-    script_name: &'static str,
-    script: &'static str,
-}
-
-#[derive(Clone, Serialize)]
-#[serde(rename_all = "snake_case")]
-enum WorkspacePolicy {
-    EphemeralScratch,
 }
 
 #[derive(Deserialize, Serialize)]
@@ -229,28 +49,10 @@ struct CreateSession {
     cwd: Option<String>,
 }
 
-#[derive(Serialize)]
-struct CreateSessionResponse {
-    id: String,
-}
-
 #[derive(Deserialize, Serialize)]
 struct ResizeSession {
     cols: u16,
     rows: u16,
-}
-
-#[derive(Clone)]
-struct TranscriptStore {
-    dir: PathBuf,
-    key: [u8; 32],
-}
-
-#[derive(Serialize, Deserialize)]
-struct TranscriptRecord {
-    ts: i64,
-    kind: String,
-    data_b64: String,
 }
 
 #[derive(Serialize)]
@@ -286,11 +88,6 @@ pub async fn run() -> Result<()> {
         .ok()
         .and_then(|s| s.parse::<u16>().ok())
         .unwrap_or(DEFAULT_PORT);
-    let dir = std::env::var("DD_SHELL_DIR").unwrap_or_else(|_| DEFAULT_DIR.into());
-    let requested_shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".into());
-    let scratch_root = std::env::var("DD_SHELL_SCRATCH_DIR")
-        .map(PathBuf::from)
-        .unwrap_or_else(|_| PathBuf::from(&dir).join("sessions"));
     let ee_socket = std::env::var("DD_SHELL_EE_SOCKET")
         .unwrap_or_else(|_| "/var/lib/easyenclave/agent.sock".into());
     let agent_api = std::env::var("DD_SHELL_AGENT_API_URL")
@@ -299,18 +96,8 @@ pub async fn run() -> Result<()> {
         std::env::var("DD_SESSIOND_HTTP_URL").unwrap_or_else(|_| "http://127.0.0.1:7683".into());
     let sessiond_attach_addr =
         std::env::var("DD_SESSIOND_ATTACH_ADDR").unwrap_or_else(|_| "127.0.0.1:7684".into());
-    let shell_dir = PathBuf::from(&dir);
-    let store = TranscriptStore::new(shell_dir.clone()).await?;
-    tokio::fs::create_dir_all(&scratch_root).await?;
-    set_private_dir_permissions(&scratch_root).await?;
-    let recipe_dir = shell_dir.join("recipes");
-    let default_shell = install_default_shell_command(&recipe_dir, &requested_shell).await?;
-    let recipe_scripts = install_builtin_recipe_scripts(&recipe_dir).await?;
-    let recipes = Arc::new(load_recipes(&default_shell, recipe_scripts));
 
     let app_state = App {
-        sessions: Arc::new(RwLock::new(HashMap::new())),
-        store,
         ee: Arc::new(Ee::new(ee_socket)),
         http: reqwest::Client::builder()
             .timeout(Duration::from_secs(3))
@@ -323,8 +110,6 @@ pub async fn run() -> Result<()> {
         owner: common.owner,
         auth,
         hostname,
-        recipes,
-        scratch_root,
     };
 
     let app = Router::new()
@@ -523,283 +308,6 @@ async fn create_session(
 ) -> Result<Json<crate::sessiond::CreateSessionResponse>> {
     ensure_shell_auth(&app, &headers, &uri)?;
     sessiond_post(&app, "/api/sessions", &req).await.map(Json)
-}
-
-fn select_recipe(app: &App, recipe_id: Option<&str>, command: Option<String>) -> Result<Recipe> {
-    if let Some(command) = command {
-        let command = command.trim();
-        if command.is_empty() {
-            return Err(Error::BadRequest("command must not be empty".into()));
-        }
-        return Ok(Recipe {
-            id: "custom".into(),
-            title: "Custom".into(),
-            description: "Custom command".into(),
-            command: command.into(),
-            cwd: "/".into(),
-            workspace_policy: WorkspacePolicy::EphemeralScratch,
-        });
-    }
-
-    let id = recipe_id.unwrap_or("shell");
-    app.recipes
-        .iter()
-        .find(|recipe| recipe.id == id)
-        .cloned()
-        .ok_or_else(|| Error::BadRequest(format!("unknown recipe: {id}")))
-}
-
-async fn install_default_shell_command(dir: &Path, requested_shell: &str) -> Result<String> {
-    if executable_exists(requested_shell).await {
-        return Ok(requested_shell.into());
-    }
-    if executable_exists("/bin/sh").await {
-        return Ok("/bin/sh".into());
-    }
-    if executable_exists("/var/lib/easyenclave/bin/busybox").await {
-        tokio::fs::create_dir_all(dir).await?;
-        set_private_dir_permissions(dir).await?;
-        let path = dir.join("plain-shell");
-        tokio::fs::write(
-            &path,
-            "#!/var/lib/easyenclave/bin/busybox sh\nexec /var/lib/easyenclave/bin/busybox sh\n",
-        )
-        .await?;
-        set_private_file_permissions(&path).await?;
-        return Ok(path.display().to_string());
-    }
-    Ok(requested_shell.into())
-}
-
-async fn executable_exists(path: &str) -> bool {
-    match tokio::fs::metadata(path).await {
-        Ok(meta) => meta.is_file() && meta.permissions().mode() & 0o111 != 0,
-        Err(_) => false,
-    }
-}
-
-async fn install_builtin_recipe_scripts(dir: &Path) -> Result<Vec<Recipe>> {
-    tokio::fs::create_dir_all(dir).await?;
-    set_private_dir_permissions(dir).await?;
-
-    let mut recipes = Vec::new();
-    for seed in builtin_recipe_seeds() {
-        let path = dir.join(seed.script_name);
-        tokio::fs::write(&path, seed.script).await?;
-        set_private_file_permissions(&path).await?;
-        recipes.push(Recipe {
-            id: seed.id.into(),
-            title: seed.title.into(),
-            description: seed.description.into(),
-            command: path.display().to_string(),
-            cwd: "/".into(),
-            workspace_policy: WorkspacePolicy::EphemeralScratch,
-        });
-    }
-    Ok(recipes)
-}
-
-fn load_recipes(default_shell: &str, mut builtin_recipes: Vec<Recipe>) -> Vec<Recipe> {
-    let mut recipes = vec![Recipe {
-        id: "shell".into(),
-        title: "Shell".into(),
-        description: "Plain interactive shell with encrypted transcript history".into(),
-        command: default_shell.into(),
-        cwd: "/".into(),
-        workspace_policy: WorkspacePolicy::EphemeralScratch,
-    }];
-    recipes.append(&mut builtin_recipes);
-
-    if let Ok(command) = std::env::var("DD_SHELL_CODEX_COMMAND") {
-        let command = command.trim();
-        if !command.is_empty() {
-            upsert_recipe(
-                &mut recipes,
-                Recipe {
-                    id: "codex-podman".into(),
-                    title: "Codex".into(),
-                    description: "Podman-backed Codex development session".into(),
-                    command: command.into(),
-                    cwd: "/".into(),
-                    workspace_policy: WorkspacePolicy::EphemeralScratch,
-                },
-            );
-        }
-    }
-
-    recipes
-}
-
-fn upsert_recipe(recipes: &mut Vec<Recipe>, recipe: Recipe) {
-    if let Some(existing) = recipes.iter_mut().find(|r| r.id == recipe.id) {
-        *existing = recipe;
-    } else {
-        recipes.push(recipe);
-    }
-}
-
-fn builtin_recipe_seeds() -> Vec<RecipeSeed> {
-    vec![
-        RecipeSeed {
-            id: "codex-podman",
-            title: "Codex",
-            description: "Podman-backed Codex development session",
-            script_name: "codex-podman",
-            script: CODEX_PODMAN_RECIPE,
-        },
-        RecipeSeed {
-            id: "podman-ubuntu",
-            title: "Ubuntu",
-            description: "Podman Ubuntu 24.04 shell",
-            script_name: "podman-ubuntu",
-            script: PODMAN_UBUNTU_RECIPE,
-        },
-        RecipeSeed {
-            id: "podman-alpine",
-            title: "Alpine",
-            description: "Podman Alpine shell",
-            script_name: "podman-alpine",
-            script: PODMAN_ALPINE_RECIPE,
-        },
-    ]
-}
-
-async fn prepare_scratch_dir(
-    app: &App,
-    id: &str,
-    policy: &WorkspacePolicy,
-) -> Result<Option<PathBuf>> {
-    match policy {
-        WorkspacePolicy::EphemeralScratch => {
-            let root = app.scratch_root.join(id);
-            tokio::fs::create_dir_all(&root).await?;
-            set_private_dir_permissions(&root).await?;
-            for name in ["workspace", "home", "containers", "cache", "tmp"] {
-                let path = root.join(name);
-                tokio::fs::create_dir_all(&path).await?;
-                set_private_dir_permissions(&path).await?;
-            }
-            Ok(Some(root))
-        }
-    }
-}
-
-async fn set_private_dir_permissions(path: &Path) -> Result<()> {
-    let permissions = std::fs::Permissions::from_mode(0o700);
-    tokio::fs::set_permissions(path, permissions).await?;
-    Ok(())
-}
-
-async fn set_private_file_permissions(path: &Path) -> Result<()> {
-    let permissions = std::fs::Permissions::from_mode(0o700);
-    tokio::fs::set_permissions(path, permissions).await?;
-    Ok(())
-}
-
-fn session_env(id: &str, scratch_dir: Option<&Path>) -> Vec<(String, String)> {
-    let mut env = vec![("DD_SESSION_ID".into(), id.into())];
-    if let Some(root) = scratch_dir {
-        env.push(("DD_SESSION_DIR".into(), root.display().to_string()));
-        env.push((
-            "DD_WORKSPACE".into(),
-            root.join("workspace").display().to_string(),
-        ));
-        env.push(("DD_HOME".into(), root.join("home").display().to_string()));
-        env.push((
-            "DD_CONTAINER_ROOT".into(),
-            root.join("containers").display().to_string(),
-        ));
-        env.push(("DD_CACHE".into(), root.join("cache").display().to_string()));
-        env.push(("TMPDIR".into(), root.join("tmp").display().to_string()));
-    }
-    env
-}
-
-fn session_name(recipe: &Recipe, id: &str) -> String {
-    format!("{}-{}", recipe.id, &id[..8])
-}
-
-fn spawn_pty(
-    command: &str,
-    cwd: &str,
-    env_vars: &[(String, String)],
-) -> Result<(Child, TokioFile, TokioFile, i32)> {
-    let mut master = -1;
-    let mut slave = -1;
-    let winsize = libc::winsize {
-        ws_row: 24,
-        ws_col: 80,
-        ws_xpixel: 0,
-        ws_ypixel: 0,
-    };
-    let open_rc = unsafe {
-        libc::openpty(
-            &mut master,
-            &mut slave,
-            std::ptr::null_mut(),
-            std::ptr::null(),
-            &winsize,
-        )
-    };
-    if open_rc != 0 {
-        return Err(Error::Internal(format!(
-            "openpty: {}",
-            std::io::Error::last_os_error()
-        )));
-    }
-
-    let master = unsafe { StdFile::from_raw_fd(master) };
-    let output = TokioFile::from_std(
-        master
-            .try_clone()
-            .map_err(|e| Error::Internal(format!("pty master clone: {e}")))?,
-    );
-    let input = TokioFile::from_std(master);
-    let slave = unsafe { StdFile::from_raw_fd(slave) };
-    let slave_fd = slave.as_raw_fd();
-
-    let dup_slave = || -> std::io::Result<StdFile> {
-        let fd = unsafe { libc::dup(slave_fd) };
-        if fd < 0 {
-            Err(std::io::Error::last_os_error())
-        } else {
-            Ok(unsafe { StdFile::from_raw_fd(fd) })
-        }
-    };
-
-    let mut cmd = Command::new(command);
-    cmd.current_dir(cwd)
-        .env("TERM", "xterm-256color")
-        .env("COLORTERM", "truecolor")
-        .stdin(Stdio::from(
-            dup_slave().map_err(|e| Error::Internal(format!("pty stdin dup: {e}")))?,
-        ))
-        .stdout(Stdio::from(
-            dup_slave().map_err(|e| Error::Internal(format!("pty stdout dup: {e}")))?,
-        ))
-        .stderr(Stdio::from(
-            dup_slave().map_err(|e| Error::Internal(format!("pty stderr dup: {e}")))?,
-        ));
-    for (key, value) in env_vars {
-        cmd.env(key, value);
-    }
-    unsafe {
-        cmd.pre_exec(move || {
-            if libc::setsid() < 0 {
-                return Err(std::io::Error::last_os_error());
-            }
-            if libc::ioctl(slave_fd, libc::TIOCSCTTY, 0) < 0 {
-                return Err(std::io::Error::last_os_error());
-            }
-            Ok(())
-        });
-    }
-    let child = cmd
-        .spawn()
-        .map_err(|e| Error::BadRequest(format!("spawn {command}: {e}")))?;
-    let pgid = child.id().map(|pid| pid as i32).unwrap_or_default();
-    drop(slave);
-    Ok((child, output, input, pgid))
 }
 
 async fn replay_session(
@@ -1092,31 +600,6 @@ async fn close_session(
     sessiond_post_empty(&app, &format!("/api/sessions/{id}/close")).await
 }
 
-fn terminate_process_group(id: String, pgid: i32) {
-    if pgid <= 0 {
-        return;
-    }
-    tokio::spawn(async move {
-        for (signal, delay) in [
-            (libc::SIGHUP, Duration::from_millis(250)),
-            (libc::SIGTERM, Duration::from_millis(1500)),
-            (libc::SIGKILL, Duration::ZERO),
-        ] {
-            let rc = unsafe { libc::kill(-pgid, signal) };
-            if rc != 0 {
-                let err = std::io::Error::last_os_error();
-                if err.raw_os_error() != Some(libc::ESRCH) {
-                    eprintln!("dd-shell: signal {signal} for {id}: {err}");
-                }
-                break;
-            }
-            if !delay.is_zero() {
-                tokio::time::sleep(delay).await;
-            }
-        }
-    });
-}
-
 fn workload_log_bytes(logs: &serde_json::Value) -> Vec<u8> {
     let mut out = Vec::new();
     if let Some(lines) = logs["lines"].as_array() {
@@ -1207,209 +690,6 @@ async fn attach(
     }
     output.abort();
     Ok(())
-}
-
-fn spawn_reader<R>(store: TranscriptStore, session: Arc<Session>, mut reader: R, kind: &'static str)
-where
-    R: tokio::io::AsyncRead + Unpin + Send + 'static,
-{
-    tokio::spawn(async move {
-        let id = session.meta.read().await.id.clone();
-        let mut buf = [0u8; 4096];
-        loop {
-            match reader.read(&mut buf).await {
-                Ok(0) => break,
-                Ok(n) => {
-                    let bytes = buf[..n].to_vec();
-                    push_ring(&session, &bytes).await;
-                    let _ = session.tx.send(bytes.clone());
-                    if let Err(e) = store.append_bytes(&id, kind, &bytes).await {
-                        eprintln!("dd-shell: transcript append failed: {e}");
-                    }
-                    session.meta.write().await.updated_at = unix_ts();
-                }
-                Err(e) => {
-                    eprintln!("dd-shell: {kind} read failed: {e}");
-                    break;
-                }
-            }
-        }
-    });
-}
-
-fn spawn_waiter(store: TranscriptStore, session: Arc<Session>) {
-    tokio::spawn(async move {
-        let status = {
-            let mut child = session.child.lock().await;
-            child.wait().await
-        };
-        mark_session_exited(&store, &session, status.ok().and_then(|s| s.code())).await;
-        cleanup_session_scratch(&session).await;
-    });
-}
-
-async fn mark_session_exited(store: &TranscriptStore, session: &Session, exit_code: Option<i32>) {
-    let mut meta = session.meta.write().await;
-    if matches!(meta.status, SessionStatus::Exited) {
-        return;
-    }
-    meta.updated_at = unix_ts();
-    meta.status = SessionStatus::Exited;
-    meta.exit_code = exit_code;
-    if let Err(e) = store.append_meta(&meta).await {
-        eprintln!("dd-shell: exit meta append failed: {e}");
-    }
-}
-
-async fn cleanup_session_scratch(session: &Session) {
-    if !session.cleanup_scratch_on_exit {
-        return;
-    }
-    let Some(path) = &session.scratch_dir else {
-        return;
-    };
-    match tokio::fs::remove_dir_all(path).await {
-        Ok(()) => {}
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-        Err(e) => eprintln!(
-            "dd-shell: scratch cleanup failed for {}: {e}",
-            path.display()
-        ),
-    }
-}
-
-async fn push_ring(session: &Session, bytes: &[u8]) {
-    let mut ring = session.ring.lock().await;
-    for b in bytes {
-        if ring.len() >= RING_LIMIT {
-            ring.pop_front();
-        }
-        ring.push_back(*b);
-    }
-}
-
-impl TranscriptStore {
-    async fn new(dir: PathBuf) -> Result<Self> {
-        tokio::fs::create_dir_all(&dir).await?;
-        let key = history_key(&dir).await?;
-        Ok(Self { dir, key })
-    }
-
-    async fn append_meta(&self, meta: &SessionMeta) -> Result<()> {
-        let bytes = serde_json::to_vec(meta).map_err(|e| Error::Internal(e.to_string()))?;
-        self.append_bytes(&meta.id, "meta", &bytes).await
-    }
-
-    async fn append_bytes(&self, id: &str, kind: &str, bytes: &[u8]) -> Result<()> {
-        let record = TranscriptRecord {
-            ts: unix_ts(),
-            kind: kind.to_string(),
-            data_b64: base64::engine::general_purpose::STANDARD.encode(bytes),
-        };
-        let plain = serde_json::to_vec(&record).map_err(|e| Error::Internal(e.to_string()))?;
-        let line = self.encrypt_line(&plain)?;
-        let path = self.path(id);
-        let mut f = OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(path)
-            .await?;
-        f.write_all(line.as_bytes()).await?;
-        f.write_all(b"\n").await?;
-        Ok(())
-    }
-
-    async fn replay(&self, id: &str) -> Result<Vec<u8>> {
-        let path = self.path(id);
-        if !Path::new(&path).exists() {
-            return Err(Error::NotFound);
-        }
-        let text = tokio::fs::read_to_string(path).await?;
-        let mut out = Vec::new();
-        for line in text.lines().filter(|l| !l.trim().is_empty()) {
-            let plain = self.decrypt_line(line)?;
-            let record: TranscriptRecord =
-                serde_json::from_slice(&plain).map_err(|e| Error::Internal(e.to_string()))?;
-            if record.kind == "pty" || record.kind == "stdout" || record.kind == "stderr" {
-                let bytes = base64::engine::general_purpose::STANDARD
-                    .decode(record.data_b64)
-                    .map_err(|e| Error::Internal(e.to_string()))?;
-                out.extend_from_slice(&bytes);
-            }
-        }
-        Ok(out)
-    }
-
-    fn path(&self, id: &str) -> PathBuf {
-        self.dir.join(format!("{id}.log.enc"))
-    }
-
-    fn encrypt_line(&self, plain: &[u8]) -> Result<String> {
-        let cipher = ChaCha20Poly1305::new(Key::from_slice(&self.key));
-        let mut nonce = [0u8; 12];
-        rand::thread_rng().fill_bytes(&mut nonce);
-        let ciphertext = cipher
-            .encrypt(Nonce::from_slice(&nonce), plain)
-            .map_err(|e| Error::Internal(format!("encrypt transcript: {e}")))?;
-        let mut packed = nonce.to_vec();
-        packed.extend_from_slice(&ciphertext);
-        Ok(base64::engine::general_purpose::STANDARD.encode(packed))
-    }
-
-    fn decrypt_line(&self, line: &str) -> Result<Vec<u8>> {
-        let packed = base64::engine::general_purpose::STANDARD
-            .decode(line)
-            .map_err(|e| Error::Internal(e.to_string()))?;
-        if packed.len() < 13 {
-            return Err(Error::Internal("truncated transcript record".into()));
-        }
-        let (nonce, ciphertext) = packed.split_at(12);
-        let cipher = ChaCha20Poly1305::new(Key::from_slice(&self.key));
-        cipher
-            .decrypt(Nonce::from_slice(nonce), ciphertext)
-            .map_err(|e| Error::Internal(format!("decrypt transcript: {e}")))
-    }
-}
-
-async fn history_key(dir: &Path) -> Result<[u8; 32]> {
-    if let Ok(raw) = std::env::var("DD_SHELL_HISTORY_KEY") {
-        let bytes = base64::engine::general_purpose::STANDARD
-            .decode(raw.trim())
-            .or_else(|_| hex::decode(raw.trim()))
-            .map_err(|_| Error::BadRequest("DD_SHELL_HISTORY_KEY must be base64 or hex".into()))?;
-        if bytes.len() != 32 {
-            return Err(Error::BadRequest(
-                "DD_SHELL_HISTORY_KEY must decode to 32 bytes".into(),
-            ));
-        }
-        let mut key = [0u8; 32];
-        key.copy_from_slice(&bytes);
-        return Ok(key);
-    }
-
-    let key_path = dir.join("history.key");
-    if let Ok(bytes) = tokio::fs::read(&key_path).await {
-        if bytes.len() == 32 {
-            let mut key = [0u8; 32];
-            key.copy_from_slice(&bytes);
-            return Ok(key);
-        }
-    }
-
-    let mut material = [0u8; 32];
-    rand::thread_rng().fill_bytes(&mut material);
-    tokio::fs::write(&key_path, material).await?;
-    let mut hasher = Sha256::new();
-    hasher.update(material);
-    hasher.update(b"dd-shell-history-v1");
-    Ok(hasher.finalize().into())
-}
-
-fn unix_ts() -> i64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or(Duration::ZERO)
-        .as_secs() as i64
 }
 
 const XTERM_CSS: &str = include_str!("../assets/xterm/xterm.css");

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -1462,6 +1462,14 @@ main { max-width:none; padding:0; height:100dvh; display:grid; grid-template-col
 .notify-item .notify-title { display:flex; align-items:center; justify-content:space-between; gap:8px; font-size:12px; font-weight:700; }
 .notify-item .notify-time { color:#8791a5; font-size:10px; font-weight:400; white-space:nowrap; }
 .notify-item .notify-body { margin-top:3px; color:#8791a5; font-size:11px; line-height:1.4; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+.prompt-feed { display:flex; flex-direction:column; gap:8px; margin:0 0 12px; }
+.prompt-card { background:#171c29; border:1px solid #7aa2f7; border-radius:7px; padding:10px; min-width:0; box-shadow:0 0 0 1px #1d3358 inset; }
+.prompt-card .prompt-head { display:flex; align-items:center; justify-content:space-between; gap:8px; font-size:12px; font-weight:800; }
+.prompt-card .prompt-meta { color:#8791a5; font-size:10px; white-space:nowrap; }
+.prompt-card .prompt-body { margin-top:6px; color:#d7deea; font-size:12px; line-height:1.45; overflow-wrap:anywhere; }
+.prompt-actions { display:flex; flex-wrap:wrap; gap:6px; margin-top:9px; }
+.prompt-actions button { flex:1 1 64px; min-width:0; padding:8px 9px; font-size:12px; }
+.prompt-actions button.dismiss { flex:0 0 auto; color:#8791a5; background:#171c29; border:1px solid #2b3242; }
 .notify-badge { display:none; min-width:18px; height:18px; border-radius:999px; background:#7aa2f7; color:#05070a; font-size:11px; font-weight:800; align-items:center; justify-content:center; padding:0 5px; }
 .notify-badge.active { display:inline-flex; }
 .toast-stack { position:fixed; top:60px; right:14px; z-index:50; display:flex; flex-direction:column; gap:8px; width:min(340px, calc(100vw - 28px)); pointer-events:none; }
@@ -1511,6 +1519,8 @@ button.secondary { background:#252a36; color:#d7deea; }
       <div class="panel active" data-panel="system">
         <div class="group-title">System</div>
         <div class="system" id="system"></div>
+        <div class="group-title">Prompt inbox</div>
+        <div class="prompt-feed" id="prompt-feed"></div>
         <div class="group-title">Notifications</div>
         <div class="notify-feed" id="notify-feed"></div>
       </div>
@@ -1592,6 +1602,9 @@ let cachedWorkloads = [];
 let activePanel = "system";
 let notifications = loadNotificationHistory();
 let unreadNotifications = 0;
+let promptRequests = loadPromptHistory();
+let promptScanBuffer = "";
+let lastPromptKey = "";
 const decoder = new TextDecoder();
 let serviceWorkerReady = null;
 installPwaMetadata();
@@ -1612,6 +1625,7 @@ async function refresh() {
     api("/api/workloads").catch(() => [])
   ]);
   renderSystem(system);
+  renderPromptFeed();
   renderNotificationFeed();
   cachedRecipes = recipes;
   renderRecipes();
@@ -1803,11 +1817,11 @@ async function attach(id) {
   };
   ws.onmessage = ev => {
     if (typeof ev.data === "string") {
-      scanNotifications(ev.data);
+      scanTerminalOutput(ev.data);
       term.write(ev.data);
     } else {
       const bytes = new Uint8Array(ev.data);
-      scanNotifications(bytes);
+      scanTerminalOutput(bytes);
       term.write(bytes);
     }
   };
@@ -2001,6 +2015,10 @@ async function sendResize() {
     body: JSON.stringify({cols: term.cols, rows: term.rows})
   }).catch(() => {});
 }
+function scanTerminalOutput(data) {
+  const text = scanNotifications(data);
+  scanPromptRequests(text);
+}
 function scanNotifications(data) {
   const text = typeof data === "string" ? data : decoder.decode(data, {stream:true});
   oscBuffer += text;
@@ -2014,6 +2032,124 @@ function scanNotifications(data) {
   }
   if (consumed > 0) oscBuffer = oscBuffer.slice(consumed);
   if (oscBuffer.length > 8192) oscBuffer = oscBuffer.slice(-1024);
+  return text;
+}
+function scanPromptRequests(text) {
+  if (!text) return;
+  promptScanBuffer = stripAnsi(promptScanBuffer + text).replace(/\r/g, "\n");
+  if (promptScanBuffer.length > 12000) promptScanBuffer = promptScanBuffer.slice(-8000);
+  const lines = promptScanBuffer.split("\n").map(l => l.trim()).filter(Boolean);
+  const recent = lines.slice(-18);
+  const prompt = detectPrompt(recent);
+  if (!prompt) return;
+  const key = `${current || "none"}:${prompt.kind}:${prompt.body}:${prompt.actions.map(a => a.input).join("|")}`;
+  if (key === lastPromptKey || promptRequests.some(p => p.key === key)) return;
+  lastPromptKey = key;
+  const item = {
+    id: `${Date.now()}-${Math.random().toString(16).slice(2)}`,
+    key,
+    sessionId: current,
+    title: prompt.title,
+    body: prompt.body,
+    actions: prompt.actions,
+    ts: Date.now()
+  };
+  promptRequests.unshift(item);
+  promptRequests = promptRequests.slice(0, 20);
+  savePromptHistory();
+  renderPromptFeed();
+  notify("Codex needs input", prompt.body);
+}
+function detectPrompt(lines) {
+  const windowText = lines.join("\n");
+  if (!/\?|select|choose|enter|approve|allow|continue|proceed|permission|confirmation/i.test(windowText)) return null;
+  const numbered = [];
+  for (const line of lines.slice(-12)) {
+    const m = line.match(/^(?:\[?([1-9])\]?[\).:]?|([1-9])\s+[-:])\s+(.{1,90})$/);
+    if (!m) continue;
+    const n = m[1] || m[2];
+    const label = `${n}: ${(m[3] || "").trim()}`.slice(0, 44);
+    if (!numbered.some(a => a.input === `${n}\n`)) numbered.push({label, input:`${n}\n`});
+  }
+  if (numbered.length >= 2 && numbered.length <= 6) {
+    return {
+      kind: "numbered",
+      title: "Input requested",
+      body: summarizePrompt(lines),
+      actions: numbered
+    };
+  }
+  const yn = windowText.match(/\((?:y\/n|Y\/n|y\/N)\)|\[(?:y\/n|Y\/n|y\/N)\]/);
+  if (yn) {
+    return {
+      kind: "yesno",
+      title: "Confirmation requested",
+      body: summarizePrompt(lines),
+      actions: [{label:"Yes", input:"y\n"}, {label:"No", input:"n\n"}]
+    };
+  }
+  if (/press enter|enter for no changes|hit enter/i.test(windowText)) {
+    return {
+      kind: "enter",
+      title: "Continue requested",
+      body: summarizePrompt(lines),
+      actions: [{label:"Enter", input:"\n"}]
+    };
+  }
+  return null;
+}
+function summarizePrompt(lines) {
+  const useful = lines.slice(-8).filter(l => !/^[\s\-\|]+$/.test(l));
+  return useful.join(" ").replace(/\s+/g, " ").slice(0, 220);
+}
+function renderPromptFeed() {
+  const root = document.getElementById("prompt-feed");
+  if (!root) return;
+  const pending = promptRequests.filter(p => !p.dismissed).slice(0, 8);
+  if (!pending.length) {
+    root.innerHTML = `<div class="empty-mini">No pending prompts</div>`;
+    return;
+  }
+  root.innerHTML = pending.map(p => `
+    <div class="prompt-card">
+      <div class="prompt-head"><span>${escapeHtml(p.title || "Input requested")}</span><span class="prompt-meta">${escapeHtml(formatClock(p.ts))}</span></div>
+      <div class="prompt-body">${escapeHtml(p.body || "")}</div>
+      <div class="prompt-actions">
+        ${(p.actions || []).map((a, i) => `<button class="secondary" data-prompt="${escapeHtml(p.id)}" data-action="${i}">${escapeHtml(a.label || "Send")}</button>`).join("")}
+        <button class="dismiss" data-dismiss-prompt="${escapeHtml(p.id)}">Dismiss</button>
+      </div>
+    </div>
+  `).join("");
+  root.querySelectorAll("button[data-action]").forEach(btn => {
+    btn.onclick = () => sendPromptInput(btn.dataset.prompt, Number(btn.dataset.action));
+  });
+  root.querySelectorAll("button[data-dismiss-prompt]").forEach(btn => {
+    btn.onclick = () => dismissPrompt(btn.dataset.dismissPrompt);
+  });
+}
+function sendPromptInput(id, actionIndex) {
+  if (currentKind !== "session" || !ws || ws.readyState !== WebSocket.OPEN) {
+    document.getElementById("status").textContent = "Attach session before sending prompt input";
+    return;
+  }
+  const prompt = promptRequests.find(p => p.id === id);
+  const action = prompt && Array.isArray(prompt.actions) ? prompt.actions[actionIndex] : null;
+  if (!action) return;
+  const input = action.input || "";
+  ws.send(input || "");
+  dismissPrompt(id);
+  document.getElementById("status").textContent = "Prompt input sent";
+}
+function dismissPrompt(id) {
+  const prompt = promptRequests.find(p => p.id === id);
+  if (prompt) prompt.dismissed = true;
+  savePromptHistory();
+  renderPromptFeed();
+}
+function stripAnsi(value) {
+  return value
+    .replace(/\x1b\][^\x07]*(?:\x07|\x1b\\)/g, "")
+    .replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, "");
 }
 function notify(title, body) {
   const item = {
@@ -2072,6 +2208,17 @@ function loadNotificationHistory() {
 }
 function saveNotificationHistory() {
   localStorage.setItem("dd-shell-notifications", JSON.stringify(notifications.slice(0, 50)));
+}
+function loadPromptHistory() {
+  try {
+    const parsed = JSON.parse(localStorage.getItem("dd-shell-prompts") || "[]");
+    return Array.isArray(parsed) ? parsed.slice(0, 20) : [];
+  } catch (_) {
+    return [];
+  }
+}
+function savePromptHistory() {
+  localStorage.setItem("dd-shell-prompts", JSON.stringify(promptRequests.slice(0, 20)));
 }
 function showToast(item) {
   const stack = document.getElementById("toast-stack");


### PR DESCRIPTION
## Summary
- cap session replay responses to 48 KiB so Noise replies stay under frame limits
- forward optional max_bytes from shell.replay_session through the Noise gateway
- return a truncated flag when replay history is clipped

## Validation
- cargo fmt
- git diff --check
- cargo check currently fails on this Mac due existing macOS PTY openpty/ioctl type errors in src/sessiond.rs, unrelated to this replay change