### PR TITLE
Bound session replay responses

### DIFF
--- a/src/noise_gateway/upstream.rs
+++ b/src/noise_gateway/upstream.rs
@@ -126,7 +126,12 @@ impl Sessiond {
             "shell.create_session" => self.post_json("/api/sessions", &session_body(req)).await,
             "shell.replay_session" => {
                 let id = required_str(&req, "id")?;
-                self.get_json(&format!("/api/sessions/{id}/replay")).await
+                let path = if let Some(max_bytes) = req.get("max_bytes").and_then(|v| v.as_u64()) {
+                    format!("/api/sessions/{id}/replay?max_bytes={max_bytes}")
+                } else {
+                    format!("/api/sessions/{id}/replay")
+                };
+                self.get_json(&path).await
             }
             "shell.resize_session" => {
                 let id = required_str(&req, "id")?;

--- a/src/sessiond.rs
+++ b/src/sessiond.rs
@@ -14,7 +14,7 @@ use std::process::Stdio;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use axum::extract::{Path as AxPath, State};
+use axum::extract::{Path as AxPath, Query, State};
 use axum::http::StatusCode;
 use axum::routing::{get, post};
 use axum::{Json, Router};
@@ -41,6 +41,8 @@ const DEFAULT_DIR: &str = "/var/lib/devopsdefender/sessiond";
 const EE_DATA_MOUNT: &str = "/var/lib/easyenclave/data";
 const DATA_MOUNT_WAIT_SECS: u64 = 60;
 const RING_LIMIT: usize = 256 * 1024;
+const DEFAULT_REPLAY_MAX_BYTES: usize = 32 * 1024;
+const ABSOLUTE_REPLAY_MAX_BYTES: usize = 32 * 1024;
 
 const CODEX_PODMAN_RECIPE: &str = r#"#!/var/lib/easyenclave/bin/busybox sh
 set -eu
@@ -226,6 +228,12 @@ pub struct ResizeSession {
 pub struct ReplayResponse {
     pub id: String,
     pub bytes_b64: String,
+    pub truncated: bool,
+}
+
+#[derive(Deserialize)]
+struct ReplayQuery {
+    max_bytes: Option<usize>,
 }
 
 struct RecipeSeed {
@@ -413,11 +421,17 @@ async fn create_session(
 async fn replay_session(
     State(app): State<App>,
     AxPath(id): AxPath<String>,
+    Query(query): Query<ReplayQuery>,
 ) -> Result<Json<ReplayResponse>> {
-    let bytes = app.store.replay(&id).await?;
+    let max_bytes = query
+        .max_bytes
+        .unwrap_or(DEFAULT_REPLAY_MAX_BYTES)
+        .min(ABSOLUTE_REPLAY_MAX_BYTES);
+    let (bytes, truncated) = app.store.replay(&id, max_bytes).await?;
     Ok(Json(ReplayResponse {
         id,
         bytes_b64: base64::engine::general_purpose::STANDARD.encode(bytes),
+        truncated,
     }))
 }
 
@@ -943,13 +957,14 @@ impl TranscriptStore {
         Ok(())
     }
 
-    async fn replay(&self, id: &str) -> Result<Vec<u8>> {
+    async fn replay(&self, id: &str, max_bytes: usize) -> Result<(Vec<u8>, bool)> {
         let path = self.path(id);
         if !Path::new(&path).exists() {
             return Err(Error::NotFound);
         }
         let text = tokio::fs::read_to_string(path).await?;
         let mut out = Vec::new();
+        let mut truncated = false;
         for line in text.lines().filter(|l| !l.trim().is_empty()) {
             let plain = self.decrypt_line(line)?;
             let record: TranscriptRecord =
@@ -959,9 +974,14 @@ impl TranscriptStore {
                     .decode(record.data_b64)
                     .map_err(|e| Error::Internal(e.to_string()))?;
                 out.extend_from_slice(&bytes);
+                if out.len() > max_bytes {
+                    let drop_len = out.len() - max_bytes;
+                    out.drain(..drop_len);
+                    truncated = true;
+                }
             }
         }
-        Ok(out)
+        Ok((out, truncated))
     }
 
     fn path(&self, id: &str) -> PathBuf {


### PR DESCRIPTION
## Summary
- cap session replay history to 32 KiB so the base64 JSON reply stays under the Noise transport frame limit
- forward optional max_bytes from shell.replay_session through the Noise gateway
- return a truncated flag when replay history is clipped

## Validation
- cargo fmt
- git diff --check
- cargo check currently fails on this Mac due existing macOS PTY openpty/ioctl type errors in src/sessiond.rs, unrelated to this replay change