### PR TITLE
fix(cp): boot the TDX CP on TDX OVMF, not generic OVMF.fd

### DIFF
--- a/apps/_infra/local-agents.sh
+++ b/apps/_infra/local-agents.sh
@@ -476,26 +476,45 @@ PY
   sed -i "s|/var/log/ee-local\\.log|/var/log/ee-local-$name.log|g" "$out"
   sed -i "s|<model type='e1000e'/>|<model type='virtio'/>|g" "$out"
 
-  # The local-tdx-qcow2 UKI is intentionally unsigned; this host's secure
-  # boot OVMF rejects it with UEFI "Access Denied". Use the non-secure
-  # ROM loader when present and disable firmware auto-selection below.
-  if [ -r /usr/share/ovmf/OVMF.fd ]; then
-    python3 - "$out" <<'PY'
-import re, sys
+  # The local-tdx-qcow2 UKI is intentionally unsigned, so a secure-boot
+  # OVMF (the ".ms" Microsoft-keys variant) rejects it with UEFI "Access
+  # Denied". But a TDX guest *also* cannot boot on the generic, non-TDX
+  # OVMF (`OVMF.fd`): its firmware faults with `#UD` (invalid opcode) and
+  # reset-loops before the kernel starts. Use a firmware that is both
+  # TDX-enlightened *and* non-secure-boot (`OVMF.inteltdx.fd`, the same one
+  # the easyenclave-local base domain boots); pin it as a stateless ROM
+  # loader and disable firmware auto-selection below.
+  #
+  # NB: render_domain_xml() streams the finished XML on stdout and the
+  # caller captures it — any logging here must go to stderr or it corrupts
+  # the domain XML fed to `virsh define`.
+  tdx_fw=""
+  for c in /usr/local/share/ovmf/OVMF.inteltdx.fd \
+           /usr/share/ovmf/OVMF.inteltdx.fd \
+           /usr/share/OVMF/OVMF.inteltdx.fd; do
+    if [ -r "$c" ]; then tdx_fw="$c"; break; fi
+  done
+  if [ -z "$tdx_fw" ]; then
+    echo "no TDX-enlightened OVMF found (looked for OVMF.inteltdx.fd in /usr/local/share/ovmf, /usr/share/ovmf, /usr/share/OVMF); cannot boot a TDX agent" >&2
+    exit 1
+  fi
+  echo "local-agents: TDX firmware -> $tdx_fw" >&2
+  TDX_FW="$tdx_fw" python3 - "$out" <<'PY'
+import re, sys, os
 p = sys.argv[1]
+fw = os.environ["TDX_FW"]
 with open(p) as f: x = f.read()
 x = re.sub(r"<os\s+firmware=['\"]efi['\"]>", "<os>", x, count=1)
 x = re.sub(r"\n\s*<firmware>.*?</firmware>", "", x, count=1, flags=re.DOTALL)
 x = re.sub(r"\n\s*<nvram[^>]*>.*?</nvram>", "", x, count=1, flags=re.DOTALL)
 x = re.sub(
     r"<loader[^>]*>.*?</loader>",
-    "<loader readonly='yes' secure='no' type='rom'>/usr/share/ovmf/OVMF.fd</loader>",
+    lambda _m: "<loader readonly='yes' secure='no' type='rom'>%s</loader>" % fw,
     x,
     count=1,
 )
 with open(p, "w") as f: f.write(x)
 PY
-  fi
 
   # CPU-only agent sizing. Dogfood is meant for real interactive
   # development, so give it enough room for Codex + nested containers.

--- a/apps/_infra/local-cp.sh
+++ b/apps/_infra/local-cp.sh
@@ -265,7 +265,10 @@ PY
     echo "no TDX-enlightened OVMF found (looked for OVMF.inteltdx.fd in /usr/local/share/ovmf, /usr/share/ovmf, /usr/share/OVMF); cannot boot a TDX CP" >&2
     exit 1
   fi
-  echo "local-cp: TDX firmware -> $tdx_fw"
+  # NB: render_domain_xml() streams the finished XML on stdout (`cat "$out"`
+  # at the end) and the caller captures it — so any progress logging here
+  # must go to stderr, or it corrupts the domain XML fed to `virsh define`.
+  echo "local-cp: TDX firmware -> $tdx_fw" >&2
   TDX_FW="$tdx_fw" python3 - "$out" <<'PY'
 import re, sys, os
 p = sys.argv[1]

--- a/apps/_infra/local-cp.sh
+++ b/apps/_infra/local-cp.sh
@@ -245,26 +245,43 @@ x = pattern.sub("\n" + replacement, x, count=1)
 with open(p, "w") as f: f.write(x)
 PY
 
-  # The local-tdx-qcow2 UKI is intentionally unsigned; this host's secure
-  # boot OVMF rejects it with UEFI "Access Denied". Use the non-secure
-  # ROM loader when present and disable firmware auto-selection below.
-  if [ -r /usr/share/ovmf/OVMF.fd ]; then
-    python3 - "$out" <<'PY'
-import re, sys
+  # The local-tdx-qcow2 UKI is intentionally unsigned, so a secure-boot
+  # OVMF (the ".ms" Microsoft-keys variant) rejects it with UEFI "Access
+  # Denied". But a TDX guest *also* cannot boot on the generic, non-TDX
+  # OVMF (`OVMF.fd`): its firmware executes a TDX-context-invalid
+  # instruction and faults with `#UD` (invalid opcode), reset-looping
+  # before the kernel ever starts. We therefore need a firmware that is
+  # both TDX-enlightened *and* non-secure-boot: `OVMF.inteltdx.fd`. Pin
+  # the first one available as a stateless ROM loader and disable
+  # libvirt's firmware auto-selection below. (This is the same firmware
+  # the easyenclave-local base domain boots.)
+  tdx_fw=""
+  for c in /usr/local/share/ovmf/OVMF.inteltdx.fd \
+           /usr/share/ovmf/OVMF.inteltdx.fd \
+           /usr/share/OVMF/OVMF.inteltdx.fd; do
+    if [ -r "$c" ]; then tdx_fw="$c"; break; fi
+  done
+  if [ -z "$tdx_fw" ]; then
+    echo "no TDX-enlightened OVMF found (looked for OVMF.inteltdx.fd in /usr/local/share/ovmf, /usr/share/ovmf, /usr/share/OVMF); cannot boot a TDX CP" >&2
+    exit 1
+  fi
+  echo "local-cp: TDX firmware -> $tdx_fw"
+  TDX_FW="$tdx_fw" python3 - "$out" <<'PY'
+import re, sys, os
 p = sys.argv[1]
+fw = os.environ["TDX_FW"]
 with open(p) as f: x = f.read()
 x = re.sub(r"<os\s+firmware=['\"]efi['\"]>", "<os>", x, count=1)
 x = re.sub(r"\n\s*<firmware>.*?</firmware>", "", x, count=1, flags=re.DOTALL)
 x = re.sub(r"\n\s*<nvram[^>]*>.*?</nvram>", "", x, count=1, flags=re.DOTALL)
 x = re.sub(
     r"<loader[^>]*>.*?</loader>",
-    "<loader readonly='yes' secure='no' type='rom'>/usr/share/ovmf/OVMF.fd</loader>",
+    lambda _m: "<loader readonly='yes' secure='no' type='rom'>%s</loader>" % fw,
     x,
     count=1,
 )
 with open(p, "w") as f: f.write(x)
 PY
-  fi
 
   # CP sizing.
   local mem_kib=16777216   # 16 GiB


### PR DESCRIPTION
## Production outage root cause

`app.devopsdefender.com` was down. The baremetal CP host was reprovisioned (fresh OS install, 2026-05-29) and the CP VM stopped booting.

`local-cp.sh` pinned the CP's firmware to **`/usr/share/ovmf/OVMF.fd`** — the *generic, non-TDX* OVMF. A TDX confidential guest can't run on it: the firmware faults with `#UD` (invalid opcode) and the TD **reset-loops before the kernel boots** → no kernel, no network, no `/health` → every deploy fails the readiness gate (streak `0/3` for the full 90 polls).

It was latent because the *old* OS's `OVMF.fd` happened to be TDX-capable; the fresh image ships a plain build.

### Confirmed on the host
- Guest firmware log: `X64 Exception Type - 06(#UD - Invalid Opcode)` in the OVMF image range, CPU spinning (reset loop).
- The base `easyenclave-local` domain boots `/usr/local/share/ovmf/OVMF.inteltdx.fd`; the old prod VM booted `OVMF.inteltdx.ms.fd`.
- Swapping the **live** VM's loader to `OVMF.inteltdx.fd` boots it straight into the Linux kernel (firmware fault gone).

## Fix
Resolve a firmware that is both **TDX-enlightened** and **non-secure-boot** (`OVMF.inteltdx.fd` — the non-`.ms` variant avoids the "Access Denied" the intentionally-unsigned UKI gets from secure-boot OVMF), searching the standard locations and failing loudly if none exists. Keeps the stateless ROM loader + firmware-auto-selection-disable the unsigned UKI requires. Applies to every env (production + pr-N previews) since they share `local-cp.sh`.

## Validation
This PR's **deploy-preview** is the test: the `pr-N` CP VM must boot on the new firmware and pass the readiness gate. (Also exercises the freshly-rotated `DD_LOCAL_SSH_KEY`.) Merging to main then redeploys production.

## Follow-up (separate, not in this PR)
`EE_GITHUB_TOKEN` is wired to the **ephemeral `github.token`** (`deploy-cp.yml:173`), so the CP can't re-fetch its release assets on any reboot after the deploy job ends → 401 → panic. That's why a host reboot can't self-heal. Needs a long-lived token (or boot-time fetch redesign); filing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)