### PR TITLE
fix(deploy): durable boot token + autostart so a host reboot self-heals

### DIFF
--- a/.github/workflows/deploy-cp.yml
+++ b/.github/workflows/deploy-cp.yml
@@ -95,7 +95,11 @@ jobs:
     env:
       DD_ENV: ${{ inputs.env }}
       DD_HOSTNAME: ${{ inputs.hostname }}
-      DD_BOOT_GITHUB_TOKEN: ${{ github.token }}
+      # Long-lived PAT (not the run-scoped github.token) so the EE VM can
+      # re-fetch its release assets on ANY later boot — a host reboot must
+      # self-heal. github.token dies with the job, which made the
+      # 2026-05-29 reboot an unrecoverable 401-on-boot outage.
+      DD_BOOT_GITHUB_TOKEN: ${{ secrets.DD_MGMT_PAT }}
       GCP_ZONE: us-central1-c
       DD_AUTH_BROKER_URL: https://app.${{ vars.DD_CF_DOMAIN || 'devopsdefender.com' }}
       DD_AUTH_COOKIE_DOMAIN: .${{ vars.DD_CF_DOMAIN || 'devopsdefender.com' }}
@@ -170,7 +174,10 @@ jobs:
           ee-channel:    ${{ steps.ee.outputs.channel }}
           ee-tag:        ${{ inputs.ee_tag }}
           owner:         ${{ inputs.owner }}
-          github-token:  ${{ github.token }}
+          # Long-lived PAT, not run-scoped github.token: EE re-fetches its
+          # release assets on every boot, so the token must outlive the job
+          # or a reboot 401s and panics. See DD_BOOT_GITHUB_TOKEN above.
+          github-token:  ${{ secrets.DD_MGMT_PAT }}
 
       - name: Create TDX VM (boots from easyenclave-mini, fetches dd from GitHub releases)
         if: inputs.target == 'gcp'
@@ -603,7 +610,9 @@ jobs:
           ee-channel: ${{ steps.ee.outputs.channel }}
           ee-tag: ${{ inputs.ee_tag }}
           owner: ${{ inputs.owner }}
-          github-token: ${{ github.token }}
+          # Long-lived PAT, not run-scoped github.token (boot-time asset
+          # fetch must survive reboots). See DD_BOOT_GITHUB_TOKEN above.
+          github-token: ${{ secrets.DD_MGMT_PAT }}
 
       # Preview only: deploy hello-world as the end-to-end canary.
       # Exercises the full GH-OIDC auth path (mint → agent verify

--- a/apps/_infra/dd-relaunch.sh
+++ b/apps/_infra/dd-relaunch.sh
@@ -77,3 +77,10 @@ for vm in "${vms[@]}"; do
   virsh start "$vm"
   echo "relaunched $vm against $CP"
 done
+
+# The prod agent must come back on its own after a host reboot. Preview
+# agents are ephemeral (recreated each preview deploy and torn down with
+# the PR), so leave their autostart off.
+if [ "$KIND" = prod ]; then
+  virsh autostart dd-local-prod >/dev/null && echo "autostart enabled for dd-local-prod (survives host reboot)"
+fi

--- a/apps/_infra/local-cp.sh
+++ b/apps/_infra/local-cp.sh
@@ -361,3 +361,10 @@ build_config_iso
 xml=$(render_domain_xml)
 echo "$xml" | virsh define /dev/stdin >/dev/null
 echo "  defined $VM"
+
+# Persistent envs must come back on their own after a host reboot.
+# Ephemeral pr-N preview CPs are torn down by cleanup, so leave their
+# autostart off (avoids resurrecting a stale preview on reboot).
+if [ "$ENV_LABEL" = production ]; then
+  virsh autostart "$VM" >/dev/null && echo "  autostart enabled for $VM (survives host reboot)"
+fi


### PR DESCRIPTION
## Why

The EE CP/agent TDX VMs re-fetch their release assets (busybox, the `devopsdefender` binary) from the **private** `devopsdefender/dd` releases on **every boot**, using `EE_GITHUB_TOKEN` baked into `config.iso`. That was the **run-scoped `github.token`**, which is revoked when the deploy job ends. So any later boot — host reboot, crash, watchdog reset — gets **401 → `easyenclave: FATAL` → kernel panic → reset loop**. With libvirt `autostart` also disabled on every domain, the 2026-05-29 host reboot became an unrecoverable production outage (the one just resolved by #278).

## What

- **Durable token:** point `EE_GITHUB_TOKEN` at the long-lived **`DD_MGMT_PAT`** instead of `github.token`, in all three boot-token feeds in `deploy-cp.yml` (the GCP `DD_BOOT_GITHUB_TOKEN`, and the `relaunch-cp` / `relaunch-agent` `github-token` inputs). A PAT outlives the job, so boot-time asset fetch keeps working across reboots.
- **Autostart:** enable `virsh autostart` on the **persistent production** domains — `dd-local-production-cp` (`local-cp.sh`) and `dd-local-prod` (`dd-relaunch.sh`). Ephemeral `pr-N` previews are intentionally left without autostart (cleanup tears them down; we don't want stale previews resurrected on reboot).

## Validation
1. This PR's **deploy-preview** must go green — proves `DD_MGMT_PAT` has `contents:read` on `devopsdefender/dd` (boot-time asset fetch works). If it 401s, the PAT lacks scope and we mint a dedicated token instead.
2. **Reboot test:** after the preview deploys, I reboot the preview VM out-of-band on the host and confirm it re-fetches assets (no 401) and re-registers — i.e. the token genuinely survives the job and the VM self-heals.

Then merging redeploys production with the durable token + autostart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)