### PR TITLE
Ownership-scoped fleet API + native-client bearer auth

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -44,6 +44,37 @@ pub struct Session {
     pub owner_name: String,
     pub owner_id: u64,
     pub owner_kind: PrincipalKind,
+    /// GitHub org logins (lowercased) the viewer belongs to — used to
+    /// scope deployment visibility by org. `#[serde(default)]` so tokens
+    /// minted before this field deserialize as "no orgs".
+    #[serde(default)]
+    pub orgs: Vec<String>,
+    /// True if the viewer is an admin of THIS fleet (the fleet owner, a
+    /// member of the fleet-owner org, or a repo collaborator). Admins see
+    /// the whole fleet; everyone else is scoped to deployments they own.
+    #[serde(default)]
+    pub is_fleet_admin: bool,
+}
+
+/// What `classify_user` learns about a freshly-authenticated GitHub user
+/// relative to this fleet. Unlike the old `authorize_user` (which
+/// rejected non-members), this admits any valid GitHub user and records
+/// how to scope them — admins see all, others see only what they own.
+struct Classification {
+    is_fleet_admin: bool,
+    orgs: Vec<String>,
+}
+
+/// Result of a device-flow poll. `Pending` while the user hasn't approved
+/// in the browser yet; `Ready` carries the minted DD bearer for the client.
+pub enum DevicePoll {
+    Pending,
+    Ready {
+        token: String,
+        exp: i64,
+        login: String,
+        is_fleet_admin: bool,
+    },
 }
 
 #[derive(Serialize, Deserialize)]
@@ -184,16 +215,8 @@ impl AuthConfig {
 
         let token = exchange_code(http, self, &state.app, code).await?;
         let user = fetch_user(http, &token).await?;
-        authorize_user(http, &token, owner, &user).await?;
-
-        let session = Session {
-            login: user.login,
-            user_id: user.id,
-            exp: now_ts() + SESSION_TTL_SECS,
-            owner_name: owner.name.clone(),
-            owner_id: owner.id,
-            owner_kind: owner.kind,
-        };
+        let class = classify_user(http, &token, owner, &user).await?;
+        let session = self.new_session(owner, &user, class);
         let token = sign(&self.cookie_secret, &session)?;
         let mut resp = Redirect::temporary(&state.return_to).into_response();
         append_set_cookie(
@@ -213,8 +236,23 @@ impl AuthConfig {
         Ok(resp)
     }
 
-    pub fn verify_session(&self, owner: &Principal, headers: &HeaderMap) -> Option<Session> {
-        let token = cookie_value(headers, SESSION_COOKIE)?;
+    fn new_session(&self, owner: &Principal, user: &GithubUser, class: Classification) -> Session {
+        Session {
+            login: user.login.clone(),
+            user_id: user.id,
+            exp: now_ts() + SESSION_TTL_SECS,
+            owner_name: owner.name.clone(),
+            owner_id: owner.id,
+            owner_kind: owner.kind,
+            orgs: class.orgs,
+            is_fleet_admin: class.is_fleet_admin,
+        }
+    }
+
+    /// Verify a DD-signed session token (used for both the `dd_session`
+    /// cookie and native-client bearer — same HMAC, same shape). Checks
+    /// signature, expiry, and that the token is bound to THIS fleet.
+    fn verify_token(&self, owner: &Principal, token: &str) -> Option<Session> {
         let session: Session = verify(&self.cookie_secret, token).ok()?;
         if session.exp < now_ts() {
             return None;
@@ -226,6 +264,100 @@ impl AuthConfig {
             return None;
         }
         Some(session)
+    }
+
+    pub fn verify_session(&self, owner: &Principal, headers: &HeaderMap) -> Option<Session> {
+        let token = cookie_value(headers, SESSION_COOKIE)?;
+        self.verify_token(owner, token)
+    }
+
+    /// Verify a human caller from either a native-client `Authorization:
+    /// Bearer <dd-token>` (checked first) or the browser `dd_session`
+    /// cookie. The fleet API accepts both; browser pages use
+    /// `verify_session` via `require_browser_auth`.
+    pub fn verify_human(&self, owner: &Principal, headers: &HeaderMap) -> Option<Session> {
+        if let Some(tok) = bearer_token(headers) {
+            if let Some(s) = self.verify_token(owner, tok) {
+                return Some(s);
+            }
+        }
+        self.verify_session(owner, headers)
+    }
+
+    /// GitHub OAuth **device flow** step 1 (for the native/iOS client):
+    /// ask GitHub for a device + user code. Returns the JSON the client
+    /// shows the user (`user_code`, `verification_uri`) plus the
+    /// `device_code` it polls back with. Requires the GitHub App to have
+    /// device flow enabled.
+    pub async fn device_start(&self, http: &Client) -> Result<serde_json::Value> {
+        let app = app_for_return_to(&self.broker_origin).unwrap_or_else(|_| "production".into());
+        let (client_id, _) = self.client_for(&app)?;
+        let resp = http
+            .post("https://github.com/login/device/code")
+            .header(header::ACCEPT, "application/json")
+            .header(header::USER_AGENT, "devopsdefender")
+            .json(&serde_json::json!({ "client_id": client_id, "scope": "read:org" }))
+            .send()
+            .await?;
+        if !resp.status().is_success() {
+            return Err(Error::Upstream(format!(
+                "GitHub device/code returned {}",
+                resp.status()
+            )));
+        }
+        let body: serde_json::Value = resp.json().await?;
+        Ok(serde_json::json!({
+            "device_code": body.get("device_code").cloned().unwrap_or_default(),
+            "user_code": body.get("user_code").cloned().unwrap_or_default(),
+            "verification_uri": body.get("verification_uri").cloned().unwrap_or_default(),
+            "expires_in": body.get("expires_in").cloned().unwrap_or_default(),
+            "interval": body.get("interval").cloned().unwrap_or(serde_json::json!(5)),
+        }))
+    }
+
+    /// Device flow step 2: poll GitHub with the `device_code`. While the
+    /// user hasn't approved yet → `Pending`. On approval, fetch + classify
+    /// the user and mint a DD bearer (same signed-`Session` the cookie
+    /// uses) the client sends as `Authorization: Bearer`.
+    pub async fn device_poll(
+        &self,
+        http: &Client,
+        owner: &Principal,
+        device_code: &str,
+    ) -> Result<DevicePoll> {
+        let app = app_for_return_to(&self.broker_origin).unwrap_or_else(|_| "production".into());
+        let (client_id, client_secret) = self.client_for(&app)?;
+        let resp = http
+            .post("https://github.com/login/oauth/access_token")
+            .header(header::ACCEPT, "application/json")
+            .header(header::USER_AGENT, "devopsdefender")
+            .json(&serde_json::json!({
+                "client_id": client_id,
+                "client_secret": client_secret,
+                "device_code": device_code,
+                "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+            }))
+            .send()
+            .await?;
+        let body: GithubTokenResponse = resp.json().await?;
+        if let Some(err) = body.error.as_deref() {
+            // Device flow signals progress via error codes, not HTTP status.
+            return match err {
+                "authorization_pending" | "slow_down" => Ok(DevicePoll::Pending),
+                other => Err(Error::Upstream(format!("device flow: {other}"))),
+            };
+        }
+        let token = body.access_token.ok_or(Error::Unauthorized)?;
+        let user = fetch_user(http, &token).await?;
+        let class = classify_user(http, &token, owner, &user).await?;
+        let session = self.new_session(owner, &user, class);
+        let bearer = sign(&self.cookie_secret, &session)?;
+        Ok(DevicePoll::Ready {
+            token: bearer,
+            exp: session.exp,
+            login: session.login,
+            is_fleet_admin: session.is_fleet_admin,
+        })
     }
 
     fn client_for(&self, app: &str) -> Result<(&str, &str)> {
@@ -294,6 +426,15 @@ pub fn cookie_value<'a>(headers: &'a HeaderMap, name: &str) -> Option<&'a str> {
     })
 }
 
+/// Extract a non-empty `Authorization: Bearer <token>` (native client).
+fn bearer_token(headers: &HeaderMap) -> Option<&str> {
+    let v = headers.get(header::AUTHORIZATION)?.to_str().ok()?;
+    v.strip_prefix("Bearer ")
+        .or_else(|| v.strip_prefix("bearer "))
+        .map(str::trim)
+        .filter(|t| !t.is_empty())
+}
+
 async fn exchange_code(http: &Client, cfg: &AuthConfig, app: &str, code: &str) -> Result<String> {
     let (client_id, client_secret) = cfg.client_for(app)?;
     let resp = http
@@ -336,50 +477,68 @@ async fn fetch_user(http: &Client, token: &str) -> Result<GithubUser> {
     Ok(resp.json().await?)
 }
 
-async fn authorize_user(
+/// Classify a freshly-authenticated GitHub user against this fleet.
+/// **Admits any valid GitHub user** (unlike the old reject-on-non-member
+/// gate) and records how to scope them: `is_fleet_admin` for the fleet
+/// owner / org member / repo collaborator, plus their org memberships for
+/// per-org deployment scoping. The admin/orgs lookups fail **closed** (a
+/// GitHub hiccup yields non-admin / no-orgs, never a spurious admin).
+async fn classify_user(
     http: &Client,
     token: &str,
     owner: &Principal,
     user: &GithubUser,
-) -> Result<()> {
-    match owner.kind {
-        PrincipalKind::User => {
-            if user.id == owner.id {
-                Ok(())
-            } else {
-                Err(Error::Unauthorized)
-            }
-        }
+) -> Result<Classification> {
+    let is_fleet_admin = match owner.kind {
+        PrincipalKind::User => user.id == owner.id,
         PrincipalKind::Org => {
-            let resp = http
-                .get(format!(
-                    "https://api.github.com/orgs/{}/public_members/{}",
-                    owner.name, user.login
-                ))
-                .bearer_auth(token)
-                .header(header::USER_AGENT, "devopsdefender")
-                .send()
-                .await?;
-            if resp.status().is_success() {
-                Ok(())
-            } else {
-                Err(Error::Unauthorized)
-            }
+            gh_ok(
+                http,
+                token,
+                &format!("orgs/{}/public_members/{}", owner.name, user.login),
+            )
+            .await
         }
-        PrincipalKind::Repo => {
-            let resp = http
-                .get(format!("https://api.github.com/repos/{}", owner.name))
-                .bearer_auth(token)
-                .header(header::USER_AGENT, "devopsdefender")
-                .send()
-                .await?;
-            if resp.status().is_success() {
-                Ok(())
-            } else {
-                Err(Error::Unauthorized)
-            }
-        }
+        PrincipalKind::Repo => gh_ok(http, token, &format!("repos/{}", owner.name)).await,
+    };
+    let orgs = fetch_user_orgs(http, token).await.unwrap_or_default();
+    Ok(Classification {
+        is_fleet_admin,
+        orgs,
+    })
+}
+
+/// `GET https://api.github.com/{path}` with the user token → did it 2xx?
+/// Any transport error or non-2xx → `false` (fail closed).
+async fn gh_ok(http: &Client, token: &str, path: &str) -> bool {
+    http.get(format!("https://api.github.com/{path}"))
+        .bearer_auth(token)
+        .header(header::USER_AGENT, "devopsdefender")
+        .send()
+        .await
+        .map(|r| r.status().is_success())
+        .unwrap_or(false)
+}
+
+/// The viewer's GitHub org logins (lowercased), for org-scoped
+/// visibility. Best-effort: errors → empty (the viewer just won't match
+/// any org-owned deployment).
+async fn fetch_user_orgs(http: &Client, token: &str) -> Result<Vec<String>> {
+    let resp = http
+        .get("https://api.github.com/user/orgs?per_page=100")
+        .bearer_auth(token)
+        .header(header::USER_AGENT, "devopsdefender")
+        .send()
+        .await?;
+    if !resp.status().is_success() {
+        return Ok(Vec::new());
     }
+    let orgs: Vec<serde_json::Value> = resp.json().await?;
+    Ok(orgs
+        .iter()
+        .filter_map(|o| o.get("login").and_then(|l| l.as_str()))
+        .map(|s| s.to_lowercase())
+        .collect())
 }
 
 fn sign<T: Serialize>(secret: &[u8], value: &T) -> Result<String> {

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -55,6 +55,13 @@ pub struct Agent {
     pub last_seen: DateTime<Utc>,
     pub agent_mode: AgentMode,
     pub integrity_state: IntegrityState,
+    /// Runtime tenant that owns this agent (the `agent_owner_principal`
+    /// from the agent's `/health`), if any. Drives ownership-scoped fleet
+    /// visibility: a non-admin viewer sees an agent only if its owner
+    /// matches their GitHub login/id or one of their orgs. `None` = no
+    /// tenant assigned (admin-only visibility).
+    #[serde(default)]
+    pub owner: Option<crate::gh_oidc::Principal>,
     pub deployment_count: usize,
     pub deployment_names: Vec<String>,
     pub unit_count: usize,
@@ -406,6 +413,10 @@ async fn tick(
                     .unwrap_or(AgentMode::ReadWrite),
                 integrity_state: serde_json::from_value(h["integrity_state"].clone())
                     .unwrap_or(IntegrityState::Controlled),
+                // Runtime tenant from /health (None if unowned or absent).
+                owner: serde_json::from_value(h["agent_owner_principal"].clone())
+                    .ok()
+                    .flatten(),
                 deployment_count: h["deployment_count"].as_u64().unwrap_or(0) as usize,
                 deployment_names: h["deployments"]
                     .as_array()
@@ -781,6 +792,7 @@ mod tests {
             last_seen,
             agent_mode: AgentMode::ReadWrite,
             integrity_state: IntegrityState::Controlled,
+            owner: None,
             deployment_count: 0,
             deployment_names: Vec::new(),
             unit_count: 0,

--- a/src/cp.rs
+++ b/src/cp.rs
@@ -223,6 +223,7 @@ pub async fn run() -> Result<()> {
             last_seen: chrono::Utc::now(),
             agent_mode: AgentMode::ReadWrite,
             integrity_state: IntegrityState::Controlled,
+            owner: None,
             deployment_count: 0,
             deployment_names: Vec::new(),
             unit_count: 0,
@@ -338,6 +339,8 @@ pub async fn run() -> Result<()> {
         .route("/", get(fleet))
         .route("/auth/github/start", get(auth_start))
         .route("/auth/github/callback", get(auth_callback))
+        .route("/auth/device/start", post(device_start))
+        .route("/auth/device/poll", post(device_poll))
         .route("/health", get(health))
         .route("/register", post(register))
         .route("/ingress/replace", post(ingress_replace))
@@ -582,6 +585,7 @@ async fn register(
                 last_seen: now,
                 agent_mode: AgentMode::ReadWrite,
                 integrity_state: IntegrityState::Controlled,
+                owner: None,
                 deployment_count: 0,
                 deployment_names: Vec::new(),
                 unit_count: 0,
@@ -801,6 +805,60 @@ async fn auth_callback(
     }
 }
 
+/// `POST /auth/device/start` — native/iOS client begins GitHub device
+/// flow. Returns `{device_code, user_code, verification_uri, interval,
+/// expires_in}`; the client shows the user code + opens the URL, then
+/// polls `/auth/device/poll`.
+async fn device_start(State(s): State<St>) -> Response {
+    match s.cfg.auth.device_start(&crate::system_http_client()).await {
+        Ok(body) => Json(body).into_response(),
+        Err(e) => e.into_response(),
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct DevicePollReq {
+    device_code: String,
+}
+
+/// `POST /auth/device/poll {device_code}` — exchange an approved device
+/// code for a CP-issued bearer. 202 `{status:"pending"}` until the user
+/// approves; then `{status:"ready", token, exp, login, is_fleet_admin}`.
+/// The bearer is the same signed session the cookie carries; send it as
+/// `Authorization: Bearer` to `/api/fleet`.
+async fn device_poll(State(s): State<St>, Json(req): Json<DevicePollReq>) -> Response {
+    match s
+        .cfg
+        .auth
+        .device_poll(
+            &crate::system_http_client(),
+            &s.cfg.common.owner,
+            &req.device_code,
+        )
+        .await
+    {
+        Ok(crate::auth::DevicePoll::Pending) => (
+            axum::http::StatusCode::ACCEPTED,
+            Json(serde_json::json!({ "status": "pending" })),
+        )
+            .into_response(),
+        Ok(crate::auth::DevicePoll::Ready {
+            token,
+            exp,
+            login,
+            is_fleet_admin,
+        }) => Json(serde_json::json!({
+            "status": "ready",
+            "token": token,
+            "exp": exp,
+            "login": login,
+            "is_fleet_admin": is_fleet_admin,
+        }))
+        .into_response(),
+        Err(e) => e.into_response(),
+    }
+}
+
 /// Live dashboard script: poll `/api/fleet` every 5s, swap the
 /// `#fleet-body` fragment, and drive the "updated Xs ago" indicator —
 /// which goes amber then red if polling stalls (frozen or unreachable
@@ -824,12 +882,101 @@ const FLEET_POLL_JS: &str = r#"(function(){
   setInterval(tick,5000); setInterval(ago,1000); tick();
 })();"#;
 
-/// Take a stable, id-sorted snapshot of the fleet store. Shared by the
-/// dashboard page and the `/api/fleet` poll endpoint.
-async fn fleet_snapshot(s: &St) -> Vec<(String, collector::Agent)> {
-    let mut by_id: Vec<_> = s.store.lock().await.clone().into_iter().collect();
+/// Resolve the human caller (native-client bearer OR browser session
+/// cookie), bound to this fleet. `Err` is the ready-to-return
+/// redirect-to-login (browser) or 401 (API).
+// The `Err` arm is a ready-to-return axum `Response` (inherently large);
+// boxing it would just churn every call site for no real benefit.
+#[allow(clippy::result_large_err)]
+fn human_session(
+    s: &St,
+    headers: &HeaderMap,
+    uri: &Uri,
+) -> std::result::Result<crate::auth::Session, Response> {
+    match s.cfg.auth.verify_human(&s.cfg.common.owner, headers) {
+        Some(sess) => Ok(sess),
+        None => Err(crate::auth::unauthorized_or_redirect(
+            &s.cfg.auth,
+            headers,
+            &crate::auth::absolute_url(headers, &s.cfg.hostname, path_and_query(uri)),
+        )),
+    }
+}
+
+/// Whether `session` may see `agent`. Fleet admins (fleet owner / org
+/// member) see everything; everyone else sees an agent only if its owner
+/// matches their GitHub login/id or one of their orgs. Unowned agents
+/// (incl. the `control-plane` entry) are admin-only.
+fn agent_visible(session: &crate::auth::Session, agent: &collector::Agent) -> bool {
+    owner_visible(session, agent.owner.as_ref())
+}
+
+/// Pure visibility decision (extracted for testing): admin sees all;
+/// otherwise the item is visible only if its owner matches the viewer.
+fn owner_visible(
+    session: &crate::auth::Session,
+    owner: Option<&crate::gh_oidc::Principal>,
+) -> bool {
+    session.is_fleet_admin || owner.is_some_and(|p| principal_matches_viewer(p, session))
+}
+
+fn principal_matches_viewer(p: &crate::gh_oidc::Principal, s: &crate::auth::Session) -> bool {
+    use crate::gh_oidc::PrincipalKind::{Org, Repo, User};
+    match p.kind {
+        User => p.id == s.user_id || p.name.eq_ignore_ascii_case(&s.login),
+        Org => s.orgs.iter().any(|o| o.eq_ignore_ascii_case(&p.name)),
+        // "owner/repo" — match the owner segment against login or orgs.
+        Repo => {
+            let seg = p.name.split('/').next().unwrap_or(&p.name);
+            seg.eq_ignore_ascii_case(&s.login) || s.orgs.iter().any(|o| o.eq_ignore_ascii_case(seg))
+        }
+    }
+}
+
+/// Id-sorted fleet snapshot scoped to what `session` may see.
+async fn scoped_snapshot(
+    s: &St,
+    session: &crate::auth::Session,
+) -> Vec<(String, collector::Agent)> {
+    let mut by_id: Vec<_> = s
+        .store
+        .lock()
+        .await
+        .iter()
+        .filter(|(_, a)| agent_visible(session, a))
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .collect();
     by_id.sort_by(|a, b| a.0.cmp(&b.0));
     by_id
+}
+
+/// Does the caller want JSON (the native client) vs the HTML fragment
+/// (the browser dashboard poll)?
+fn wants_json(headers: &HeaderMap) -> bool {
+    headers
+        .get(axum::http::header::ACCEPT)
+        .and_then(|v| v.to_str().ok())
+        .map(|v| v.contains("application/json"))
+        .unwrap_or(false)
+}
+
+/// Scoped fleet snapshot as JSON for the native/iOS client.
+fn fleet_json(s: &St, by_id: &[(String, collector::Agent)]) -> serde_json::Value {
+    let healthy = by_id.iter().filter(|(_, a)| a.status == "healthy").count();
+    let unit_total: usize = by_id.iter().map(|(_, a)| a.units.len()).sum();
+    let oracle_total: usize = by_id.iter().map(|(_, a)| a.oracles.len()).sum();
+    serde_json::json!({
+        "generated_at": chrono::Utc::now().to_rfc3339(),
+        "env": s.cfg.common.env_label,
+        "hostname": s.cfg.hostname,
+        "summary": {
+            "agents": by_id.len(),
+            "healthy": healthy,
+            "units": unit_total,
+            "oracles": oracle_total,
+        },
+        "agents": by_id.iter().map(|(_, a)| a).collect::<Vec<_>>(),
+    })
 }
 
 /// Render the live-swappable fleet body: summary line, count cards, the
@@ -946,10 +1093,11 @@ fn render_fleet_body(host: &str, env: &str, by_id: &[(String, collector::Agent)]
 }
 
 async fn fleet(State(s): State<St>, headers: HeaderMap, uri: Uri) -> Response {
-    if let Some(resp) = require_browser_auth(&s, &headers, &uri) {
-        return resp;
-    }
-    let by_id = fleet_snapshot(&s).await;
+    let session = match human_session(&s, &headers, &uri) {
+        Ok(sess) => sess,
+        Err(resp) => return resp,
+    };
+    let by_id = scoped_snapshot(&s, &session).await;
     let body = render_fleet_body(&s.cfg.hostname, &s.cfg.common.env_label, &by_id);
     Html(shell(
         "DD Fleet",
@@ -963,22 +1111,28 @@ async fn fleet(State(s): State<St>, headers: HeaderMap, uri: Uri) -> Response {
     .into_response()
 }
 
-/// `GET /api/fleet` — the live-refresh fragment: exactly the body
-/// `fleet()` renders initially, so the dashboard's 5s poll can swap it in
-/// place. Browser-gated like the dashboard (the poll fetches it
-/// same-origin with the session cookie); CF Access also covers it at the
-/// edge since it has no bypass app of its own.
+/// `GET /api/fleet` — ownership-scoped fleet, for both the browser
+/// dashboard poll (HTML fragment) and the native/iOS client
+/// (`Accept: application/json`). Auth is `verify_human`: the `dd_session`
+/// cookie (browser) OR a CP-issued `Authorization: Bearer` (native).
+/// The result is filtered to what the caller may see — admins get the
+/// whole fleet, everyone else only the deployments they own.
 async fn fleet_fragment(State(s): State<St>, headers: HeaderMap, uri: Uri) -> Response {
-    if let Some(resp) = require_browser_auth(&s, &headers, &uri) {
-        return resp;
+    let session = match human_session(&s, &headers, &uri) {
+        Ok(sess) => sess,
+        Err(resp) => return resp,
+    };
+    let by_id = scoped_snapshot(&s, &session).await;
+    if wants_json(&headers) {
+        Json(fleet_json(&s, &by_id)).into_response()
+    } else {
+        Html(render_fleet_body(
+            &s.cfg.hostname,
+            &s.cfg.common.env_label,
+            &by_id,
+        ))
+        .into_response()
     }
-    let by_id = fleet_snapshot(&s).await;
-    Html(render_fleet_body(
-        &s.cfg.hostname,
-        &s.cfg.common.env_label,
-        &by_id,
-    ))
-    .into_response()
 }
 
 // ── Enrollment broker ───────────────────────────────────────────────────
@@ -1162,11 +1316,14 @@ async fn agent_detail(
     uri: Uri,
     Path(id): Path<String>,
 ) -> Response {
-    if let Some(resp) = require_browser_auth(&s, &headers, &uri) {
-        return resp;
-    }
+    let session = match human_session(&s, &headers, &uri) {
+        Ok(sess) => sess,
+        Err(resp) => return resp,
+    };
     let agent = s.store.lock().await.get(&id).cloned();
-    let Some(a) = agent else {
+    // Scope: hide agents the caller may not see behind the same 404 as a
+    // missing one, so a non-admin can't probe for agents they don't own.
+    let Some(a) = agent.filter(|a| agent_visible(&session, a)) else {
         return (
             axum::http::StatusCode::NOT_FOUND,
             Html(shell("Not found", "", "<h1>Not found</h1>")),
@@ -1505,6 +1662,97 @@ async fn agent_logs(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::gh_oidc::{Principal, PrincipalKind};
+
+    fn sess(login: &str, user_id: u64, orgs: &[&str], admin: bool) -> crate::auth::Session {
+        crate::auth::Session {
+            login: login.into(),
+            user_id,
+            exp: i64::MAX,
+            owner_name: "devopsdefender".into(),
+            owner_id: 1,
+            owner_kind: PrincipalKind::Org,
+            orgs: orgs.iter().map(|o| o.to_string()).collect(),
+            is_fleet_admin: admin,
+        }
+    }
+    fn principal(kind: PrincipalKind, name: &str, id: u64) -> Principal {
+        Principal {
+            name: name.into(),
+            id,
+            kind,
+        }
+    }
+
+    #[test]
+    fn admin_sees_everything_including_unowned() {
+        let admin = sess("ops", 7, &[], true);
+        assert!(owner_visible(&admin, None));
+        assert!(owner_visible(
+            &admin,
+            Some(&principal(PrincipalKind::User, "someone", 999))
+        ));
+    }
+
+    #[test]
+    fn non_admin_cannot_see_unowned() {
+        let user = sess("alice", 42, &["acme"], false);
+        assert!(!owner_visible(&user, None));
+    }
+
+    #[test]
+    fn non_admin_sees_own_by_user_id_or_login() {
+        let user = sess("alice", 42, &[], false);
+        // match by numeric id (login differs / renamed)
+        assert!(owner_visible(
+            &user,
+            Some(&principal(PrincipalKind::User, "renamed", 42))
+        ));
+        // match by login (case-insensitive)
+        assert!(owner_visible(
+            &user,
+            Some(&principal(PrincipalKind::User, "ALICE", 999))
+        ));
+        // different user → hidden
+        assert!(!owner_visible(
+            &user,
+            Some(&principal(PrincipalKind::User, "bob", 43))
+        ));
+    }
+
+    #[test]
+    fn non_admin_sees_org_owned_only_if_member() {
+        let user = sess("alice", 42, &["acme", "widgets"], false);
+        assert!(owner_visible(
+            &user,
+            Some(&principal(PrincipalKind::Org, "Acme", 5))
+        ));
+        assert!(!owner_visible(
+            &user,
+            Some(&principal(PrincipalKind::Org, "other-co", 6))
+        ));
+    }
+
+    #[test]
+    fn non_admin_repo_owner_matches_owner_segment() {
+        let user = sess("alice", 42, &["acme"], false);
+        // repo owned by org the viewer belongs to
+        assert!(owner_visible(
+            &user,
+            Some(&principal(PrincipalKind::Repo, "acme/app", 9))
+        ));
+        // repo owned by the viewer's own login
+        let solo = sess("alice", 42, &[], false);
+        assert!(owner_visible(
+            &solo,
+            Some(&principal(PrincipalKind::Repo, "alice/tool", 10))
+        ));
+        // repo owned by a stranger org
+        assert!(!owner_visible(
+            &user,
+            Some(&principal(PrincipalKind::Repo, "evil/app", 11))
+        ));
+    }
 
     #[test]
     fn fleet_body_empty_fleet_renders_zeroed_summary() {

--- a/src/gh_oidc.rs
+++ b/src/gh_oidc.rs
@@ -74,7 +74,7 @@ impl PrincipalKind {
 
 /// One of the three principal kinds the agent's `/deploy` verifier
 /// accepts. See module docs for shape.
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Principal {
     pub name: String,
     pub id: u64,


### PR DESCRIPTION
**Phase 1** of the zero-trust scoped-fleet plan — the backend the iOS dd-client consumes.

### What changes
- **Multi-tenant visibility.** Auth no longer rejects non-org-members: any GitHub user authenticates, but sees only what they own. A **fleet admin** (fleet owner / org member) sees the whole fleet; a **deployment owner** sees only agents whose owner matches their GitHub login/id or one of their orgs. Unowned agents (incl. control-plane) are admin-only.
- **Native-client auth.** GitHub OAuth **device flow** (`POST /auth/device/start` → `POST /auth/device/poll`) mints a **CP-issued bearer** (same signed-Session HMAC as the `dd_session` cookie). `/api/fleet` accepts the cookie (browser) OR the bearer (native).
- **Scoped `/api/fleet`.** `verify_human` + ownership filter; content-negotiated — `Accept: application/json` → scoped JSON `{generated_at, summary, agents[]}` for the client; otherwise the live HTML fragment the dashboard already swaps. The dashboard page + `/agent/{id}` are scoped too.

### Security notes (please review before merge)
- This **broadens** who can authenticate (previously fleet-org members only). Non-admins see a scoped/empty fleet — no fleet data leaks — but the dashboard *shell* now loads for any GitHub user. Intended per the tiered model.
- Admin/org lookups **fail closed** (a GitHub error → non-admin / no-orgs, never spurious admin).
- **Terminals are unaffected** — still Noise paired-device only on the agent; a GitHub session/bearer never grants a shell.
- **Ownership is sourced from agent `/health`** (`agent_owner_principal`) for now; durable DNS-backed ownership is **Phase A** (next PR).
- **Ops prerequisite:** the GitHub App must have **device flow enabled** for `/auth/device/*`.

clippy clean, 89 tests (5 new scoping truth-table tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)