### PR TITLE
Remove STONITH eviction + self-watchdog (keep poweroff)

### DIFF
--- a/src/cp.rs
+++ b/src/cp.rs
@@ -166,26 +166,11 @@ pub async fn run() -> Result<()> {
 
     spawn_cloudflared(tunnel.token.clone());
 
-    {
-        let http = http.clone();
-        let cf = cfg.cf.clone();
-        let id = tunnel.id.clone();
-        let env = cfg.common.env_label.clone();
-        tokio::spawn(async move {
-            tokio::time::sleep(Duration::from_secs(5)).await;
-            stonith::kill_old_tunnels(&http, &cf, &id, &env).await;
-        });
-    }
-
-    // Graceful shutdown signal. The watchdog triggers it when the
-    // tunnel's been reaped by a successor CP; axum::serve below
-    // awaits it and drains in-flight connections before exiting.
-    let (shutdown_tx, mut shutdown_rx) = tokio::sync::broadcast::channel::<()>(1);
-    tokio::spawn(stonith::self_watchdog(
-        cfg.cf.clone(),
-        tunnel.id.clone(),
-        shutdown_tx.clone(),
-    ));
+    // STONITH (new-CP-evicts-old: tunnel-delete + a self-watchdog that
+    // powered the old CP off when its tunnel vanished) was removed — it
+    // churned the Cloudflare tunnel hand-off, and the SSH/prod relaunch
+    // already destroys the old CP VM before booting this one. We just
+    // create our tunnel, flip the CNAME (in `cf::create`), and serve.
 
     // Stage 4: delete legacy Cloudflare Access apps for our published
     // hosts/paths. DD owns browser and machine auth in-code; Cloudflare
@@ -357,10 +342,6 @@ pub async fn run() -> Result<()> {
         listener,
         app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
     )
-    .with_graceful_shutdown(async move {
-        let _ = shutdown_rx.recv().await;
-        eprintln!("cp: graceful shutdown signaled; draining in-flight requests");
-    })
     .await
     .map_err(|e| Error::Internal(e.to_string()))
 }

--- a/src/stonith.rs
+++ b/src/stonith.rs
@@ -1,26 +1,13 @@
-//! STONITH: kill old CP VMs so the new one owns `$DD_HOSTNAME`.
+//! Poweroff helper for fatal CP boot failures.
 //!
-//!   1. **Tunnel-delete STONITH at startup** — list CF tunnels, find
-//!      CP tunnels (name starts with `dd-{env}-cp-`) that aren't ours,
-//!      delete them. Their cloudflared exits; their watchdog picks up
-//!      tunnel-gone and `poweroff`s within ~30 s.
-//!   2. **Self-watchdog** — poll CF every 8–12 s for our own tunnel.
-//!      Three consecutive gone readings → poweroff. Catches the case
-//!      where we *are* the old CP being killed.
-
-use std::time::Duration;
-
-use rand::Rng;
-use reqwest::Client;
-
-use crate::cf;
-use crate::config::CfCreds;
-
-const POLL_BASE_SECS: u64 = 10;
-const POLL_JITTER_SECS: u64 = 4;
-const INITIAL_MIN_SECS: u64 = 10;
-const INITIAL_MAX_SECS: u64 = 25;
-const CONSECUTIVE_GONE: u32 = 3;
+//! STONITH proper — the new-CP-evicts-old-CP fencing (delete the old
+//! CP's tunnel by name prefix, plus a self-watchdog that powered the old
+//! CP off once it saw its own tunnel vanish) — has been removed for now.
+//! It churned the Cloudflare tunnel hand-off (the 502 flap during
+//! cutover), and on the SSH/prod path the relaunch already destroys the
+//! old CP VM before booting the new one, so the fencing was redundant
+//! there. What remains is `poweroff`, used by `cp::run` to halt the VM
+//! on unrecoverable boot errors.
 
 /// Poweroff via reboot(2). Bypasses busybox's PID-1-is-systemd
 /// assumption. Requires CAP_SYS_BOOT (we're root). Linux-only; on
@@ -39,87 +26,4 @@ pub fn poweroff() -> ! {
 pub fn poweroff() -> ! {
     eprintln!("stonith: poweroff called on non-linux target — aborting process");
     std::process::abort();
-}
-
-/// Delete any CP tunnel (by name prefix) except our own.
-pub async fn kill_old_tunnels(http: &Client, cf: &CfCreds, self_tunnel_id: &str, env: &str) {
-    let prefix = cf::cp_prefix(env);
-    let Ok(tunnels) = cf::list(http, cf).await else {
-        eprintln!("stonith: list failed");
-        return;
-    };
-    for t in &tunnels {
-        let Some(id) = t["id"].as_str() else { continue };
-        if id == self_tunnel_id {
-            continue;
-        }
-        let Some(name) = t["name"].as_str() else {
-            continue;
-        };
-        if !name.starts_with(&prefix) {
-            continue;
-        }
-        eprintln!("stonith: killing old CP tunnel {name} ({id})");
-        cf::delete_by_name(http, cf, name).await;
-    }
-}
-
-/// How long we give in-flight requests to finish after the tunnel is
-/// confirmed deleted before forcing a poweroff. Buys time for streaming
-/// Noise sessions + long polls on the old CP to drain cleanly.
-const GRACEFUL_DRAIN: Duration = Duration::from_secs(30);
-
-/// Background watchdog — runs until the VM powers off. When the
-/// tunnel goes away (new CP took over), fires `shutdown` to let axum
-/// drain in-flight requests, waits up to `GRACEFUL_DRAIN`, then
-/// powers off.
-pub async fn self_watchdog(
-    cf: CfCreds,
-    self_tunnel_id: String,
-    shutdown: tokio::sync::broadcast::Sender<()>,
-) -> ! {
-    let http = reqwest::Client::builder()
-        .timeout(Duration::from_secs(10))
-        .no_hickory_dns()
-        .build()
-        .unwrap_or_else(|_| crate::system_http_client());
-
-    let initial = rand::thread_rng().gen_range(INITIAL_MIN_SECS..=INITIAL_MAX_SECS);
-    tokio::time::sleep(Duration::from_secs(initial)).await;
-
-    let mut gone: u32 = 0;
-    loop {
-        match cf::exists(&http, &cf, &self_tunnel_id).await {
-            Some(true) => {
-                if gone > 0 {
-                    eprintln!("stonith: watchdog recovered after {gone} missed check(s)");
-                }
-                gone = 0;
-            }
-            Some(false) => {
-                gone += 1;
-                eprintln!("stonith: watchdog: tunnel gone ({gone}/{CONSECUTIVE_GONE})");
-                if gone >= CONSECUTIVE_GONE {
-                    eprintln!(
-                        "stonith: tunnel {self_tunnel_id} confirmed deleted — draining ({}s) before poweroff",
-                        GRACEFUL_DRAIN.as_secs()
-                    );
-                    // Signal axum::serve(..).with_graceful_shutdown(..)
-                    // to stop accepting new connections and let the
-                    // live ones finish. `send` can only fail if every
-                    // subscriber has been dropped, which is fine
-                    // (nothing to drain anyway).
-                    let _ = shutdown.send(());
-                    tokio::time::sleep(GRACEFUL_DRAIN).await;
-                    poweroff();
-                }
-            }
-            None => {
-                eprintln!("stonith: watchdog: ambiguous check result");
-            }
-        }
-        let jitter = rand::thread_rng().gen_range(0..=POLL_JITTER_SECS);
-        let secs = POLL_BASE_SECS + jitter - POLL_JITTER_SECS / 2;
-        tokio::time::sleep(Duration::from_secs(secs)).await;
-    }
 }


### PR DESCRIPTION
Simplification: rip out the STONITH fencing for now.

`kill_old_tunnels` + `self_watchdog` churned the Cloudflare tunnel hand-off (the 502 flap during cutover that the no-retry `Verify CP health payload` deploy step fails on). On the SSH/prod path the relaunch already destroys the old CP VM before booting the new one, so the fencing was redundant.

- Removed `stonith::kill_old_tunnels`, `stonith::self_watchdog`, their `cp::run` spawns, and the broadcast / `with_graceful_shutdown` plumbing only the watchdog drove.
- Kept `stonith::poweroff` (fatal-boot-error paths still use it).
- Trade-off: orphaned old CP tunnels linger in CF until `force-cleanup-tunnels.yml` reaps them — acceptable for now.

clippy clean, 75 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)